### PR TITLE
Fix NPE in IssueListActivity when not authorized

### DIFF
--- a/src/com/gh4a/activities/IssueListActivity.java
+++ b/src/com/gh4a/activities/IssueListActivity.java
@@ -265,7 +265,7 @@ public class IssueListActivity extends BasePagerActivity implements
     @Override
     protected void onPageMoved(int position, float fraction) {
         super.onPageMoved(position, fraction);
-        if (!mSearchMode) {
+        if (!mSearchMode && mCreateFab != null) {
             float openFraction = 1 - position - fraction;
             ViewCompat.setScaleX(mCreateFab, openFraction);
             ViewCompat.setScaleY(mCreateFab, openFraction);


### PR DESCRIPTION
The `mCreateFab` member is only set when authorized.

Fixes #319.