### PR TITLE
fixed line breaks on release notes using newline characters

### DIFF
--- a/src/com/github/mobile/util/HtmlUtils.java
+++ b/src/com/github/mobile/util/HtmlUtils.java
@@ -327,6 +327,7 @@ public class HtmlUtils {
         // Replace paragraphs with breaks
         replace(formatted, PARAGRAPH_START, BREAK);
         replace(formatted, PARAGRAPH_END, BREAK);
+        replace(formatted, "\n", BREAK);
 
         formatPres(formatted);
 


### PR DESCRIPTION
It seems like the release notes on GitHub can use newline characters as opposed to standard HTML syntax. This commit makes sure that these get replaced by the appropriate HTML tag before being displayed in the TextView.