### PR TITLE
Set default application theme

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:name="com.gh4a.Gh4Application"
         android:allowBackup="true"
         android:icon="@drawable/octodroid"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:theme="@style/LightTheme">
         <activity
             android:name=".activities.Github4AndroidActivity"
             android:configChanges="orientation|screenSize" >


### PR DESCRIPTION
While the theme is set programmatically for each activity it is helpful to also define default theme for application in the AndroidManifest file. Doing so tells Android Studio to use this theme when looking at the layout preview. Without that Android Studio uses incorrect theme which requires to change it manually each time to be able to see correct preview and avoid errors.