### PR TITLE
Improve layout previews

### DIFF
--- a/res/layout-land/color_picker_dialog.xml
+++ b/res/layout-land/color_picker_dialog.xml
@@ -5,13 +5,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal"
-    android:padding="@dimen/content_padding" >
+    android:padding="@dimen/content_padding">
 
     <com.larswerkman.holocolorpicker.ColorPicker
         android:id="@+id/color_picker"
         android:layout_width="0dp"
-        android:layout_weight="1"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
 
     <com.larswerkman.holocolorpicker.SaturationBar
         android:id="@+id/saturation"

--- a/res/layout/ab_loading.xml
+++ b/res/layout/ab_loading.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center">
+
     <ProgressBar
         android:id="@+id/ab_pb"
         android:layout_width="32dp"
         android:layout_height="32dp"
+        android:layout_gravity="center"
         android:layout_marginLeft="12dp"
         android:layout_marginRight="12dp"
-        android:layout_gravity="center"
         android:indeterminate="true"
         android:theme="@style/Theme.Header" />
 </FrameLayout>

--- a/res/layout/about_dialog.xml
+++ b/res/layout/about_dialog.xml
@@ -1,42 +1,48 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/layout_root"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:padding="@dimen/content_padding">
+
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/copyright"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium" />
+
     <com.gh4a.widget.StyleableTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:autoLink="email"
         android:text="@string/my_email"
-        android:autoLink="email" />
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
     <com.gh4a.widget.StyleableTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:autoLink="web"
         android:text="@string/my_web"
-        android:autoLink="web" />
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
     <com.gh4a.widget.StyleableTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:text="@string/feedback_text"/>
+        android:text="@string/feedback_text"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
     <Button
         android:id="@+id/btn_by_email"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:text="@string/feedback_by_email"/>
+        android:text="@string/feedback_by_email"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
     <Button
         android:id="@+id/btn_by_gh4a"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:text="@string/feedback_by_gh4a"/>
+        android:text="@string/feedback_by_gh4a"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
 </LinearLayout>

--- a/res/layout/accept_fab.xml
+++ b/res/layout/accept_fab.xml
@@ -7,6 +7,6 @@
     android:layout_marginRight="16dp"
     android:src="@drawable/navigation_accept"
     app:backgroundTint="?attr/colorFab"
+    app:fabSize="mini"
     app:layout_anchor="@+id/header"
-    app:layout_anchorGravity="right|bottom"
-    app:fabSize="mini" />
+    app:layout_anchorGravity="right|bottom" />

--- a/res/layout/add_fab.xml
+++ b/res/layout/add_fab.xml
@@ -8,5 +8,5 @@
     android:layout_gravity="bottom|right"
     android:layout_margin="16dp"
     android:src="@drawable/content_new"
-    app:layout_behavior="com.gh4a.widget.ScrollAwareFloatingActionButtonBehavior"
-    app:backgroundTint="?attr/colorFab" />
+    app:backgroundTint="?attr/colorFab"
+    app:layout_behavior="com.gh4a.widget.ScrollAwareFloatingActionButtonBehavior" />

--- a/res/layout/base_activity.xml
+++ b/res/layout/base_activity.xml
@@ -50,20 +50,20 @@
                         android:layout_height="wrap_content"
                         android:indeterminate="true"
                         android:visibility="gone"
-                        app:spb_sections_count="6"
-                        app:spb_speed="1.0"
+                        app:spb_interpolator="spb_interpolator_acceleratedecelerate"
                         app:spb_progressiveStart_activated="true"
                         app:spb_progressiveStart_speed="1.5"
                         app:spb_progressiveStop_speed="3.4"
-                        app:spb_interpolator="spb_interpolator_acceleratedecelerate" />
+                        app:spb_sections_count="6"
+                        app:spb_speed="1.0" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@android:id/empty"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:gravity="center"
-                        android:visibility="gone"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:visibility="gone" />
 
                     <FrameLayout
                         android:id="@+id/content_container"

--- a/res/layout/breadcrumb.xml
+++ b/res/layout/breadcrumb.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical"
     android:background="?attr/selectableItemBackgroundBorderless"
     android:orientation="horizontal"
-    android:padding="@dimen/breadcrumb_padding_side">
+    android:padding="@dimen/breadcrumb_padding_side"
+    tools:background="?colorBreadcrumbBackground">
 
     <com.gh4a.widget.StyleableTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
-        android:textColor="@color/crumb_text" />
+        android:textColor="@color/crumb_text"
+        tools:text="directory" />
 
     <ImageView
         android:layout_width="@dimen/breadcrumb_arrow_size"
@@ -22,6 +25,7 @@
         android:layout_marginLeft="@dimen/breadcrumb_arrow_margin"
         android:scaleType="fitXY"
         android:src="@drawable/ic_right_arrow"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible" />
 
 </LinearLayout>

--- a/res/layout/breadcrumb.xml
+++ b/res/layout/breadcrumb.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical"
@@ -11,14 +12,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:textColor="@color/crumb_text"
-        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+        android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+        android:textColor="@color/crumb_text" />
 
     <ImageView
         android:layout_width="@dimen/breadcrumb_arrow_size"
         android:layout_height="@dimen/breadcrumb_arrow_size"
-        android:layout_marginLeft="@dimen/breadcrumb_arrow_margin"
         android:layout_gravity="center_vertical"
+        android:layout_marginLeft="@dimen/breadcrumb_arrow_margin"
         android:scaleType="fitXY"
         android:src="@drawable/ic_right_arrow"
         android:visibility="gone" />

--- a/res/layout/color_picker_dialog.xml
+++ b/res/layout/color_picker_dialog.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/content_padding" >
+    android:padding="@dimen/content_padding">
 
     <com.larswerkman.holocolorpicker.ColorPicker
         android:id="@+id/color_picker"

--- a/res/layout/comment_edit_box.xml
+++ b/res/layout/comment_edit_box.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/comment_editor"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -29,7 +30,8 @@
             android:layout_weight="1"
             android:inputType="textMultiLine|textCapSentences"
             android:maxLines="@integer/comment_box_max_lines"
-            android:padding="8dp" />
+            android:padding="8dp"
+            tools:text="Enter comment" />
 
         <ImageView
             android:id="@+id/iv_comment"

--- a/res/layout/comment_edit_box.xml
+++ b/res/layout/comment_edit_box.xml
@@ -4,17 +4,17 @@
     android:id="@+id/comment_editor"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
     android:background="?attr/listBackground"
     android:descendantFocusability="beforeDescendants"
-    android:focusableInTouchMode="true">
+    android:focusableInTouchMode="true"
+    android:orientation="vertical">
 
     <View
         android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="@color/divider_bg"
-        android:layout_marginBottom="2dp" />
+        android:layout_marginBottom="2dp"
+        android:background="@color/divider_bg" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -25,20 +25,20 @@
             android:id="@+id/et_comment"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:layout_gravity="center_vertical"
-            android:padding="8dp"
+            android:layout_weight="1"
+            android:inputType="textMultiLine|textCapSentences"
             android:maxLines="@integer/comment_box_max_lines"
-            android:inputType="textMultiLine|textCapSentences" />
+            android:padding="8dp" />
 
         <ImageView
             android:id="@+id/iv_comment"
+            style="@style/SelectableBorderlessItem"
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:layout_gravity="bottom"
-            android:src="?attr/sendIcon"
-            style="@style/SelectableBorderlessItem"
-            android:scaleType="centerInside" />
+            android:scaleType="centerInside"
+            android:src="?attr/sendIcon" />
 
     </LinearLayout>
 

--- a/res/layout/commit.xml
+++ b/res/layout/commit.xml
@@ -2,6 +2,7 @@
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -29,7 +30,8 @@
                         android:layout_width="40dp"
                         android:layout_height="40dp"
                         android:layout_marginRight="16dp"
-                        android:background="?attr/selectableItemBackgroundBorderless" />
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        tools:src="@drawable/default_avatar" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_author"
@@ -38,7 +40,8 @@
                         android:layout_toRightOf="@id/iv_gravatar"
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColor="?android:attr/textColorPrimary"
-                        android:textSize="16sp" />
+                        android:textSize="16sp"
+                        tools:text="Username" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_timestamp"
@@ -47,7 +50,8 @@
                         android:layout_below="@id/tv_author"
                         android:layout_marginTop="2dp"
                         android:layout_toRightOf="@id/iv_gravatar"
-                        android:textAppearance="@style/TextAppearance.VerySmall" />
+                        android:textAppearance="@style/TextAppearance.VerySmall"
+                        tools:text="yesterday" />
 
                 </RelativeLayout>
 
@@ -62,7 +66,8 @@
                         android:id="@+id/iv_commit_gravatar"
                         android:layout_width="24dp"
                         android:layout_height="24dp"
-                        android:layout_marginRight="8dp" />
+                        android:layout_marginRight="8dp"
+                        tools:src="@drawable/default_avatar" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_commit_extra"
@@ -70,7 +75,8 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="?android:attr/textColorPrimary" />
+                        android:textColor="?android:attr/textColorPrimary"
+                        tools:text="Committed by username2 yesterday" />
 
                 </LinearLayout>
 
@@ -80,7 +86,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:textAppearance="@style/TextAppearance.ItemTitle"
-                    android:textIsSelectable="true" />
+                    android:textIsSelectable="true"
+                    tools:text="Commit title" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_message"
@@ -88,7 +95,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textIsSelectable="true" />
+                    android:textIsSelectable="true"
+                    tools:text="Commit message" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_desc"
@@ -96,7 +104,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    app:font="italic" />
+                    app:font="italic"
+                    tools:text="10 files added with 42 additions and 32 deletions." />
 
             </LinearLayout>
 

--- a/res/layout/commit.xml
+++ b/res/layout/commit.xml
@@ -44,10 +44,10 @@
                         android:id="@+id/tv_timestamp"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:textAppearance="@style/TextAppearance.VerySmall"
+                        android:layout_below="@id/tv_author"
                         android:layout_marginTop="2dp"
                         android:layout_toRightOf="@id/iv_gravatar"
-                        android:layout_below="@id/tv_author" />
+                        android:textAppearance="@style/TextAppearance.VerySmall" />
 
                 </RelativeLayout>
 
@@ -79,16 +79,16 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:textIsSelectable="true"
-                    android:textAppearance="@style/TextAppearance.ItemTitle" />
+                    android:textAppearance="@style/TextAppearance.ItemTitle"
+                    android:textIsSelectable="true" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_message"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:textIsSelectable="true"
-                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textIsSelectable="true" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_desc"
@@ -104,28 +104,28 @@
 
         <android.support.v7.widget.CardView
             android:id="@+id/card_changed"
+            style="?attr/cardViewTheme"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="?attr/cardViewTheme">
+            android:layout_height="wrap_content">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-            <com.gh4a.widget.StyleableTextView
-                android:id="@+id/commit_changed"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                style="@style/HeaderLabel"
-                android:text="@string/commit_changed" />
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/commit_changed"
+                    style="@style/HeaderLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/commit_changed" />
 
-            <LinearLayout
-                android:id="@+id/ll_changed"
-                android:orientation="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/overview_header_spacing" />
+                <LinearLayout
+                    android:id="@+id/ll_changed"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/overview_header_spacing"
+                    android:orientation="vertical" />
 
             </LinearLayout>
 
@@ -133,9 +133,9 @@
 
         <android.support.v7.widget.CardView
             android:id="@+id/card_added"
+            style="?attr/cardViewTheme"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="?attr/cardViewTheme">
+            android:layout_height="wrap_content">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -144,16 +144,17 @@
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/commit_added"
+                    style="@style/HeaderLabel"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/HeaderLabel"
                     android:text="@string/commit_added" />
+
                 <LinearLayout
                     android:id="@+id/ll_added"
-                    android:orientation="vertical"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/overview_header_spacing" />
+                    android:layout_marginBottom="@dimen/overview_header_spacing"
+                    android:orientation="vertical" />
 
             </LinearLayout>
 
@@ -161,9 +162,9 @@
 
         <android.support.v7.widget.CardView
             android:id="@+id/card_renamed"
+            style="?attr/cardViewTheme"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="?attr/cardViewTheme">
+            android:layout_height="wrap_content">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -172,16 +173,17 @@
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/commit_renamed"
+                    style="@style/HeaderLabel"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/HeaderLabel"
                     android:text="@string/commit_renamed" />
+
                 <LinearLayout
                     android:id="@+id/ll_renamed"
-                    android:orientation="vertical"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/overview_header_spacing" />
+                    android:layout_marginBottom="@dimen/overview_header_spacing"
+                    android:orientation="vertical" />
 
             </LinearLayout>
 
@@ -189,9 +191,9 @@
 
         <android.support.v7.widget.CardView
             android:id="@+id/card_deleted"
+            style="?attr/cardViewTheme"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="?attr/cardViewTheme">
+            android:layout_height="wrap_content">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -200,16 +202,17 @@
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/commit_deleted"
+                    style="@style/HeaderLabel"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/HeaderLabel"
                     android:text="@string/commit_deleted" />
+
                 <LinearLayout
                     android:id="@+id/ll_deleted"
-                    android:orientation="vertical"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/overview_header_spacing" />
+                    android:layout_marginBottom="@dimen/overview_header_spacing"
+                    android:orientation="vertical" />
 
             </LinearLayout>
 

--- a/res/layout/commit_comment_dialog.xml
+++ b/res/layout/commit_comment_dialog.xml
@@ -1,5 +1,6 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,7 +12,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/overview_item_spacing"
-        android:maxLines="3" />
+        android:maxLines="3"
+        tools:text="+ void codeLine() {" />
 
     <EditText
         android:id="@+id/body"

--- a/res/layout/commit_comment_dialog.xml
+++ b/res/layout/commit_comment_dialog.xml
@@ -1,23 +1,24 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/layout_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/content_padding" >
+    android:padding="@dimen/content_padding">
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/line"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/overview_item_spacing"
-        android:maxLines="3"/>
+        android:maxLines="3" />
 
     <EditText
         android:id="@+id/body"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:imeOptions="actionDone"
         android:gravity="top"
-        android:lines="5"/>
+        android:imeOptions="actionDone"
+        android:lines="5" />
 
 </LinearLayout>

--- a/res/layout/commit_comment_list.xml
+++ b/res/layout/commit_comment_list.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -15,7 +16,8 @@
         android:id="@+id/comment_box"
         android:name="com.gh4a.fragment.CommentBoxFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:layout="@layout/comment_edit_box" />
 
 </LinearLayout>
 

--- a/res/layout/commit_filename.xml
+++ b/res/layout/commit_filename.xml
@@ -21,6 +21,7 @@
         android:drawablePadding="4dp"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:visibility="gone"
+        tools:text="10"
         tools:visibility="visible" />
 
     <com.gh4a.widget.StyleableTextView
@@ -30,13 +31,15 @@
         android:layout_alignParentLeft="true"
         android:layout_alignWithParentIfMissing="true"
         android:layout_toLeftOf="@id/comments"
-        android:typeface="monospace" />
+        android:typeface="monospace"
+        tools:text="some/file/in/directories.txt" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/stats"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/filename"
-        android:textAppearance="@style/TextAppearance.VerySmall" />
+        android:textAppearance="@style/TextAppearance.VerySmall"
+        tools:text="+3 -34" />
 
 </RelativeLayout>

--- a/res/layout/commit_filename.xml
+++ b/res/layout/commit_filename.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/SelectableItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="4dp"
     android:paddingBottom="4dp"
     android:paddingLeft="@dimen/content_padding"
     android:paddingRight="@dimen/content_padding"
-    style="@style/SelectableItem">
+    android:paddingTop="4dp">
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/comments"
@@ -15,19 +15,19 @@
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
+        android:layout_marginLeft="4dp"
         android:drawableLeft="?attr/commentsIcon"
         android:drawablePadding="4dp"
-        android:layout_marginLeft="4dp"
-        android:visibility="gone"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:visibility="gone" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/filename"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toLeftOf="@id/comments"
         android:layout_alignParentLeft="true"
         android:layout_alignWithParentIfMissing="true"
+        android:layout_toLeftOf="@id/comments"
         android:typeface="monospace" />
 
     <com.gh4a.widget.StyleableTextView

--- a/res/layout/commit_filename.xml
+++ b/res/layout/commit_filename.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/SelectableItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -19,7 +20,8 @@
         android:drawableLeft="?attr/commentsIcon"
         android:drawablePadding="4dp"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/filename"

--- a/res/layout/content_list.xml
+++ b/res/layout/content_list.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -9,10 +10,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorBreadcrumbBackground"
-        android:scrollbarSize="2dp"
+        android:elevation="2dp"
         android:paddingLeft="8dp"
         android:paddingRight="8dp"
-        android:elevation="2dp" />
+        android:scrollbarSize="2dp" />
 
     <FrameLayout
         android:id="@+id/content_list_container"

--- a/res/layout/drawer_title_home.xml
+++ b/res/layout/drawer_title_home.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingTop="24dp">
+    android:paddingTop="24dp"
+    tools:background="?colorPrimary">
 
     <ImageView
         android:id="@+id/avatar"
@@ -19,6 +21,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:textAppearance="?attr/drawerTitleTextAppearance" />
+        android:textAppearance="?attr/drawerTitleTextAppearance"
+        tools:text="Username" />
 
 </LinearLayout>

--- a/res/layout/drawer_title_home.xml
+++ b/res/layout/drawer_title_home.xml
@@ -4,8 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center_vertical"
-    android:paddingTop="24dp"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:paddingTop="24dp">
 
     <ImageView
         android:id="@+id/avatar"

--- a/res/layout/drawer_title_main.xml
+++ b/res/layout/drawer_title_main.xml
@@ -4,8 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center_vertical"
-    android:paddingTop="24dp"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:paddingTop="24dp">
 
     <ImageView
         android:layout_width="48dp"

--- a/res/layout/drawer_title_main.xml
+++ b/res/layout/drawer_title_main.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingTop="24dp">
+    android:paddingTop="24dp"
+    tools:background="?colorPrimary">
 
     <ImageView
         android:layout_width="48dp"

--- a/res/layout/drawer_title_right.xml
+++ b/res/layout/drawer_title_right.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/right_drawer_title"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?attr/actionBarSize" />
+    android:minHeight="?attr/actionBarSize"
+    tools:background="?colorPrimary" />

--- a/res/layout/drawer_title_right.xml
+++ b/res/layout/drawer_title_right.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/right_drawer_title"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/res/layout/edit_text.xml
+++ b/res/layout/edit_text.xml
@@ -4,9 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="@dimen/content_padding">
+
     <EditText
         android:id="@+id/et_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:inputType="textMultiLine|textCapSentences"/>
+        android:inputType="textMultiLine|textCapSentences" />
 </ScrollView>

--- a/res/layout/error.xml
+++ b/res/layout/error.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/error"
     android:layout_width="match_parent"
@@ -16,28 +17,28 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal|top"
-        android:text="@string/load_failure_explanation"
-        android:textSize="16sp"
-        android:textColor="?android:attr/textColorSecondary"
+        android:paddingBottom="8dp"
         android:paddingLeft="16dp"
         android:paddingRight="16dp"
         android:paddingTop="8dp"
-        android:paddingBottom="8dp" />
+        android:text="@string/load_failure_explanation"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textSize="16sp" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/retry_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:text="@string/try_again"
-        android:textColor="?attr/colorAccent"
-        app:allCaps="true"
-        app:font="medium"
         android:background="?attr/selectableItemBackgroundBorderless"
+        android:paddingBottom="8dp"
         android:paddingLeft="16dp"
         android:paddingRight="16dp"
         android:paddingTop="8dp"
-        android:paddingBottom="8dp" />
+        android:text="@string/try_again"
+        android:textColor="?attr/colorAccent"
+        app:allCaps="true"
+        app:font="medium" />
 
     <View
         android:layout_width="match_parent"

--- a/res/layout/frame_layout.xml
+++ b/res/layout/frame_layout.xml
@@ -1,8 +1,11 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
     <FrameLayout
         android:id="@+id/details"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 </LinearLayout>

--- a/res/layout/gist.xml
+++ b/res/layout/gist.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -23,13 +24,15 @@
                     android:id="@+id/tv_created_at"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    tools:text="on 1/1/1970" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_desc"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:textAppearance="@style/TextAppearance.ItemTitle" />
+                    android:textAppearance="@style/TextAppearance.ItemTitle"
+                    tools:text="Gist title" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_private"
@@ -40,7 +43,8 @@
                     android:drawablePadding="4dp"
                     android:text="@string/repo_type_private"
                     android:textAppearance="@style/TextAppearance.VerySmall.Bold"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    tools:visibility="visible" />
 
             </LinearLayout>
 

--- a/res/layout/gist.xml
+++ b/res/layout/gist.xml
@@ -12,35 +12,35 @@
         <android.support.v7.widget.CardView
             style="?attr/cardViewTheme">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/overview_header_spacing"
-            android:padding="@dimen/content_padding"
-            android:orientation="vertical">
-
-            <com.gh4a.widget.StyleableTextView
-                android:id="@+id/tv_created_at"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:layout_marginBottom="@dimen/overview_header_spacing"
+                android:orientation="vertical"
+                android:padding="@dimen/content_padding">
 
-            <com.gh4a.widget.StyleableTextView
-                android:id="@+id/tv_desc"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textAppearance="@style/TextAppearance.ItemTitle" />
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/tv_created_at"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
-            <com.gh4a.widget.StyleableTextView
-                android:id="@+id/tv_private"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:drawableLeft="?attr/privateSmallIcon"
-                android:drawablePadding="4dp"
-                android:text="@string/repo_type_private"
-                android:textAppearance="@style/TextAppearance.VerySmall.Bold"
-                android:visibility="gone" />
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/tv_desc"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="@style/TextAppearance.ItemTitle" />
+
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/tv_private"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:drawableLeft="?attr/privateSmallIcon"
+                    android:drawablePadding="4dp"
+                    android:text="@string/repo_type_private"
+                    android:textAppearance="@style/TextAppearance.VerySmall.Bold"
+                    android:visibility="gone" />
 
             </LinearLayout>
 
@@ -58,9 +58,9 @@
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/files_title"
+                    style="@style/HeaderLabel"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/HeaderLabel"
                     android:text="@string/gist_files" />
 
                 <LinearLayout

--- a/res/layout/issue.xml
+++ b/res/layout/issue.xml
@@ -10,8 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:scrollbars="vertical"
-        android:background="?attr/listBackground" />
+        android:background="?attr/listBackground"
+        android:scrollbars="vertical" />
 
     <fragment
         android:id="@+id/comment_box"

--- a/res/layout/issue.xml
+++ b/res/layout/issue.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -17,6 +18,7 @@
         android:id="@+id/comment_box"
         android:name="com.gh4a.fragment.CommentBoxFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:layout="@layout/comment_edit_box" />
 
 </LinearLayout>

--- a/res/layout/issue_comment_list_header.xml
+++ b/res/layout/issue_comment_list_header.xml
@@ -60,7 +60,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/overview_item_spacing"
-        android:visibility="gone">
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <ImageView
             android:id="@+id/iv_pr"
@@ -74,7 +75,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toRightOf="@id/iv_pr"
-            android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+            tools:text="From branch" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_pr_to"
@@ -82,7 +84,8 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/tv_pr_from"
             android:layout_toRightOf="@id/iv_pr"
-            android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+            tools:text="Into branch" />
 
     </RelativeLayout>
 
@@ -91,7 +94,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/overview_item_spacing"
-        android:visibility="gone">
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <ImageView
             android:id="@+id/iv_milestone"
@@ -115,7 +119,8 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/tv_milestone_label"
             android:layout_toRightOf="@id/iv_milestone"
-            android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+            tools:text="v1.10.1" />
 
     </RelativeLayout>
 
@@ -124,7 +129,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/overview_item_spacing"
-        android:visibility="gone">
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <ImageView
             android:id="@+id/iv_assignee_icon"
@@ -157,7 +163,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/overview_item_spacing"
-        android:visibility="gone">
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <ImageView
             android:id="@+id/iv_labels"
@@ -180,7 +187,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@id/tv_labels_label"
-            android:layout_toRightOf="@id/iv_labels" />
+            android:layout_toRightOf="@id/iv_labels"
+            tools:text="colored labels here" />
 
     </RelativeLayout>
 
@@ -189,20 +197,23 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/overview_item_spacing"
-        android:visibility="gone">
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <ImageView
             android:id="@+id/iv_merge_status_icon"
             android:layout_width="30dp"
             android:layout_height="30dp"
-            android:layout_marginRight="10dp" />
+            android:layout_marginRight="10dp"
+            tools:src="@drawable/pull_request_merge_ok" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/merge_status_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toRightOf="@id/iv_merge_status_icon"
-            android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            tools:text="@string/pull_merge_status_clean" />
 
         <LinearLayout
             android:id="@+id/merge_commit_status_container"
@@ -232,6 +243,7 @@
         android:text="@string/view_pull_request"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorLink"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible" />
 
 </LinearLayout>

--- a/res/layout/issue_comment_list_header.xml
+++ b/res/layout/issue_comment_list_header.xml
@@ -25,21 +25,21 @@
             android:id="@+id/tv_extra"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_toRightOf="@id/iv_gravatar"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="?android:attr/textColorPrimary"
             android:textSize="16sp"
-            android:layout_toRightOf="@id/iv_gravatar"
             tools:text="Username" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_timestamp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.VerySmall"
-            android:textColor="?android:attr/textColorSecondary"
+            android:layout_below="@id/tv_extra"
             android:layout_marginTop="2dp"
             android:layout_toRightOf="@id/iv_gravatar"
-            android:layout_below="@id/tv_extra"
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            android:textColor="?android:attr/textColorSecondary"
             tools:text="yesterday" />
 
     </RelativeLayout>
@@ -48,11 +48,11 @@
         android:id="@+id/tv_desc"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/content_padding"
         android:paddingBottom="@dimen/content_padding"
-        android:textIsSelectable="true"
+        android:paddingTop="@dimen/content_padding"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorPrimary"
+        android:textIsSelectable="true"
         tools:text="Description of the issue." />
 
     <RelativeLayout
@@ -225,13 +225,13 @@
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_pull"
+        style="@style/SelectableLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/overview_item_spacing"
-        style="@style/SelectableLabel"
+        android:text="@string/view_pull_request"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorLink"
-        android:text="@string/view_pull_request"
         android:visibility="gone" />
 
 </LinearLayout>

--- a/res/layout/issue_create.xml
+++ b/res/layout/issue_create.xml
@@ -2,24 +2,24 @@
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:paddingBottom="@dimen/content_padding"
         android:paddingLeft="@dimen/content_padding"
         android:paddingRight="@dimen/content_padding"
-        android:paddingTop="@dimen/floating_action_button_margin_mini"
-        android:paddingBottom="@dimen/content_padding">
+        android:paddingTop="@dimen/floating_action_button_margin_mini">
 
         <RelativeLayout
             android:id="@+id/milestone_container"
             android:layout_width="match_parent"
             android:layout_height="72dp"
-            android:gravity="center_vertical"
+            android:background="?attr/selectableItemBackground"
             android:clickable="true"
-            android:background="?attr/selectableItemBackground">
+            android:gravity="center_vertical">
 
             <ImageView
                 android:id="@+id/iv_milestone"
@@ -51,9 +51,9 @@
             android:id="@+id/assignee_container"
             android:layout_width="match_parent"
             android:layout_height="72dp"
-            android:gravity="center_vertical"
+            android:background="?attr/selectableItemBackground"
             android:clickable="true"
-            android:background="?attr/selectableItemBackground">
+            android:gravity="center_vertical">
 
             <ImageView
                 android:id="@+id/iv_assignee"
@@ -85,9 +85,9 @@
             android:id="@+id/label_container"
             android:layout_width="match_parent"
             android:layout_height="72dp"
-            android:gravity="center_vertical"
+            android:background="?attr/selectableItemBackground"
             android:clickable="true"
-            android:background="?attr/selectableItemBackground">
+            android:gravity="center_vertical">
 
             <ImageView
                 android:id="@+id/iv_labels"

--- a/res/layout/issue_create.xml
+++ b/res/layout/issue_create.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -43,7 +44,8 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/tv_milestone_label"
                 android:layout_toRightOf="@id/iv_milestone"
-                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                tools:text="v10.1.2" />
 
         </RelativeLayout>
 
@@ -77,7 +79,8 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/tv_assignee_label"
                 android:layout_toRightOf="@id/iv_assignee"
-                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                tools:text="list of people" />
 
         </RelativeLayout>
 
@@ -111,7 +114,8 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/tv_labels_label"
                 android:layout_toRightOf="@id/iv_labels"
-                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                tools:text="colored labels here" />
 
         </RelativeLayout>
 

--- a/res/layout/issue_create_header.xml
+++ b/res/layout/issue_create_header.xml
@@ -3,11 +3,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/floating_action_button_margin_mini"
     android:paddingLeft="@dimen/content_padding"
     android:paddingRight="@dimen/content_padding"
-    android:paddingTop="@dimen/content_padding"
-    android:paddingBottom="@dimen/floating_action_button_margin_mini"
-    android:orientation="vertical">
+    android:paddingTop="@dimen/content_padding">
 
     <android.support.design.widget.TextInputLayout
         android:id="@+id/title_wrapper"
@@ -17,10 +17,10 @@
 
         <android.support.design.widget.TextInputEditText
             android:id="@+id/et_title"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:layout_marginBottom="@dimen/overview_item_spacing"
             style="@style/TextAppearance.Header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/overview_item_spacing"
             android:maxLines="2" />
 
     </android.support.design.widget.TextInputLayout>
@@ -33,13 +33,13 @@
 
         <android.support.design.widget.TextInputEditText
             android:id="@+id/et_desc"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
             style="@style/TextAppearance.Header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:gravity="top"
-            android:minLines="@integer/issue_edit_body_min_lines"
+            android:inputType="textMultiLine|textCapSentences"
             android:maxLines="@integer/issue_edit_body_max_lines"
-            android:inputType="textMultiLine|textCapSentences" />
+            android:minLines="@integer/issue_edit_body_min_lines" />
 
     </android.support.design.widget.TextInputLayout>
 

--- a/res/layout/issue_create_milestone.xml
+++ b/res/layout/issue_create_milestone.xml
@@ -2,19 +2,19 @@
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent">
 
     <RelativeLayout
         android:id="@+id/due_container"
         android:layout_width="match_parent"
         android:layout_height="72dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:gravity="center_vertical"
+        android:paddingBottom="@dimen/content_padding"
         android:paddingLeft="@dimen/content_padding"
         android:paddingRight="@dimen/content_padding"
-        android:paddingTop="@dimen/floating_action_button_margin_mini"
-        android:paddingBottom="@dimen/content_padding"
-        android:gravity="center_vertical"
-        android:clickable="true"
-        android:background="?attr/selectableItemBackground">
+        android:paddingTop="@dimen/floating_action_button_margin_mini">
 
         <ImageView
             android:id="@+id/iv_due"

--- a/res/layout/issue_create_milestone.xml
+++ b/res/layout/issue_create_milestone.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -38,7 +39,8 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/tv_due_label"
             android:layout_toRightOf="@id/iv_due"
-            android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+            tools:text="1/1/1970" />
 
     </RelativeLayout>
 

--- a/res/layout/issue_edit_fab.xml
+++ b/res/layout/issue_edit_fab.xml
@@ -8,6 +8,6 @@
     android:layout_marginRight="16dp"
     android:src="@drawable/content_edit_white"
     app:backgroundTint="?attr/colorIssueEditFab"
+    app:fabSize="mini"
     app:layout_anchor="@id/header"
-    app:layout_anchorGravity="right|bottom"
-    app:fabSize="mini" />
+    app:layout_anchorGravity="right|bottom" />

--- a/res/layout/issue_header.xml
+++ b/res/layout/issue_header.xml
@@ -1,9 +1,11 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    tools:background="@color/issue_open_light">
 
     <com.gh4a.widget.VerticalTextView
         android:id="@+id/tv_state"
@@ -14,7 +16,8 @@
         android:paddingLeft="16dp"
         android:paddingRight="16dp"
         android:textAppearance="@style/TextAppearance.VerySmall"
-        android:textColor="@color/primary_text_default_material_dark" />
+        android:textColor="@color/primary_text_default_material_dark"
+        tools:text="OPEN" />
 
     <!-- right padding is FAB size + FAB right margin -->
     <com.gh4a.widget.StyleableTextView
@@ -32,6 +35,7 @@
         android:textAppearance="@style/TextAppearance.AppCompat.Title"
         android:textColor="@color/primary_text_default_material_dark"
         android:textIsSelectable="true"
-        app:font="condensed" />
+        app:font="condensed"
+        tools:text="Issue title" />
 
 </LinearLayout>

--- a/res/layout/issue_header.xml
+++ b/res/layout/issue_header.xml
@@ -10,28 +10,28 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
+        android:gravity="bottom|center"
         android:paddingLeft="16dp"
         android:paddingRight="16dp"
         android:textAppearance="@style/TextAppearance.VerySmall"
-        android:textColor="@color/primary_text_default_material_dark"
-        android:gravity="bottom|center" />
+        android:textColor="@color/primary_text_default_material_dark" />
 
     <!-- right padding is FAB size + FAB right margin -->
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:layout_gravity="center_vertical"
-        android:paddingTop="8dp"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="2"
         android:paddingBottom="8dp"
         android:paddingLeft="16dp"
         android:paddingRight="42dp"
-        android:maxLines="2"
-        android:ellipsize="end"
-        android:textIsSelectable="true"
+        android:paddingTop="8dp"
         android:textAppearance="@style/TextAppearance.AppCompat.Title"
-        app:font="condensed"
-        android:textColor="@color/primary_text_default_material_dark" />
+        android:textColor="@color/primary_text_default_material_dark"
+        android:textIsSelectable="true"
+        app:font="condensed" />
 
 </LinearLayout>

--- a/res/layout/list_fragment_content.xml
+++ b/res/layout/list_fragment_content.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/res/layout/list_loading_view.xml
+++ b/res/layout/list_loading_view.xml
@@ -4,11 +4,11 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center"
+    android:orientation="horizontal"
+    android:paddingBottom="8dp"
     android:paddingLeft="@dimen/content_padding"
     android:paddingRight="@dimen/content_padding"
-    android:orientation="horizontal"
     android:paddingTop="8dp"
-    android:paddingBottom="8dp"
     android:visibility="gone">
 
     <ProgressBar
@@ -21,8 +21,8 @@
     <com.gh4a.widget.StyleableTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/loading_msg"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?attr/colorAccent"
-        android:text="@string/loading_msg" />
+        android:textColor="?attr/colorAccent" />
 
 </LinearLayout>

--- a/res/layout/loading_fragment.xml
+++ b/res/layout/loading_fragment.xml
@@ -11,12 +11,12 @@
         android:layout_height="wrap_content"
         android:indeterminate="true"
         android:visibility="gone"
-        app:spb_sections_count="6"
-        app:spb_speed="1.0"
+        app:spb_interpolator="spb_interpolator_acceleratedecelerate"
         app:spb_progressiveStart_activated="true"
         app:spb_progressiveStart_speed="1.5"
         app:spb_progressiveStop_speed="3.4"
-        app:spb_interpolator="spb_interpolator_acceleratedecelerate" />
+        app:spb_sections_count="6"
+        app:spb_speed="1.0" />
 
     <FrameLayout
         android:id="@+id/content_container"

--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -4,10 +4,10 @@
     android:id="@+id/main_content"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:gravity="center_vertical"
+    android:orientation="vertical"
     android:paddingLeft="@dimen/content_padding"
-    android:paddingRight="@dimen/content_padding" >
+    android:paddingRight="@dimen/content_padding">
 
     <android.support.design.widget.TextInputLayout
         android:layout_width="match_parent"
@@ -16,13 +16,13 @@
 
         <android.support.design.widget.TextInputEditText
             android:id="@+id/et_username_main"
-            android:layout_height="wrap_content"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_above="@+id/spacer"
             android:layout_gravity="center"
             android:imeOptions="actionNext"
-            android:singleLine="true"
-            android:nextFocusDown="@+id/et_password_main"/>
+            android:nextFocusDown="@+id/et_password_main"
+            android:singleLine="true" />
 
     </android.support.design.widget.TextInputLayout>
 
@@ -38,8 +38,8 @@
 
         <android.support.design.widget.TextInputEditText
             android:id="@id/et_password_main"
-            android:layout_height="wrap_content"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_below="@+id/spacer"
             android:imeOptions="actionDone"
             android:inputType="textPassword"

--- a/res/layout/open_source_component_item.xml
+++ b/res/layout/open_source_component_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -17,14 +18,16 @@
                 android:id="@+id/title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textAppearance="@style/TextAppearance.ItemTitle" />
+                android:textAppearance="@style/TextAppearance.ItemTitle"
+                tools:text="Library title" />
 
             <com.gh4a.widget.StyleableTextView
                 android:id="@+id/url"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"
-                android:autoLink="web" />
+                android:autoLink="web"
+                tools:text="https://example.com" />
 
         </LinearLayout>
 

--- a/res/layout/open_source_component_item.xml
+++ b/res/layout/open_source_component_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -9,8 +10,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="4dp"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:padding="4dp">
 
             <com.gh4a.widget.StyleableTextView
                 android:id="@+id/title"

--- a/res/layout/open_source_component_list.xml
+++ b/res/layout/open_source_component_list.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ListView xmlns:android="http://schemas.android.com/apk/res/android"
+<ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:listSelector="@null"
     android:divider="@null"
     android:dividerHeight="0dp"
-    android:scrollbarStyle="outsideOverlay"
+    android:listSelector="@null"
+    android:paddingBottom="8dp"
     android:paddingLeft="@dimen/content_padding"
     android:paddingRight="@dimen/content_padding"
     android:paddingTop="8dp"
-    android:paddingBottom="8dp" />
+    android:scrollbarStyle="outsideOverlay" />

--- a/res/layout/popup_menu_item.xml
+++ b/res/layout/popup_menu_item.xml
@@ -3,6 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textAppearance="?android:attr/textAppearanceMedium"
+    android:minWidth="120dp"
     android:padding="10dp"
-    android:minWidth="120dp" />
+    android:textAppearance="?android:attr/textAppearanceMedium" />

--- a/res/layout/pull_merge_message_dialog.xml
+++ b/res/layout/pull_merge_message_dialog.xml
@@ -9,15 +9,15 @@
     <com.gh4a.widget.StyleableTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:text="@string/pull_merge_message_description" />
+        android:text="@string/pull_merge_message_description"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
 
     <EditText
         android:id="@+id/et_commit_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:imeOptions="flagNoFullscreen|actionNext"
         android:cursorVisible="true"
+        android:imeOptions="flagNoFullscreen|actionNext"
         android:maxLines="5" />
 
 </LinearLayout>

--- a/res/layout/release.xml
+++ b/res/layout/release.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -25,14 +26,16 @@
                     android:layout_height="40dp"
                     android:layout_centerVertical="true"
                     android:layout_marginRight="16dp"
-                    android:background="?attr/selectableItemBackgroundBorderless" />
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    tools:src="@drawable/default_avatar" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_releaseinfo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_toRightOf="@id/iv_gravatar"
-                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    tools:text="Released by username yesterday" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_releasetype"
@@ -41,7 +44,8 @@
                     android:layout_below="@id/tv_releaseinfo"
                     android:layout_marginTop="@dimen/overview_header_spacing"
                     android:layout_toRightOf="@id/iv_gravatar"
-                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    tools:text="Release type" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_releasetag"
@@ -52,7 +56,8 @@
                     android:layout_toRightOf="@id/iv_gravatar"
                     android:background="?attr/selectableItemBackground"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?attr/colorAccent" />
+                    android:textColor="?attr/colorAccent"
+                    tools:text="On tag v3.23.2" />
 
             </RelativeLayout>
 
@@ -86,7 +91,9 @@
                     android:paddingBottom="@dimen/content_padding"
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    tools:text="Release notes text"
+                    tools:visibility="visible" />
 
             </LinearLayout>
 

--- a/res/layout/release.xml
+++ b/res/layout/release.xml
@@ -31,28 +31,28 @@
                     android:id="@+id/tv_releaseinfo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:layout_toRightOf="@id/iv_gravatar" />
+                    android:layout_toRightOf="@id/iv_gravatar"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_releasetype"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_below="@id/tv_releaseinfo"
                     android:layout_marginTop="@dimen/overview_header_spacing"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
                     android:layout_toRightOf="@id/iv_gravatar"
-                    android:layout_below="@id/tv_releaseinfo" />
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_releasetag"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/overview_header_spacing"
-                    android:textColor="?attr/colorAccent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:layout_toRightOf="@id/iv_gravatar"
                     android:layout_below="@id/tv_releasetype"
-                    android:background="?attr/selectableItemBackground" />
+                    android:layout_marginTop="@dimen/overview_header_spacing"
+                    android:layout_toRightOf="@id/iv_gravatar"
+                    android:background="?attr/selectableItemBackground"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?attr/colorAccent" />
 
             </RelativeLayout>
 
@@ -68,25 +68,25 @@
                 android:layout_marginBottom="@dimen/overview_header_spacing"
                 android:orientation="vertical">
 
-            <com.gh4a.widget.StyleableTextView
-                android:id="@+id/release_notes_title"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                style="@style/HeaderLabel"
-                android:text="@string/release_notes" />
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/release_notes_title"
+                    style="@style/HeaderLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/release_notes" />
 
-            <ProgressBar
-                android:id="@+id/pb_releasenotes"
-                style="@style/LoadingProgress" />
+                <ProgressBar
+                    android:id="@+id/pb_releasenotes"
+                    style="@style/LoadingProgress" />
 
-            <com.gh4a.widget.StyleableTextView
-                android:id="@+id/tv_release_notes"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingLeft="@dimen/content_padding"
-                android:paddingRight="@dimen/content_padding"
-                android:paddingBottom="@dimen/content_padding"
-                android:visibility="gone" />
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/tv_release_notes"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="@dimen/content_padding"
+                    android:paddingLeft="@dimen/content_padding"
+                    android:paddingRight="@dimen/content_padding"
+                    android:visibility="gone" />
 
             </LinearLayout>
 
@@ -105,9 +105,9 @@
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/downloads_title"
+                    style="@style/HeaderLabel"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/HeaderLabel"
                     android:text="@string/downloads" />
 
                 <android.support.v7.widget.RecyclerView

--- a/res/layout/repository.xml
+++ b/res/layout/repository.xml
@@ -66,8 +66,8 @@
                     android:id="@+id/tv_private"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
                     android:layout_below="@id/tv_language"
+                    android:layout_marginTop="2dp"
                     android:drawableLeft="?attr/privateSmallIcon"
                     android:drawablePadding="4dp"
                     android:text="@string/repo_type_private"
@@ -227,9 +227,9 @@
                     android:id="@+id/readme"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingBottom="@dimen/content_padding"
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
-                    android:paddingBottom="@dimen/content_padding"
                     android:textIsSelectable="true"
                     android:visibility="gone" />
 

--- a/res/layout/repository.xml
+++ b/res/layout/repository.xml
@@ -2,6 +2,7 @@
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@id/main_content"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -24,7 +25,8 @@
                     android:id="@+id/tv_repo_name"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:textAppearance="@style/TextAppearance.HeaderTitle" />
+                    android:textAppearance="@style/TextAppearance.HeaderTitle"
+                    tools:text="Username/Repository" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_parent"
@@ -35,14 +37,16 @@
                     android:layout_marginTop="8dp"
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="?android:attr/textColorLink"
-                    app:font="italic" />
+                    app:font="italic"
+                    tools:text="forked from other/repository" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_desc"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_below="@id/tv_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    tools:text="Repository description" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_url"
@@ -52,7 +56,8 @@
                     android:layout_marginTop="2dp"
                     android:autoLink="web"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColorLink="?android:attr/textColorLink" />
+                    android:textColorLink="?android:attr/textColorLink"
+                    tools:text="https://example.com" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_language"
@@ -60,7 +65,8 @@
                     android:layout_height="wrap_content"
                     android:layout_below="@id/tv_url"
                     android:layout_marginTop="2dp"
-                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    tools:text="Language Java" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_private"
@@ -72,7 +78,8 @@
                     android:drawablePadding="4dp"
                     android:text="@string/repo_type_private"
                     android:textAppearance="@style/TextAppearance.VerySmall.Bold"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    tools:visibility="visible" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -129,7 +136,8 @@
                             android:id="@+id/tv_stargazers_count"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:textAppearance="@style/TextAppearance.CountHeaderItem" />
+                            android:textAppearance="@style/TextAppearance.CountHeaderItem"
+                            tools:text="10" />
 
                         <com.gh4a.widget.StyleableTextView
                             android:id="@+id/tv_stargazers_label"
@@ -152,7 +160,8 @@
                             android:id="@+id/tv_forks_count"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:textAppearance="@style/TextAppearance.CountHeaderItem" />
+                            android:textAppearance="@style/TextAppearance.CountHeaderItem"
+                            tools:text="1" />
 
                         <com.gh4a.widget.StyleableTextView
                             android:id="@+id/tv_forks_label"
@@ -231,7 +240,9 @@
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
                     android:textIsSelectable="true"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    tools:text="Readme text"
+                    tools:visibility="visible" />
 
             </LinearLayout>
         </android.support.v7.widget.CardView>

--- a/res/layout/row_assignee.xml
+++ b/res/layout/row_assignee.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="4dp"
@@ -11,13 +12,15 @@
         android:layout_width="20dp"
         android:layout_height="20dp"
         android:layout_gravity="center_vertical"
-        android:layout_marginRight="4dp" />
+        android:layout_marginRight="4dp"
+        tools:src="@drawable/default_avatar" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_assignee"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+        android:textAppearance="@style/TextAppearance.AppCompat.Small"
+        tools:text="Username" />
 
 </LinearLayout>

--- a/res/layout/row_assignee.xml
+++ b/res/layout/row_assignee.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="4dp"
@@ -9,8 +10,8 @@
         android:id="@+id/iv_assignee"
         android:layout_width="20dp"
         android:layout_height="20dp"
-        android:layout_marginRight="4dp"
-        android:layout_gravity="center_vertical" />
+        android:layout_gravity="center_vertical"
+        android:layout_marginRight="4dp" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_assignee"

--- a/res/layout/row_bookmark.xml
+++ b/res/layout/row_bookmark.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
@@ -13,7 +14,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:layout_marginRight="16dp" />
+        android:layout_marginRight="16dp"
+        tools:src="@drawable/repo_bookmark" />
 
     <LinearLayout
         android:layout_width="0dp"
@@ -27,12 +29,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
-            android:textAppearance="@style/TextAppearance.ItemTitle" />
+            android:textAppearance="@style/TextAppearance.ItemTitle"
+            tools:text="username/repository" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_extra"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="branch" />
     </LinearLayout>
 </LinearLayout>

--- a/res/layout/row_bookmark.xml
+++ b/res/layout/row_bookmark.xml
@@ -4,27 +4,31 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="horizontal"
     android:padding="@dimen/content_padding"
-    android:paddingRight="@dimen/content_padding"
-    android:orientation="horizontal" >
+    android:paddingRight="@dimen/content_padding">
+
     <ImageView
         android:id="@+id/iv_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:layout_marginRight="16dp" />
+
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:layout_gravity="center_vertical"
-        android:orientation="vertical" >
+        android:layout_weight="1"
+        android:orientation="vertical">
+
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.ItemTitle"
-            android:gravity="center_vertical" />
+            android:gravity="center_vertical"
+            android:textAppearance="@style/TextAppearance.ItemTitle" />
+
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_extra"
             android:layout_width="match_parent"

--- a/res/layout/row_branch.xml
+++ b/res/layout/row_branch.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/branch_item_background"
@@ -13,7 +14,8 @@
         android:id="@+id/icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical" />
+        android:layout_gravity="center_vertical"
+        tools:src="@drawable/branch" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/title"
@@ -21,6 +23,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:layout_marginLeft="16dp"
-        android:textAppearance="?attr/textAppearanceListItemSmall" />
+        android:textAppearance="?attr/textAppearanceListItemSmall"
+        tools:text="branch" />
 
 </LinearLayout>

--- a/res/layout/row_branch.xml
+++ b/res/layout/row_branch.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?attr/listPreferredItemHeightSmall"
     android:background="@drawable/branch_item_background"
+    android:minHeight="?attr/listPreferredItemHeightSmall"
+    android:orientation="horizontal"
     android:paddingLeft="16dp"
-    android:paddingRight="16dp"
-    android:orientation="horizontal">
+    android:paddingRight="16dp">
 
     <ImageView
         android:id="@+id/icon"
@@ -18,8 +19,8 @@
         android:id="@+id/title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="16dp"
         android:layout_gravity="center_vertical"
+        android:layout_marginLeft="16dp"
         android:textAppearance="?attr/textAppearanceListItemSmall" />
 
 </LinearLayout>

--- a/res/layout/row_code_search.xml
+++ b/res/layout/row_code_search.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -13,19 +14,22 @@
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.ItemTitle" />
+        android:textAppearance="@style/TextAppearance.ItemTitle"
+        tools:text="Result name" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_repo"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.AppCompat.Small"
-        android:textColor="?android:attr/textColorPrimary" />
+        android:textColor="?android:attr/textColorPrimary"
+        tools:text="username/repository" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_matches"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.VerySmall" />
+        android:textAppearance="@style/TextAppearance.VerySmall"
+        tools:text="code matches" />
 
 </LinearLayout>

--- a/res/layout/row_code_search.xml
+++ b/res/layout/row_code_search.xml
@@ -3,9 +3,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?android:attr/listPreferredItemHeight"
-    android:gravity="center_vertical"
     android:background="?attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeight"
     android:orientation="vertical"
     android:padding="@dimen/content_padding">
 

--- a/res/layout/row_commit.xml
+++ b/res/layout/row_commit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -13,7 +14,8 @@
         android:layout_height="40dp"
         android:layout_marginRight="16dp"
         android:layout_marginTop="8dp"
-        android:background="?attr/selectableItemBackgroundBorderless" />
+        android:background="?attr/selectableItemBackgroundBorderless"
+        tools:src="@drawable/default_avatar" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_comments"
@@ -24,7 +26,9 @@
         android:drawableLeft="?attr/commentsIcon"
         android:drawablePadding="4dp"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:text="10"
+        tools:visibility="visible" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_extra"
@@ -33,7 +37,8 @@
         android:layout_alignParentTop="true"
         android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?android:attr/textColorPrimary" />
+        android:textColor="?android:attr/textColorPrimary"
+        tools:text="Username" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_timestamp"
@@ -44,7 +49,8 @@
         android:layout_marginLeft="16dp"
         android:layout_toLeftOf="@id/tv_comments"
         android:layout_toRightOf="@id/tv_extra"
-        android:textAppearance="@style/TextAppearance.VerySmall" />
+        android:textAppearance="@style/TextAppearance.VerySmall"
+        tools:text="yesterday" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
@@ -56,7 +62,8 @@
         android:layout_toRightOf="@id/iv_gravatar"
         android:ellipsize="end"
         android:maxLines="2"
-        android:textAppearance="@style/TextAppearance.ItemTitle" />
+        android:textAppearance="@style/TextAppearance.ItemTitle"
+        tools:text="Commit title" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_sha"
@@ -66,6 +73,7 @@
         android:layout_below="@id/tv_desc"
         android:layout_toLeftOf="@id/tv_comments"
         android:layout_toRightOf="@id/iv_gravatar"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        tools:text="ad65d46d38d" />
 
 </RelativeLayout>

--- a/res/layout/row_commit.xml
+++ b/res/layout/row_commit.xml
@@ -3,16 +3,16 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?android:attr/listPreferredItemHeight"
     android:background="?attr/selectableItemBackground"
+    android:minHeight="?android:attr/listPreferredItemHeight"
     android:padding="@dimen/content_padding">
 
     <com.gh4a.widget.FixedSizeImageView
         android:id="@+id/iv_gravatar"
         android:layout_width="40dp"
         android:layout_height="40dp"
-        android:layout_marginTop="8dp"
         android:layout_marginRight="16dp"
+        android:layout_marginTop="8dp"
         android:background="?attr/selectableItemBackgroundBorderless" />
 
     <com.gh4a.widget.StyleableTextView
@@ -23,49 +23,49 @@
         android:layout_alignParentRight="true"
         android:drawableLeft="?attr/commentsIcon"
         android:drawablePadding="4dp"
-        android:visibility="gone"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:visibility="gone" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_extra"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?android:attr/textColorPrimary"
+        android:layout_alignParentTop="true"
         android:layout_toRightOf="@id/iv_gravatar"
-        android:layout_alignParentTop="true" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="?android:attr/textColorPrimary" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_timestamp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.VerySmall"
-        android:layout_marginLeft="16dp"
-        android:layout_toRightOf="@id/tv_extra"
         android:layout_alignBaseline="@id/tv_extra"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_marginLeft="16dp"
         android:layout_toLeftOf="@id/tv_comments"
-        android:layout_alignWithParentIfMissing="true" />
+        android:layout_toRightOf="@id/tv_extra"
+        android:textAppearance="@style/TextAppearance.VerySmall" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.ItemTitle"
-        android:maxLines="2"
-        android:ellipsize="end"
-        android:layout_toRightOf="@id/iv_gravatar"
-        android:layout_toLeftOf="@id/tv_comments"
         android:layout_alignWithParentIfMissing="true"
-        android:layout_below="@id/tv_extra" />
+        android:layout_below="@id/tv_extra"
+        android:layout_toLeftOf="@id/tv_comments"
+        android:layout_toRightOf="@id/iv_gravatar"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:textAppearance="@style/TextAppearance.ItemTitle" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_sha"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:layout_toRightOf="@id/iv_gravatar"
-        android:layout_toLeftOf="@id/tv_comments"
+        android:layout_alignWithParentIfMissing="true"
         android:layout_below="@id/tv_desc"
-        android:layout_alignWithParentIfMissing="true" />
+        android:layout_toLeftOf="@id/tv_comments"
+        android:layout_toRightOf="@id/iv_gravatar"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
 
 </RelativeLayout>

--- a/res/layout/row_commit_status.xml
+++ b/res/layout/row_commit_status.xml
@@ -15,16 +15,16 @@
         android:id="@+id/tv_desc"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/iv_status_icon"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-        android:textColor="?android:attr/textColorSecondary"
-        android:layout_toRightOf="@id/iv_status_icon" />
+        android:textColor="?android:attr/textColorSecondary" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_context"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/iv_status_icon"
         android:layout_below="@id/tv_desc"
+        android:layout_toRightOf="@id/iv_status_icon"
         android:textAppearance="@style/TextAppearance.VerySmall" />
 
 </RelativeLayout>

--- a/res/layout/row_commit_status.xml
+++ b/res/layout/row_commit_status.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="4dp">
@@ -9,7 +10,8 @@
         android:id="@+id/iv_status_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginRight="8dp" />
+        android:layout_marginRight="8dp"
+        tools:src="@drawable/commit_status_ok" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
@@ -17,7 +19,8 @@
         android:layout_height="wrap_content"
         android:layout_toRightOf="@id/iv_status_icon"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-        android:textColor="?android:attr/textColorSecondary" />
+        android:textColor="?android:attr/textColorSecondary"
+        tools:text="Commit status" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_context"
@@ -25,6 +28,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@id/tv_desc"
         android:layout_toRightOf="@id/iv_status_icon"
-        android:textAppearance="@style/TextAppearance.VerySmall" />
+        android:textAppearance="@style/TextAppearance.VerySmall"
+        tools:text="context" />
 
 </RelativeLayout>

--- a/res/layout/row_download.xml
+++ b/res/layout/row_download.xml
@@ -4,16 +4,16 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
     android:minHeight="72dp"
     android:orientation="horizontal"
-    android:background="?attr/selectableItemBackground"
     android:padding="@dimen/content_padding">
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:layout_gravity="center_vertical"
+        android:layout_weight="1"
         android:orientation="vertical">
 
         <com.gh4a.widget.StyleableTextView
@@ -26,8 +26,8 @@
             android:id="@+id/tv_desc"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:maxLines="2" />
+            android:maxLines="2"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_created_at"

--- a/res/layout/row_download.xml
+++ b/res/layout/row_download.xml
@@ -2,6 +2,7 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -20,20 +21,23 @@
             android:id="@+id/tv_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.ItemTitle" />
+            android:textAppearance="@style/TextAppearance.ItemTitle"
+            tools:text="filename" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_desc"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:maxLines="2"
-            android:textAppearance="?android:attr/textAppearanceSmall" />
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            tools:text="Description" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_created_at"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="Created yesterday" />
 
     </LinearLayout>
 
@@ -50,7 +54,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="?attr/sizeSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="4.75 MB" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_downloads"
@@ -59,7 +64,8 @@
             android:layout_marginTop="2dp"
             android:drawableLeft="?attr/downloadSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="34" />
 
     </LinearLayout>
 

--- a/res/layout/row_event.xml
+++ b/res/layout/row_event.xml
@@ -7,18 +7,18 @@
     android:layout_height="wrap_content">
 
     <android.support.v7.widget.CardView
+        style="?attr/cardViewTheme"
         android:layout_marginLeft="0dp"
         android:layout_marginRight="0dp"
-        app:cardCornerRadius="0dp"
-        style="?attr/cardViewTheme">
+        app:cardCornerRadius="0dp">
 
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:paddingBottom="16dp"
             android:paddingLeft="@dimen/content_padding"
             android:paddingRight="@dimen/content_padding"
-            android:paddingTop="8dp"
-            android:paddingBottom="16dp">
+            android:paddingTop="8dp">
 
             <com.gh4a.widget.FixedSizeImageView
                 android:id="@+id/iv_gravatar"
@@ -31,9 +31,9 @@
                 android:id="@+id/tv_actor"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_toRightOf="@id/iv_gravatar"
-                android:layout_alignTop="@id/iv_gravatar"
                 android:layout_alignBottom="@id/iv_gravatar"
+                android:layout_alignTop="@id/iv_gravatar"
+                android:layout_toRightOf="@id/iv_gravatar"
                 android:gravity="center_vertical"
                 android:singleLine="true"
                 android:textAppearance="@style/TextAppearance.AppCompat.Body1"
@@ -43,9 +43,9 @@
                 android:id="@+id/tv_created_at"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_toRightOf="@id/tv_actor"
-                android:layout_alignParentRight="true"
                 android:layout_alignBaseline="@id/tv_actor"
+                android:layout_alignParentRight="true"
+                android:layout_toRightOf="@id/tv_actor"
                 android:gravity="right"
                 android:singleLine="true"
                 android:textAppearance="@style/TextAppearance.VerySmall" />
@@ -55,8 +55,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/iv_gravatar"
-                android:layout_marginTop="8dp"
                 android:layout_marginBottom="8dp"
+                android:layout_marginTop="8dp"
                 android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
 
             <com.gh4a.widget.StyleableTextView

--- a/res/layout/row_event.xml
+++ b/res/layout/row_event.xml
@@ -3,6 +3,7 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -25,7 +26,8 @@
                 android:layout_width="30dp"
                 android:layout_height="30dp"
                 android:layout_marginRight="8dp"
-                android:background="?attr/selectableItemBackgroundBorderless" />
+                android:background="?attr/selectableItemBackgroundBorderless"
+                tools:src="@drawable/default_avatar" />
 
             <com.gh4a.widget.StyleableTextView
                 android:id="@+id/tv_actor"
@@ -37,7 +39,8 @@
                 android:gravity="center_vertical"
                 android:singleLine="true"
                 android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-                app:font="bold" />
+                app:font="bold"
+                tools:text="username" />
 
             <com.gh4a.widget.StyleableTextView
                 android:id="@+id/tv_created_at"
@@ -48,7 +51,8 @@
                 android:layout_toRightOf="@id/tv_actor"
                 android:gravity="right"
                 android:singleLine="true"
-                android:textAppearance="@style/TextAppearance.VerySmall" />
+                android:textAppearance="@style/TextAppearance.VerySmall"
+                tools:text="yesterday" />
 
             <com.gh4a.widget.StyleableTextView
                 android:id="@+id/tv_title"
@@ -57,7 +61,8 @@
                 android:layout_below="@id/iv_gravatar"
                 android:layout_marginBottom="8dp"
                 android:layout_marginTop="8dp"
-                android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                tools:text="Event title" />
 
             <com.gh4a.widget.StyleableTextView
                 android:id="@+id/tv_desc"
@@ -66,7 +71,8 @@
                 android:layout_below="@id/tv_title"
                 android:ellipsize="end"
                 android:maxLines="@integer/event_description_max_lines"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                tools:text="Event description" />
 
         </RelativeLayout>
 

--- a/res/layout/row_feed.xml
+++ b/res/layout/row_feed.xml
@@ -2,6 +2,7 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -14,7 +15,8 @@
         android:layout_height="40dp"
         android:layout_marginRight="16dp"
         android:layout_marginTop="8dp"
-        android:background="?attr/selectableItemBackgroundBorderless" />
+        android:background="?attr/selectableItemBackgroundBorderless"
+        tools:src="@drawable/default_avatar" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_extra"
@@ -23,7 +25,8 @@
         android:layout_alignParentTop="true"
         android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?android:attr/textColorPrimary" />
+        android:textColor="?android:attr/textColorPrimary"
+        tools:text="username" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_timestamp"
@@ -32,7 +35,8 @@
         android:layout_alignBaseline="@id/tv_extra"
         android:layout_marginLeft="16dp"
         android:layout_toRightOf="@id/tv_extra"
-        android:textAppearance="@style/TextAppearance.VerySmall" />
+        android:textAppearance="@style/TextAppearance.VerySmall"
+        tools:text="yesterday" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
@@ -42,7 +46,8 @@
         android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="@style/TextAppearance.ItemTitle"
         android:textSize="16sp"
-        app:font="boldCondensed" />
+        app:font="boldCondensed"
+        tools:text="Feed item title" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
@@ -52,6 +57,7 @@
         android:layout_toRightOf="@id/iv_gravatar"
         android:ellipsize="end"
         android:maxLines="2"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        tools:text="Feed item description" />
 
 </RelativeLayout>

--- a/res/layout/row_feed.xml
+++ b/res/layout/row_feed.xml
@@ -4,16 +4,16 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?attr/listPreferredItemHeight"
     android:background="?attr/selectableItemBackground"
+    android:minHeight="?attr/listPreferredItemHeight"
     android:padding="@dimen/content_padding">
 
     <com.gh4a.widget.FixedSizeImageView
         android:id="@+id/iv_gravatar"
         android:layout_width="40dp"
         android:layout_height="40dp"
-        android:layout_marginTop="8dp"
         android:layout_marginRight="16dp"
+        android:layout_marginTop="8dp"
         android:background="?attr/selectableItemBackgroundBorderless" />
 
     <com.gh4a.widget.StyleableTextView
@@ -29,29 +29,29 @@
         android:id="@+id/tv_timestamp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/tv_extra"
         android:layout_alignBaseline="@id/tv_extra"
         android:layout_marginLeft="16dp"
+        android:layout_toRightOf="@id/tv_extra"
         android:textAppearance="@style/TextAppearance.VerySmall" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/iv_gravatar"
         android:layout_below="@id/tv_extra"
+        android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="@style/TextAppearance.ItemTitle"
-        app:font="boldCondensed"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        app:font="boldCondensed" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/iv_gravatar"
         android:layout_below="@id/tv_title"
-        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:layout_toRightOf="@id/iv_gravatar"
+        android:ellipsize="end"
         android:maxLines="2"
-        android:ellipsize="end" />
+        android:textAppearance="?android:attr/textAppearanceSmall" />
 
 </RelativeLayout>

--- a/res/layout/row_file_manager.xml
+++ b/res/layout/row_file_manager.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -16,7 +17,8 @@
         android:id="@+id/iv_icon"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_marginRight="16dp" />
+        android:layout_marginRight="16dp"
+        tools:src="@drawable/file" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_text"
@@ -24,7 +26,8 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:textAppearance="?android:attr/textAppearanceMedium"
-        android:textColor="?android:attr/textColorPrimary" />
+        android:textColor="?android:attr/textColorPrimary"
+        tools:text="filename.txt" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_size"
@@ -32,6 +35,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:layout_marginLeft="4dp"
-        android:textAppearance="@style/TextAppearance.VerySmall" />
+        android:textAppearance="@style/TextAppearance.VerySmall"
+        tools:text="2.5 KB" />
 
 </LinearLayout>

--- a/res/layout/row_file_manager.xml
+++ b/res/layout/row_file_manager.xml
@@ -3,20 +3,21 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingLeft="@dimen/content_padding"
-    android:paddingRight="@dimen/content_padding"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp"
+    android:background="?attr/selectableItemBackground"
+    android:gravity="center_vertical"
     android:minHeight="48dp"
     android:orientation="horizontal"
-    android:background="?attr/selectableItemBackground"
-    android:gravity="center_vertical">
+    android:paddingBottom="8dp"
+    android:paddingLeft="@dimen/content_padding"
+    android:paddingRight="@dimen/content_padding"
+    android:paddingTop="8dp">
 
     <ImageView
         android:id="@+id/iv_icon"
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_marginRight="16dp" />
+
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_text"
         android:layout_width="0dp"
@@ -24,12 +25,13 @@
         android:layout_weight="1"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="?android:attr/textColorPrimary" />
+
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_size"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="4dp"
         android:layout_gravity="bottom"
+        android:layout_marginLeft="4dp"
         android:textAppearance="@style/TextAppearance.VerySmall" />
 
 </LinearLayout>

--- a/res/layout/row_gist.xml
+++ b/res/layout/row_gist.xml
@@ -3,8 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="72dp"
     android:background="?attr/selectableItemBackground"
+    android:minHeight="72dp"
     android:padding="@dimen/content_padding">
 
     <LinearLayout
@@ -51,28 +51,28 @@
         android:id="@+id/tv_timestamp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toLeftOf="@id/info"
-        android:layout_toRightOf="@id/tv_creator"
         android:layout_alignBaseline="@id/tv_creator"
         android:layout_alignWithParentIfMissing="true"
+        android:layout_toLeftOf="@id/info"
+        android:layout_toRightOf="@id/tv_creator"
         android:textAppearance="@style/TextAppearance.VerySmall" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toLeftOf="@id/info"
         android:layout_alignParentLeft="true"
         android:layout_below="@id/tv_timestamp"
+        android:layout_toLeftOf="@id/info"
         android:textAppearance="@style/TextAppearance.ItemTitle" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_sha"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toLeftOf="@id/info"
         android:layout_alignParentLeft="true"
         android:layout_below="@id/tv_title"
+        android:layout_toLeftOf="@id/info"
         android:textAppearance="?android:attr/textAppearanceSmall" />
 
 </RelativeLayout>

--- a/res/layout/row_gist.xml
+++ b/res/layout/row_gist.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -25,7 +26,8 @@
             android:drawablePadding="4dp"
             android:text="@string/repo_type_private"
             android:textAppearance="@style/TextAppearance.VerySmall.Bold"
-            android:visibility="gone" />
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_files"
@@ -33,7 +35,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="?attr/filesSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="2" />
 
     </LinearLayout>
 
@@ -45,7 +48,9 @@
         android:layout_marginRight="16dp"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorPrimary"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:text="Creator"
+        tools:visibility="visible" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_timestamp"
@@ -55,7 +60,8 @@
         android:layout_alignWithParentIfMissing="true"
         android:layout_toLeftOf="@id/info"
         android:layout_toRightOf="@id/tv_creator"
-        android:textAppearance="@style/TextAppearance.VerySmall" />
+        android:textAppearance="@style/TextAppearance.VerySmall"
+        tools:text="yesterday" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
@@ -64,7 +70,8 @@
         android:layout_alignParentLeft="true"
         android:layout_below="@id/tv_timestamp"
         android:layout_toLeftOf="@id/info"
-        android:textAppearance="@style/TextAppearance.ItemTitle" />
+        android:textAppearance="@style/TextAppearance.ItemTitle"
+        tools:text="Gist title" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_sha"
@@ -73,6 +80,7 @@
         android:layout_alignParentLeft="true"
         android:layout_below="@id/tv_title"
         android:layout_toLeftOf="@id/info"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        tools:text="da7b7aa36a89" />
 
 </RelativeLayout>

--- a/res/layout/row_gravatar_comment.xml
+++ b/res/layout/row_gravatar_comment.xml
@@ -27,7 +27,8 @@
             android:layout_height="16dp"
             android:layout_gravity="end|bottom"
             android:visibility="gone"
-            tools:src="@drawable/issue_event_closed" />
+            tools:src="@drawable/issue_event_closed"
+            tools:visibility="visible" />
     </FrameLayout>
 
     <ImageView
@@ -48,7 +49,7 @@
         android:layout_toRightOf="@id/fl_avatar_container"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorPrimary"
-        tools:text="octopus" />
+        tools:text="username" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_timestamp"
@@ -71,7 +72,9 @@
         android:layout_toLeftOf="@id/iv_edit"
         android:layout_toRightOf="@id/fl_avatar_container"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:text="Comment on filename.txt"
+        tools:visibility="visible" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"

--- a/res/layout/row_gravatar_comment.xml
+++ b/res/layout/row_gravatar_comment.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?attr/listPreferredItemHeight"
     android:clipToPadding="false"
+    android:minHeight="?attr/listPreferredItemHeight"
     android:padding="@dimen/content_padding">
 
     <FrameLayout
@@ -32,59 +32,59 @@
 
     <ImageView
         android:id="@+id/iv_edit"
+        style="@style/SelectableBorderlessItem"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_marginRight="-8dp"
         android:layout_alignParentRight="true"
+        android:layout_marginRight="-8dp"
         android:src="?attr/contentEditIcon"
-        style="@style/SelectableBorderlessItem"
         tools:src="@drawable/content_edit" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_extra"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_toRightOf="@id/fl_avatar_container"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorPrimary"
-        android:layout_toRightOf="@id/fl_avatar_container"
-        android:layout_alignParentTop="true"
         tools:text="octopus" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_timestamp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.VerySmall"
-        android:layout_marginLeft="16dp"
-        android:layout_toRightOf="@id/tv_extra"
-        android:layout_toLeftOf="@id/iv_edit"
         android:layout_alignBaseline="@id/tv_extra"
         android:layout_alignWithParentIfMissing="true"
+        android:layout_marginLeft="16dp"
+        android:layout_toLeftOf="@id/iv_edit"
+        android:layout_toRightOf="@id/tv_extra"
+        android:textAppearance="@style/TextAppearance.VerySmall"
         tools:text="5 days ago" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_file"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:layout_below="@id/tv_extra"
-        android:layout_toRightOf="@id/fl_avatar_container"
-        android:layout_toLeftOf="@id/iv_edit"
         android:layout_alignWithParentIfMissing="true"
+        android:layout_below="@id/tv_extra"
+        android:layout_toLeftOf="@id/iv_edit"
+        android:layout_toRightOf="@id/fl_avatar_container"
+        android:textAppearance="?android:attr/textAppearanceSmall"
         android:visibility="gone" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_below="@id/tv_file"
+        android:layout_marginTop="2dp"
+        android:layout_toLeftOf="@id/iv_edit"
+        android:layout_toRightOf="@id/fl_avatar_container"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorPrimary"
         android:textIsSelectable="true"
-        android:layout_marginTop="2dp"
-        android:layout_below="@id/tv_file"
-        android:layout_toLeftOf="@id/iv_edit"
-        android:layout_toRightOf="@id/fl_avatar_container"
-        android:layout_alignWithParentIfMissing="true"
         tools:text="Comment text" />
 
 </RelativeLayout>

--- a/res/layout/row_gravatar_twoline.xml
+++ b/res/layout/row_gravatar_twoline.xml
@@ -4,8 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?android:attr/listPreferredItemHeight"
     android:background="?attr/selectableItemBackground"
+    android:minHeight="?android:attr/listPreferredItemHeight"
     android:padding="@dimen/content_padding">
 
     <com.gh4a.widget.FixedSizeImageView
@@ -20,17 +20,17 @@
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.ItemTitle"
-        app:font="boldCondensed"
+        android:layout_alignParentTop="true"
         android:layout_toRightOf="@id/iv_gravatar"
-        android:layout_alignParentTop="true" />
+        android:textAppearance="@style/TextAppearance.ItemTitle"
+        app:font="boldCondensed" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_extra"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/iv_gravatar"
         android:layout_below="@id/tv_title"
+        android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="@style/TextAppearance.VerySmall"
         app:font="italic" />
 

--- a/res/layout/row_gravatar_twoline.xml
+++ b/res/layout/row_gravatar_twoline.xml
@@ -2,6 +2,7 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -14,7 +15,8 @@
         android:layout_height="40dp"
         android:layout_centerVertical="true"
         android:layout_marginRight="16dp"
-        android:background="?attr/selectableItemBackgroundBorderless" />
+        android:background="?attr/selectableItemBackgroundBorderless"
+        tools:src="@drawable/default_avatar" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
@@ -23,7 +25,8 @@
         android:layout_alignParentTop="true"
         android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="@style/TextAppearance.ItemTitle"
-        app:font="boldCondensed" />
+        app:font="boldCondensed"
+        tools:text="Username" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_extra"
@@ -32,6 +35,7 @@
         android:layout_below="@id/tv_title"
         android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="@style/TextAppearance.VerySmall"
-        app:font="italic" />
+        app:font="italic"
+        tools:text="Extra text" />
 
 </RelativeLayout>

--- a/res/layout/row_issue.xml
+++ b/res/layout/row_issue.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?attr/listPreferredItemHeightLarge"
     android:background="?attr/selectableItemBackground"
+    android:minHeight="?attr/listPreferredItemHeightLarge"
     android:padding="@dimen/content_padding">
 
     <LinearLayout
@@ -22,15 +22,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="4dp"
-            android:maxWidth="80dp"
-            android:singleLine="true"
-            android:ellipsize="end"
             android:drawableLeft="?attr/milestoneSmallIcon"
             android:drawablePadding="4dp"
+            android:ellipsize="end"
+            android:maxWidth="80dp"
+            android:singleLine="true"
             android:textAppearance="@style/TextAppearance.VerySmall"
             android:visibility="gone"
-            tools:visibility="visible"
-            tools:text="v2.10.3" />
+            tools:text="v2.10.3"
+            tools:visibility="visible" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_comments"
@@ -56,8 +56,8 @@
         android:id="@+id/labels"
         android:layout_width="40dp"
         android:layout_height="wrap_content"
-        android:layout_below="@id/iv_gravatar"
         android:layout_alignParentBottom="true"
+        android:layout_below="@id/iv_gravatar"
         android:layout_gravity="bottom"
         android:layout_marginTop="8dp" />
 
@@ -65,18 +65,18 @@
         android:id="@+id/tv_creator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?android:attr/textColorPrimary"
-        android:layout_toRightOf="@id/iv_gravatar"
         tools:text="IssueCreatorUsername" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_timestamp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/tv_creator"
         android:layout_alignBaseline="@id/tv_creator"
         android:layout_marginLeft="16dp"
+        android:layout_toRightOf="@id/tv_creator"
         android:textAppearance="@style/TextAppearance.VerySmall"
         tools:text="yesterday" />
 
@@ -84,22 +84,22 @@
         android:id="@+id/tv_desc"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.ItemTitle"
-        android:layout_toRightOf="@id/iv_gravatar"
         android:layout_below="@id/tv_creator"
         android:layout_toLeftOf="@id/info"
-        android:maxLines="2"
+        android:layout_toRightOf="@id/iv_gravatar"
         android:ellipsize="end"
+        android:maxLines="2"
+        android:textAppearance="@style/TextAppearance.ItemTitle"
         tools:text="Long issue title that is supposed to wrap in the layout preview." />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_number"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/iv_gravatar"
         android:layout_below="@id/tv_desc"
         android:layout_toLeftOf="@id/info"
+        android:layout_toRightOf="@id/iv_gravatar"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        tools:text="#999 on LongUsername/LongRepositoryName"/>
+        tools:text="#999 on LongUsername/LongRepositoryName" />
 
 </RelativeLayout>

--- a/res/layout/row_issue_create_label.xml
+++ b/res/layout/row_issue_create_label.xml
@@ -3,11 +3,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="5dp"
-    android:paddingBottom="5dp">
+    android:orientation="horizontal"
+    android:paddingBottom="5dp"
+    android:paddingTop="5dp">
 
     <View
         android:id="@+id/view_color"
@@ -19,11 +19,11 @@
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingLeft="8dp"
-        android:paddingTop="5dp"
-        android:paddingBottom="5dp"
-        android:paddingRight="8dp"
         android:foreground="?attr/selectableItemBackground"
+        android:paddingBottom="5dp"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp"
+        android:paddingTop="5dp"
         android:textAppearance="?android:attr/textAppearanceMedium"
         app:font="condensed"
         tools:text="Label title" />

--- a/res/layout/row_issue_label.xml
+++ b/res/layout/row_issue_label.xml
@@ -22,8 +22,8 @@
             android:id="@+id/tv_title"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             android:layout_marginLeft="16dp"
+            android:layout_weight="1"
             android:gravity="center_vertical"
             android:textAppearance="@style/TextAppearance.ItemTitle" />
 
@@ -55,72 +55,80 @@
                 android:layout_height="40dp"
                 android:layout_marginRight="6dp"
                 android:layout_weight="1"
-                android:tag="dddddd"
+                android:background="#dddddd"
                 android:foreground="?attr/selectableItemBackground"
-                android:background="#dddddd" />
+                android:tag="dddddd" />
+
             <View
                 android:layout_width="0dp"
                 android:layout_height="40dp"
                 android:layout_marginRight="6dp"
                 android:layout_weight="1"
-                android:tag="444444"
+                android:background="#444444"
                 android:foreground="?attr/selectableItemBackground"
-                android:background="#444444" />
+                android:tag="444444" />
+
             <View
                 android:layout_width="0dp"
                 android:layout_height="40dp"
                 android:layout_marginRight="6dp"
                 android:layout_weight="1"
-                android:tag="e10c02"
+                android:background="#e10c02"
                 android:foreground="?attr/selectableItemBackground"
-                android:background="#e10c02" />
+                android:tag="e10c02" />
+
             <View
                 android:layout_width="0dp"
                 android:layout_height="40dp"
                 android:layout_marginRight="6dp"
                 android:layout_weight="1"
-                android:tag="d7e102"
+                android:background="#d7e102"
                 android:foreground="?attr/selectableItemBackground"
-                android:background="#d7e102" />
+                android:tag="d7e102" />
+
             <View
                 android:layout_width="0dp"
                 android:layout_height="40dp"
                 android:layout_marginRight="6dp"
                 android:layout_weight="1"
-                android:tag="02e10c"
+                android:background="#02e10c"
                 android:foreground="?attr/selectableItemBackground"
-                android:background="#02e10c" />
+                android:tag="02e10c" />
+
             <View
                 android:layout_width="0dp"
                 android:layout_height="40dp"
                 android:layout_marginRight="6dp"
                 android:layout_weight="1"
-                android:tag="02d7e1"
+                android:background="#02d7e1"
                 android:foreground="?attr/selectableItemBackground"
-                android:background="#02d7e1" />
+                android:tag="02d7e1" />
+
             <View
                 android:layout_width="0dp"
                 android:layout_height="40dp"
                 android:layout_marginRight="6dp"
                 android:layout_weight="1"
-                android:tag="0b02e1"
+                android:background="#0b02e1"
                 android:foreground="?attr/selectableItemBackground"
-                android:background="#0b02e1" />
+                android:tag="0b02e1" />
+
             <View
                 android:layout_width="0dp"
                 android:layout_height="40dp"
                 android:layout_marginRight="6dp"
                 android:layout_weight="1"
-                android:tag="e102d8"
+                android:background="#e102d8"
                 android:foreground="?attr/selectableItemBackground"
-                android:background="#e102d8" />
+                android:tag="e102d8" />
+
             <com.gh4a.widget.StyleableTextView
                 android:id="@+id/custom"
                 android:layout_width="wrap_content"
                 android:layout_height="40dp"
                 android:layout_weight="1"
-                android:gravity="center"
                 android:foreground="?attr/selectableItemBackground"
+                android:gravity="center"
                 android:text="@string/ellipse" />
 
         </LinearLayout>

--- a/res/layout/row_milestone.xml
+++ b/res/layout/row_milestone.xml
@@ -3,17 +3,17 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?attr/listPreferredItemHeight"
-    android:padding="@dimen/content_padding"
-    android:gravity="center_vertical"
     android:background="?attr/selectableItemBackground"
-    android:orientation="horizontal">
+    android:gravity="center_vertical"
+    android:minHeight="?attr/listPreferredItemHeight"
+    android:orientation="horizontal"
+    android:padding="@dimen/content_padding">
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:layout_gravity="center_vertical"
+        android:layout_weight="1"
         android:orientation="vertical">
 
         <com.gh4a.widget.StyleableTextView
@@ -26,17 +26,17 @@
             android:id="@+id/tv_desc"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:ellipsize="end"
             android:maxLines="2"
-            android:ellipsize="end" />
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="8dp"
         android:layout_gravity="center_vertical"
+        android:layout_marginLeft="8dp"
         android:orientation="vertical">
 
         <com.gh4a.widget.StyleableTextView

--- a/res/layout/row_milestone.xml
+++ b/res/layout/row_milestone.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -20,7 +21,8 @@
             android:id="@+id/tv_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.ItemTitle" />
+            android:textAppearance="@style/TextAppearance.ItemTitle"
+            tools:text="Milestone title" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_desc"
@@ -28,7 +30,8 @@
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:maxLines="2"
-            android:textAppearance="?android:attr/textAppearanceSmall" />
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            tools:text="Description" />
 
     </LinearLayout>
 
@@ -44,14 +47,16 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="@style/TextAppearance.VerySmall"
-            android:textColor="?attr/colorCommitAddition" />
+            android:textColor="?attr/colorCommitAddition"
+            tools:text="3 open" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_closed"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="@style/TextAppearance.VerySmall"
-            android:textColor="?attr/colorCommitDeletion" />
+            android:textColor="?attr/colorCommitDeletion"
+            tools:text="3 closed" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_due"
@@ -59,7 +64,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="?attr/dueSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="in 2 days" />
 
     </LinearLayout>
 

--- a/res/layout/row_release.xml
+++ b/res/layout/row_release.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -13,19 +14,22 @@
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.ItemTitle" />
+        android:textAppearance="@style/TextAppearance.ItemTitle"
+        tools:text="Release title" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_type"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        tools:text="Release type" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_created_at"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.VerySmall" />
+        android:textAppearance="@style/TextAppearance.VerySmall"
+        tools:text="Created yesterday" />
 
 </LinearLayout>

--- a/res/layout/row_release.xml
+++ b/res/layout/row_release.xml
@@ -3,11 +3,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?android:attr/listPreferredItemHeight"
-    android:gravity="center_vertical"
-    android:padding="@dimen/content_padding"
     android:background="?attr/selectableItemBackground"
-    android:orientation="vertical">
+    android:gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="vertical"
+    android:padding="@dimen/content_padding">
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"

--- a/res/layout/row_repo.xml
+++ b/res/layout/row_repo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -12,7 +13,8 @@
         android:id="@+id/tv_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.ItemTitle" />
+        android:textAppearance="@style/TextAppearance.ItemTitle"
+        tools:text="User/Repository" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
@@ -21,7 +23,8 @@
         android:layout_marginTop="2dp"
         android:ellipsize="end"
         android:maxLines="2"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        tools:text="Short repository description" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -38,7 +41,8 @@
             android:drawablePadding="4dp"
             android:text="@string/repo_type_private"
             android:textAppearance="@style/TextAppearance.VerySmall.Bold"
-            android:visibility="gone" />
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_language"
@@ -46,7 +50,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="?attr/languageSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="Language" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_forks"
@@ -55,7 +60,8 @@
             android:layout_marginLeft="16dp"
             android:drawableLeft="?attr/forkSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="0" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_stars"
@@ -64,7 +70,8 @@
             android:layout_marginLeft="16dp"
             android:drawableLeft="?attr/starSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="0" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_size"
@@ -73,7 +80,8 @@
             android:layout_marginLeft="16dp"
             android:drawableLeft="?attr/sizeSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="0" />
 
     </LinearLayout>
 

--- a/res/layout/row_repo.xml
+++ b/res/layout/row_repo.xml
@@ -3,10 +3,10 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="72dp"
-    android:padding="@dimen/content_padding"
     android:background="?attr/selectableItemBackground"
-    android:orientation="vertical">
+    android:minHeight="72dp"
+    android:orientation="vertical"
+    android:padding="@dimen/content_padding">
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
@@ -19,9 +19,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
-        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:ellipsize="end"
         android:maxLines="2"
-        android:ellipsize="end" />
+        android:textAppearance="?android:attr/textAppearanceSmall" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -44,8 +44,8 @@
             android:id="@+id/tv_language"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:drawablePadding="4dp"
             android:drawableLeft="?attr/languageSmallIcon"
+            android:drawablePadding="4dp"
             android:textAppearance="@style/TextAppearance.VerySmall" />
 
         <com.gh4a.widget.StyleableTextView
@@ -53,8 +53,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="16dp"
-            android:drawablePadding="4dp"
             android:drawableLeft="?attr/forkSmallIcon"
+            android:drawablePadding="4dp"
             android:textAppearance="@style/TextAppearance.VerySmall" />
 
         <com.gh4a.widget.StyleableTextView
@@ -62,8 +62,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="16dp"
-            android:drawablePadding="4dp"
             android:drawableLeft="?attr/starSmallIcon"
+            android:drawablePadding="4dp"
             android:textAppearance="@style/TextAppearance.VerySmall" />
 
         <com.gh4a.widget.StyleableTextView
@@ -71,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="16dp"
-            android:drawablePadding="4dp"
             android:drawableLeft="?attr/sizeSmallIcon"
+            android:drawablePadding="4dp"
             android:textAppearance="@style/TextAppearance.VerySmall" />
 
     </LinearLayout>

--- a/res/layout/row_trend.xml
+++ b/res/layout/row_trend.xml
@@ -2,6 +2,7 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -13,7 +14,8 @@
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.ItemTitle" />
+        android:textAppearance="@style/TextAppearance.ItemTitle"
+        tools:text="username/repository" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
@@ -21,7 +23,8 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
         android:maxLines="2"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        tools:text="Repository description" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -36,7 +39,8 @@
             android:layout_marginRight="16dp"
             android:drawableLeft="?attr/forkSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="2" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_stars"
@@ -44,7 +48,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="?attr/starSmallIcon"
             android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="3468" />
 
     </LinearLayout>
 

--- a/res/layout/row_trend.xml
+++ b/res/layout/row_trend.xml
@@ -4,10 +4,10 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="72dp"
-    android:padding="@dimen/content_padding"
     android:background="?attr/selectableItemBackground"
-    android:orientation="vertical">
+    android:minHeight="72dp"
+    android:orientation="vertical"
+    android:padding="@dimen/content_padding">
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
@@ -20,8 +20,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:maxLines="2" />
+        android:maxLines="2"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/res/layout/row_user.xml
+++ b/res/layout/row_user.xml
@@ -4,11 +4,11 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="?android:attr/listPreferredItemHeight"
-    android:paddingLeft="@dimen/content_padding"
-    android:paddingRight="@dimen/content_padding"
     android:background="?attr/selectableItemBackground"
-    android:orientation="horizontal">
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="horizontal"
+    android:paddingLeft="@dimen/content_padding"
+    android:paddingRight="@dimen/content_padding">
 
     <com.gh4a.widget.FixedSizeImageView
         android:id="@+id/iv_gravatar"
@@ -22,9 +22,9 @@
         android:id="@+id/tv_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
         android:layout_weight="1"
         android:textAppearance="@style/TextAppearance.ItemTitle"
-        app:font="boldCondensed"
-        android:layout_gravity="center_vertical" />
+        app:font="boldCondensed" />
 
 </LinearLayout>

--- a/res/layout/row_user.xml
+++ b/res/layout/row_user.xml
@@ -2,6 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -13,6 +14,7 @@
     <com.gh4a.widget.FixedSizeImageView
         android:id="@+id/iv_gravatar"
         android:layout_width="40dp"
+        tools:src="@drawable/default_avatar"
         android:layout_height="40dp"
         android:layout_gravity="center_vertical"
         android:layout_marginRight="16dp"
@@ -22,6 +24,7 @@
         android:id="@+id/tv_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        tools:text="Username"
         android:layout_gravity="center_vertical"
         android:layout_weight="1"
         android:textAppearance="@style/TextAppearance.ItemTitle"

--- a/res/layout/search_action_bar.xml
+++ b/res/layout/search_action_bar.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dimensions are set at runtime in ActionBarAdapter -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content">
 
     <Spinner
         android:id="@+id/search_type"
@@ -16,7 +17,7 @@
         android:layout_width="0dip"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        app:iconifiedByDefault="false"
-        android:inputType="textFilter" />
+        android:inputType="textFilter"
+        app:iconifiedByDefault="false" />
 
 </LinearLayout>

--- a/res/layout/search_type_popup.xml
+++ b/res/layout/search_type_popup.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="?attr/dropdownListPreferredItemHeight"
     android:orientation="horizontal"
@@ -9,7 +10,8 @@
     <ImageView
         android:id="@+id/icon"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:src="@drawable/icon_repositories" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/label"
@@ -18,6 +20,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:ellipsize="marquee"
-        android:singleLine="true" />
+        android:singleLine="true"
+        tools:text="Sort type" />
 
 </LinearLayout>

--- a/res/layout/search_type_popup.xml
+++ b/res/layout/search_type_popup.xml
@@ -3,8 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="?attr/dropdownListPreferredItemHeight"
-    android:padding="8dip"
-    android:orientation="horizontal" >
+    android:orientation="horizontal"
+    android:padding="8dip">
 
     <ImageView
         android:id="@+id/icon"
@@ -13,11 +13,11 @@
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/label"
+        style="?android:attr/spinnerDropDownItemStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:singleLine="true"
         android:ellipsize="marquee"
-        style="?android:attr/spinnerDropDownItemStyle" />
+        android:singleLine="true" />
 
 </LinearLayout>

--- a/res/layout/search_type_small.xml
+++ b/res/layout/search_type_small.xml
@@ -4,5 +4,5 @@
     android:id="@+id/icon"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:gravity="center" >
+    android:gravity="center">
 </ImageView>

--- a/res/layout/search_type_small.xml
+++ b/res/layout/search_type_small.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/icon"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:gravity="center">
-</ImageView>
+    android:gravity="center"
+    tools:src="@drawable/icon_repositories" />

--- a/res/layout/selectable_label.xml
+++ b/res/layout/selectable_label.xml
@@ -2,10 +2,10 @@
 <com.gh4a.widget.StyleableTextView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/tv_title"
+    style="@style/SelectableLabel"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    style="@style/SelectableLabel"
+    android:paddingBottom="8dp"
     android:paddingLeft="@dimen/content_padding"
     android:paddingRight="@dimen/content_padding"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp" />
+    android:paddingTop="8dp" />

--- a/res/layout/selectable_label_with_avatar.xml
+++ b/res/layout/selectable_label_with_avatar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/SelectableItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -16,7 +17,8 @@
         android:layout_height="24dp"
         android:layout_gravity="center_vertical"
         android:layout_marginRight="16dp"
-        android:background="?attr/selectableItemBackgroundBorderless" />
+        android:background="?attr/selectableItemBackgroundBorderless"
+        tools:src="@drawable/default_avatar" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
@@ -24,6 +26,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:layout_weight="1"
-        android:textAppearance="@style/TextAppearance.ItemTitle" />
+        android:textAppearance="@style/TextAppearance.ItemTitle"
+        tools:text="title" />
 
 </LinearLayout>

--- a/res/layout/selectable_label_with_avatar.xml
+++ b/res/layout/selectable_label_with_avatar.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/SelectableItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
+    android:paddingBottom="8dp"
     android:paddingLeft="@dimen/content_padding"
     android:paddingRight="@dimen/content_padding"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp"
-    style="@style/SelectableItem">
+    android:paddingTop="8dp">
 
     <com.gh4a.widget.FixedSizeImageView
         android:id="@+id/iv_gravatar"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_marginRight="16dp"
         android:layout_gravity="center_vertical"
+        android:layout_marginRight="16dp"
         android:background="?attr/selectableItemBackgroundBorderless" />
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:layout_gravity="center_vertical"
+        android:layout_weight="1"
         android:textAppearance="@style/TextAppearance.ItemTitle" />
 
 </LinearLayout>

--- a/res/layout/tab_bar.xml
+++ b/res/layout/tab_bar.xml
@@ -5,9 +5,9 @@
     android:id="@+id/tabs"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    app:tabMode="scrollable"
     app:tabGravity="fill"
+    app:tabIndicatorColor="@color/tab_indicator_color"
     app:tabMaxWidth="-1dp"
-    app:tabTextColor="@color/tab_text_color"
+    app:tabMode="scrollable"
     app:tabSelectedTextColor="@color/tab_indicator_color"
-    app:tabIndicatorColor="@color/tab_indicator_color" />
+    app:tabTextColor="@color/tab_text_color" />

--- a/res/layout/top_repo.xml
+++ b/res/layout/top_repo.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/SelectableItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="72dp"
-    android:paddingTop="6dp"
+    android:orientation="horizontal"
     android:paddingBottom="6dp"
     android:paddingLeft="@dimen/content_padding"
     android:paddingRight="@dimen/content_padding"
-    android:orientation="horizontal"
-    style="@style/SelectableItem">
+    android:paddingTop="6dp">
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:layout_gravity="center_vertical"
+        android:layout_weight="1"
         android:orientation="vertical">
 
         <com.gh4a.widget.StyleableTextView
@@ -28,34 +28,35 @@
             android:id="@+id/tv_desc"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:ellipsize="end"
             android:maxLines="2"
-            android:ellipsize="end" />
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="8dp"
         android:layout_gravity="center_vertical"
+        android:layout_marginLeft="8dp"
         android:orientation="vertical">
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_forks"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:drawablePadding="4dp"
             android:drawableLeft="?attr/forkSmallIcon"
+            android:drawablePadding="4dp"
             android:gravity="right"
             android:textAppearance="@style/TextAppearance.VerySmall" />
+
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_stars"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="2dp"
-            android:drawablePadding="4dp"
             android:drawableLeft="?attr/starSmallIcon"
+            android:drawablePadding="4dp"
             android:gravity="right"
             android:textAppearance="@style/TextAppearance.VerySmall" />
 

--- a/res/layout/top_repo.xml
+++ b/res/layout/top_repo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/SelectableItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -22,7 +23,8 @@
             android:id="@+id/tv_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.ItemTitle" />
+            android:textAppearance="@style/TextAppearance.ItemTitle"
+            tools:text="username/repository" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_desc"
@@ -30,7 +32,8 @@
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:maxLines="2"
-            android:textAppearance="?android:attr/textAppearanceSmall" />
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            tools:text="Repository description" />
 
     </LinearLayout>
 
@@ -48,7 +51,8 @@
             android:drawableLeft="?attr/forkSmallIcon"
             android:drawablePadding="4dp"
             android:gravity="right"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="10" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/tv_stars"
@@ -58,7 +62,8 @@
             android:drawableLeft="?attr/starSmallIcon"
             android:drawablePadding="4dp"
             android:gravity="right"
-            android:textAppearance="@style/TextAppearance.VerySmall" />
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="43" />
 
     </LinearLayout>
 

--- a/res/layout/twofactor_auth_dialog.xml
+++ b/res/layout/twofactor_auth_dialog.xml
@@ -1,8 +1,9 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/content_padding" >
+    android:padding="@dimen/content_padding">
 
     <android.support.design.widget.TextInputLayout
         android:layout_width="match_parent"

--- a/res/layout/user.xml
+++ b/res/layout/user.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -31,7 +32,8 @@
                         android:layout_width="60dp"
                         android:layout_height="60dp"
                         android:layout_marginRight="16dp"
-                        android:background="?attr/selectableItemBackgroundBorderless" />
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        tools:src="@drawable/default_avatar" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_name"
@@ -39,7 +41,8 @@
                         android:layout_height="wrap_content"
                         android:layout_alignParentTop="true"
                         android:layout_toRightOf="@id/iv_gravatar"
-                        android:textAppearance="@style/TextAppearance.HeaderTitle" />
+                        android:textAppearance="@style/TextAppearance.HeaderTitle"
+                        tools:text="Username" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_created_at"
@@ -48,7 +51,8 @@
                         android:layout_below="@id/tv_name"
                         android:layout_marginTop="2dp"
                         android:layout_toRightOf="@id/iv_gravatar"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        tools:text="yesterday" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_email"
@@ -59,7 +63,8 @@
                         android:layout_toRightOf="@id/iv_gravatar"
                         android:autoLink="email"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColorLink="?android:attr/textColorLink" />
+                        android:textColorLink="?android:attr/textColorLink"
+                        tools:text='user@email.com' />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_website"
@@ -70,7 +75,8 @@
                         android:layout_toRightOf="@id/iv_gravatar"
                         android:autoLink="web"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColorLink="?android:attr/textColorLink" />
+                        android:textColorLink="?android:attr/textColorLink"
+                        tools:text="https://example.com" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_company"
@@ -79,7 +85,8 @@
                         android:layout_below="@id/tv_website"
                         android:layout_marginTop="2dp"
                         android:layout_toRightOf="@id/iv_gravatar"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        tools:text="Company name" />
 
                     <com.gh4a.widget.StyleableTextView
                         android:id="@+id/tv_location"
@@ -89,7 +96,8 @@
                         android:layout_marginTop="2dp"
                         android:layout_toRightOf="@id/iv_gravatar"
                         android:autoLink="map"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        tools:text="Location" />
                 </RelativeLayout>
 
                 <LinearLayout
@@ -135,7 +143,8 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:gravity="center"
-                            android:textAppearance="@style/TextAppearance.CountHeaderItem" />
+                            android:textAppearance="@style/TextAppearance.CountHeaderItem"
+                            tools:text="354" />
 
                         <com.gh4a.widget.StyleableTextView
                             android:id="@+id/tv_followers_label"
@@ -158,7 +167,8 @@
                             android:id="@+id/tv_following_count"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:textAppearance="@style/TextAppearance.CountHeaderItem" />
+                            android:textAppearance="@style/TextAppearance.CountHeaderItem"
+                            tools:text="23" />
 
                         <com.gh4a.widget.StyleableTextView
                             android:id="@+id/tv_following_label"
@@ -181,7 +191,8 @@
                             android:id="@+id/tv_repos_count"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:textAppearance="@style/TextAppearance.CountHeaderItem" />
+                            android:textAppearance="@style/TextAppearance.CountHeaderItem"
+                            tools:text="1" />
 
                         <com.gh4a.widget.StyleableTextView
                             android:id="@+id/tv_repos_label"
@@ -204,7 +215,8 @@
                             android:id="@+id/tv_gists_count"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:textAppearance="@style/TextAppearance.CountHeaderItem" />
+                            android:textAppearance="@style/TextAppearance.CountHeaderItem"
+                            tools:text="0" />
 
                         <com.gh4a.widget.StyleableTextView
                             android:id="@+id/tv_gists_label"
@@ -257,7 +269,8 @@
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
                     android:text="@string/view_more"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    tools:visibility="visible" />
 
             </LinearLayout>
 

--- a/res/layout/user.xml
+++ b/res/layout/user.xml
@@ -46,8 +46,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@id/tv_name"
-                        android:layout_toRightOf="@id/iv_gravatar"
                         android:layout_marginTop="2dp"
+                        android:layout_toRightOf="@id/iv_gravatar"
                         android:textAppearance="?android:attr/textAppearanceSmall" />
 
                     <com.gh4a.widget.StyleableTextView
@@ -55,8 +55,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@id/tv_created_at"
-                        android:layout_toRightOf="@id/iv_gravatar"
                         android:layout_marginTop="2dp"
+                        android:layout_toRightOf="@id/iv_gravatar"
                         android:autoLink="email"
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColorLink="?android:attr/textColorLink" />
@@ -66,8 +66,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@id/tv_email"
-                        android:layout_toRightOf="@id/iv_gravatar"
                         android:layout_marginTop="2dp"
+                        android:layout_toRightOf="@id/iv_gravatar"
                         android:autoLink="web"
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColorLink="?android:attr/textColorLink" />
@@ -77,8 +77,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@id/tv_website"
-                        android:layout_toRightOf="@id/iv_gravatar"
                         android:layout_marginTop="2dp"
+                        android:layout_toRightOf="@id/iv_gravatar"
                         android:textAppearance="?android:attr/textAppearanceSmall" />
 
                     <com.gh4a.widget.StyleableTextView
@@ -86,8 +86,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@id/tv_company"
-                        android:layout_toRightOf="@id/iv_gravatar"
                         android:layout_marginTop="2dp"
+                        android:layout_toRightOf="@id/iv_gravatar"
                         android:autoLink="map"
                         android:textAppearance="?android:attr/textAppearanceSmall" />
                 </RelativeLayout>
@@ -235,7 +235,7 @@
                     style="@style/HeaderLabel"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/user_pub_repos"/>
+                    android:text="@string/user_pub_repos" />
 
                 <ProgressBar
                     android:id="@+id/pb_top_repos"
@@ -253,9 +253,9 @@
                     style="@style/MoreButton"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
-                    android:gravity="center_horizontal"
                     android:text="@string/view_more"
                     android:visibility="gone" />
 
@@ -284,8 +284,8 @@
                     android:id="@+id/ll_org"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginBottom="@dimen/overview_header_spacing" />
+                    android:layout_marginBottom="@dimen/overview_header_spacing"
+                    android:orientation="vertical" />
 
             </LinearLayout>
         </android.support.v7.widget.CardView>


### PR DESCRIPTION
Currently editing layout files is annoying because there is hardly anything displayed in the layout preview. This pull request fixes this by adding tools attributes to each of the layout files.

Before:
![screenshot_20170217_184517](https://cloud.githubusercontent.com/assets/5156340/23076587/6d5638d0-f541-11e6-91da-4fa5440784d1.png)

After:
![screenshot_20170217_184542](https://cloud.githubusercontent.com/assets/5156340/23076600/74f3b43c-f541-11e6-9650-7c1941ddc356.png)

It's **not a finished work** as I would like to know if I should continue with the rest of the layouts.

Additionally, I've added commit which sorted all layout attributes to appear in alphabetical order.