### PR TITLE
Fix off by one error for organization selection

### DIFF
--- a/src/com/gh4a/activities/home/NewsFeedFactory.java
+++ b/src/com/gh4a/activities/home/NewsFeedFactory.java
@@ -121,7 +121,7 @@ public class NewsFeedFactory extends FragmentFactory implements Spinner.OnItemSe
 
     @Override
     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-        mSelectedOrganization = position != 0 ? mUserScopes.get(position) : null;
+        mSelectedOrganization = position != 0 ? mUserScopes.get(position - 1) : null;
         mActivity.invalidateFragments();
 
     }


### PR DESCRIPTION
The `position == 0` is used for viewing user activity which makes it necessary to distract 1 from the position when attempting to retrieve correct organization