### PR TITLE
Change title of search action in repository activity

### DIFF
--- a/res/menu/repo_menu.xml
+++ b/res/menu/repo_menu.xml
@@ -14,7 +14,7 @@
         android:icon="@drawable/social_share"
         app:showAsAction="never" />
     <item android:id="@+id/search"
-        android:title="@string/search"
+        android:title="@string/search_code"
         android:icon="@drawable/action_search"
         app:showAsAction="never"/>
     <item android:id="@+id/watch"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="merging_msg">Merging\u2026</string>
     <string name="authenticating">Authenticating\u2026</string>
     <string name="search">Search</string>
+    <string name="search_code">Search code</string>
     <string name="logout">Logout</string>
     <string name="login">Login</string>
     <string name="try_again">Try again</string>


### PR DESCRIPTION
Simply calling the action "Search" is a bit too broad since it doesn't specify exactly what the user would be searching for. Is it issues, code, content of readme, files?

This commit fixes the issue by making the action exactly specify what it can be used to search for, which is "Search code".