### PR TITLE
Add shortcuts to enter labels and milestone management screens

### DIFF
--- a/src/com/gh4a/activities/IssueEditActivity.java
+++ b/src/com/gh4a/activities/IssueEditActivity.java
@@ -74,6 +74,9 @@ public class IssueEditActivity extends BaseActivity implements View.OnClickListe
                 .putExtra("issue", issue);
     }
 
+    private static final int REQUEST_MANAGE_LABELS = 1000;
+    private static final int REQUEST_MANAGE_MILESTONES = 1001;
+
     private String mRepoOwner;
     private String mRepoName;
 
@@ -320,6 +323,23 @@ public class IssueEditActivity extends BaseActivity implements View.OnClickListe
         return IssueActivity.makeIntent(this, mRepoOwner, mRepoName, mEditIssue.getNumber());
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == REQUEST_MANAGE_LABELS) {
+            if (resultCode == RESULT_OK) {
+                // Require reload of labels
+                mAllLabels = null;
+            }
+        } else if (requestCode == REQUEST_MANAGE_MILESTONES) {
+            if (resultCode == RESULT_OK) {
+                // Require reload of milestones
+                mAllMilestone = null;
+            }
+        } else {
+            super.onActivityResult(requestCode, resultCode, data);
+        }
+    }
+
     private void showMilestonesDialog() {
         if (mAllMilestone == null) {
             getSupportLoaderManager().initLoader(1, null, mMilestoneCallback);
@@ -355,6 +375,16 @@ public class IssueEditActivity extends BaseActivity implements View.OnClickListe
                     .setTitle(R.string.issue_milestone_hint)
                     .setSingleChoiceItems(milestones, selected, selectCb)
                     .setNegativeButton(R.string.cancel, null)
+                    .setNeutralButton(R.string.issue_manage_milestones,
+                            new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            Intent intent = IssueMilestoneListActivity.makeIntent(
+                                    IssueEditActivity.this, mRepoOwner, mRepoName,
+                                    mEditIssue.getPullRequest() != null);
+                            startActivityForResult(intent, REQUEST_MANAGE_MILESTONES);
+                        }
+                    })
                     .show();
         }
     }
@@ -457,6 +487,16 @@ public class IssueEditActivity extends BaseActivity implements View.OnClickListe
                         public void onClick(DialogInterface dialog, int which) {
                             mEditIssue.setLabels(selectedLabels);
                             updateLabels();
+                        }
+                    })
+                    .setNeutralButton(R.string.issue_manage_labels,
+                            new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            Intent intent = IssueLabelListActivity.makeIntent(
+                                    IssueEditActivity.this, mRepoOwner, mRepoName,
+                                    mEditIssue.getPullRequest() != null);
+                            startActivityForResult(intent, REQUEST_MANAGE_LABELS);
                         }
                     })
                     .show();

--- a/src/com/gh4a/activities/IssueLabelListActivity.java
+++ b/src/com/gh4a/activities/IssueLabelListActivity.java
@@ -310,6 +310,7 @@ public class IssueLabelListActivity extends BaseActivity implements
         @Override
         protected void onSuccess(Void result) {
             forceLoaderReload(0);
+            setResult(RESULT_OK);
         }
 
         @Override
@@ -352,6 +353,7 @@ public class IssueLabelListActivity extends BaseActivity implements
         @Override
         protected void onSuccess(Void result) {
             forceLoaderReload(0);
+            setResult(RESULT_OK);
         }
 
         @Override
@@ -392,6 +394,7 @@ public class IssueLabelListActivity extends BaseActivity implements
         protected void onSuccess(Void result) {
             forceLoaderReload(0);
             mAddedLabel = null;
+            setResult(RESULT_OK);
         }
 
         @Override

--- a/src/com/gh4a/activities/IssueMilestoneEditActivity.java
+++ b/src/com/gh4a/activities/IssueMilestoneEditActivity.java
@@ -153,13 +153,6 @@ public class IssueMilestoneEditActivity extends BaseActivity implements View.OnC
         return getIntent().hasExtra("milestone");
     }
 
-    private void openIssueMilestones() {
-        Intent intent = IssueMilestoneListActivity.makeIntent(this,
-                mRepoOwner, mRepoName, mFromPullRequest);
-        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        startActivity(intent);
-    }
-
     @Override
     protected boolean canSwipeToRefresh() {
         // swipe-to-refresh doesn't make much sense in the
@@ -306,7 +299,8 @@ public class IssueMilestoneEditActivity extends BaseActivity implements View.OnC
 
         @Override
         protected void onSuccess(Void result) {
-            openIssueMilestones();
+            setResult(RESULT_OK);
+            finish();
         }
 
         @Override
@@ -339,7 +333,8 @@ public class IssueMilestoneEditActivity extends BaseActivity implements View.OnC
 
         @Override
         protected void onSuccess(Void result) {
-            openIssueMilestones();
+            setResult(RESULT_OK);
+            finish();
         }
 
         @Override
@@ -377,6 +372,7 @@ public class IssueMilestoneEditActivity extends BaseActivity implements View.OnC
         @Override
         protected void onSuccess(Void result) {
             supportInvalidateOptionsMenu();
+            setResult(RESULT_OK);
         }
 
         @Override

--- a/src/com/gh4a/activities/IssueMilestoneListActivity.java
+++ b/src/com/gh4a/activities/IssueMilestoneListActivity.java
@@ -42,6 +42,8 @@ public class IssueMilestoneListActivity extends BasePagerActivity implements
                 .putExtra("from_pr", fromPullRequest);
     }
 
+    private static final int REQUEST_EDIT_MILESTONE = 1000;
+
     private static final int[] TITLES = new int[] {
         R.string.open, R.string.closed
     };
@@ -137,13 +139,24 @@ public class IssueMilestoneListActivity extends BasePagerActivity implements
 
     @Override
     public void onClick(View view) {
-        startActivity(IssueMilestoneEditActivity.makeCreateIntent(this,
-                mRepoOwner, mRepoName, mParentIsPullRequest));
+        startActivityForResult(IssueMilestoneEditActivity.makeCreateIntent(this,
+                mRepoOwner, mRepoName, mParentIsPullRequest), REQUEST_EDIT_MILESTONE);
     }
 
     @Override
     protected void invalidateFragments() {
         mOpenFragment = null;
         super.invalidateFragments();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == REQUEST_EDIT_MILESTONE) {
+            if (resultCode == RESULT_OK) {
+                setResult(RESULT_OK);
+            }
+        } else {
+            super.onActivityResult(requestCode, resultCode, data);
+        }
     }
 }

--- a/src/com/gh4a/fragment/IssueMilestoneListFragment.java
+++ b/src/com/gh4a/fragment/IssueMilestoneListFragment.java
@@ -15,6 +15,8 @@
  */
 package com.gh4a.fragment;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.content.Loader;
 import android.support.v7.widget.RecyclerView;
@@ -52,6 +54,8 @@ public class IssueMilestoneListFragment extends ListDataBaseFragment<Milestone> 
         return f;
     }
 
+    private static final int REQUEST_EDIT_MILESTONE = 2000;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -78,13 +82,26 @@ public class IssueMilestoneListFragment extends ListDataBaseFragment<Milestone> 
 
     @Override
     public void onItemClick(Milestone milestone) {
-        startActivity(IssueMilestoneEditActivity.makeEditIntent(
-                getActivity(), mRepoOwner, mRepoName, milestone, mFromPullRequest));
+        startActivityForResult(IssueMilestoneEditActivity.makeEditIntent(
+                getActivity(), mRepoOwner, mRepoName, milestone, mFromPullRequest),
+                REQUEST_EDIT_MILESTONE);
     }
 
     @Override
     public Loader<LoaderResult<List<Milestone>>> onCreateLoader() {
         return new MilestoneListLoader(getActivity(), mRepoOwner, mRepoName,
                 mShowClosed ? ApiHelpers.IssueState.CLOSED : ApiHelpers.IssueState.OPEN);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == REQUEST_EDIT_MILESTONE) {
+            if (resultCode == Activity.RESULT_OK) {
+                onRefresh();
+                getActivity().setResult(Activity.RESULT_OK);
+            }
+        } else {
+            super.onActivityResult(requestCode, resultCode, data);
+        }
     }
 }


### PR DESCRIPTION
This commits adds neutral buttons to the dialogs displayed in the issue edit activity when selecting labels or milestones. Pressing on these buttons opens corresponding screens and if something is modified by the user they notify the calling activities to reload the data.

To implement this change I had to make a small modification in the `IssueMilestoneEditActivity`. It now uses the `finish()` method after successfull actions instead of starting new issue list activity. This is the same behavior as the one used in `IssueEditActivity`. I made the necessary changes to make sure that the parent milestones list reloads its data if it was the one that opened the edit screen.

![peek 2017-04-01 22-47](https://cloud.githubusercontent.com/assets/5156340/24582315/32609438-172d-11e7-8747-85c9e29de371.gif)
