### PR TITLE
Make code search results scroll to matching fragments

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/CodeSearchAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CodeSearchAdapter.java
@@ -48,8 +48,7 @@ public class CodeSearchAdapter extends RootAdapter<CodeSearchResult, CodeSearchA
 
             for (int i = 0; i < matches.size(); i++) {
                 TextMatch match = matches.get(i);
-                SpannableStringBuilder builder = new SpannableStringBuilder();
-                builder.append(match.getFragment());
+                SpannableStringBuilder builder = new SpannableStringBuilder(match.getFragment());
 
                 List<TextMatch.MatchItem> items = match.getMatches();
                 if (items != null) {

--- a/app/src/main/java/com/gh4a/adapter/CodeSearchAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CodeSearchAdapter.java
@@ -44,9 +44,7 @@ public class CodeSearchAdapter extends RootAdapter<CodeSearchResult, CodeSearchA
 
         List<TextMatch> matches = result.getTextMatches();
         if (matches != null && !matches.isEmpty()) {
-
             LayoutInflater inflater = LayoutInflater.from(mContext);
-            holder.matchesContainer.removeAllViews();
 
             for (int i = 0; i < matches.size(); i++) {
                 TextMatch match = matches.get(i);
@@ -64,15 +62,22 @@ public class CodeSearchAdapter extends RootAdapter<CodeSearchResult, CodeSearchA
                     }
                 }
 
-                View row =
-                        inflater.inflate(R.layout.row_search_match, holder.matchesContainer, false);
+                View row = holder.matchesContainer.getChildAt(i);
+                if (row == null) {
+                    row = inflater.inflate(R.layout.row_search_match,
+                            holder.matchesContainer, false);
+                    holder.matchesContainer.addView(row);
+                }
+
                 TextView tvMatch = (TextView) row.findViewById(R.id.tv_match);
                 tvMatch.setOnClickListener(this);
                 tvMatch.setText(builder);
                 tvMatch.setTag(result);
                 tvMatch.setTag(R.id.search_match_index, i);
-
-                holder.matchesContainer.addView(row);
+                row.setVisibility(View.VISIBLE);
+            }
+            for (int i = matches.size(); i < holder.matchesContainer.getChildCount(); i++) {
+                holder.matchesContainer.getChildAt(i).setVisibility(View.GONE);
             }
             holder.matchesContainer.setVisibility(View.VISIBLE);
         } else {

--- a/app/src/main/java/com/gh4a/utils/StringUtils.java
+++ b/app/src/main/java/com/gh4a/utils/StringUtils.java
@@ -143,27 +143,13 @@ public class StringUtils {
 
     @Nullable
     public static int[] findMatchingLines(String input, String match) {
-        String[] lines = input.split("\n");
-        String[] matchLines = match.split("\n");
-
-        for (int i = 0; i < lines.length - matchLines.length; i++) {
-            boolean isMatch = true;
-            for (int j = 0; j < matchLines.length; j++) {
-                String cLine = lines[i + j];
-                String fLine = matchLines[j];
-                if ((j == 0 && !cLine.endsWith(fLine)) ||
-                        (j != 0 && j != matchLines.length - 1 && !cLine.equals(fLine)) ||
-                        (j == matchLines.length - 1 && !cLine.startsWith(fLine))) {
-                    isMatch = false;
-                    break;
-                }
-            }
-
-            if (isMatch) {
-                return new int[] { i + 1, i + matchLines.length };
-            }
+        int pos = input.indexOf(match);
+        if (pos < 0) {
+            return null;
         }
 
-        return null;
+        int start = input.substring(0, pos).split("\n").length;
+        int end = start + match.split("\n").length - 1;
+        return new int[] { start, end };
     }
 }

--- a/app/src/main/java/com/gh4a/utils/StringUtils.java
+++ b/app/src/main/java/com/gh4a/utils/StringUtils.java
@@ -17,6 +17,7 @@ package com.gh4a.utils;
 
 import android.content.Context;
 import android.graphics.Typeface;
+import android.support.annotation.Nullable;
 import android.text.SpannableStringBuilder;
 import android.text.format.DateUtils;
 
@@ -138,5 +139,31 @@ public class StringUtils {
             }
         }
         return ssb;
+    }
+
+    @Nullable
+    public static int[] findMatchingLines(String input, String match) {
+        String[] lines = input.split("\n");
+        String[] matchLines = match.split("\n");
+
+        for (int i = 0; i < lines.length - matchLines.length; i++) {
+            boolean isMatch = true;
+            for (int j = 0; j < matchLines.length; j++) {
+                String cLine = lines[i + j];
+                String fLine = matchLines[j];
+                if ((j == 0 && !cLine.endsWith(fLine)) ||
+                        (j != 0 && j != matchLines.length - 1 && !cLine.equals(fLine)) ||
+                        (j == matchLines.length - 1 && !cLine.startsWith(fLine))) {
+                    isMatch = false;
+                    break;
+                }
+            }
+
+            if (isMatch) {
+                return new int[] { i + 1, i + matchLines.length };
+            }
+        }
+
+        return null;
     }
 }

--- a/app/src/main/res/layout/row_code_search.xml
+++ b/app/src/main/res/layout/row_code_search.xml
@@ -25,11 +25,10 @@
         android:textColor="?android:attr/textColorPrimary"
         tools:text="username/repository" />
 
-    <com.gh4a.widget.StyleableTextView
-        android:id="@+id/tv_matches"
+    <LinearLayout
+        android:id="@+id/matches_container"
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.VerySmall"
-        tools:text="code matches" />
+        android:layout_height="wrap_content"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/row_search_match.xml
+++ b/app/src/main/res/layout/row_search_match.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.gh4a.widget.StyleableTextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tv_match"
+    android:foreground="?selectableItemBackground"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:background="?colorControlHighlight"
+    android:padding="8dp"
+    android:textAppearance="@style/TextAppearance.VerySmall"
+    tools:text="code match" />

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="search_match_index" type="id" />
+</resources>

--- a/github-api/src/main/java/org/eclipse/egit/github/core/TextMatch.java
+++ b/github-api/src/main/java/org/eclipse/egit/github/core/TextMatch.java
@@ -36,7 +36,7 @@ public class TextMatch implements Serializable {
 		/**
 		 * @return End position of text in fragment
 		 */
-		public int getEdndPos() {
+		public int getEndPos() {
 			return indices != null && indices.size() >= 2 ? indices.get(1) : -1;
 		}
 	}


### PR DESCRIPTION
The appearance of code search results was changed so it's now possible to click on individual matched code blocks. When doing so the opened file will be automatically scrolled to the matched block.

![peek 2017-05-24 14-55](https://cloud.githubusercontent.com/assets/5156340/26404191/41984ee0-4091-11e7-9794-1a964eb47fb2.gif)

Closes #597.