### PR TITLE
Pull request diff comment links

### DIFF
--- a/app/src/main/java/com/gh4a/BrowseFilter.java
+++ b/app/src/main/java/com/gh4a/BrowseFilter.java
@@ -142,7 +142,7 @@ public class BrowseFilter extends AppCompatActivity {
                         try {
                             intent = IssueActivity.makeIntent(this, user, repo,
                                     Integer.parseInt(id),
-                                    generateInitialCommentMarker(uri.getFragment(), "issue"));
+                                    generateInitialCommentMarker(uri.getFragment(), "issuecomment-"));
                         } catch (NumberFormatException e) {
                             // ignored
                         }
@@ -172,10 +172,18 @@ public class BrowseFilter extends AppCompatActivity {
                     } else {
                         String target = parts.size() >= 5 ? parts.get(4) : null;
                         int page = "commits".equals(action) ? PullRequestActivity.PAGE_COMMITS
-                                : "files".equals(target) ? PullRequestActivity.PAGE_FILES
-                                : -1;
+                                : "files".equals(target) ? PullRequestActivity.PAGE_FILES : -1;
+                        IntentUtils.InitialCommentMarker initialDiffComment =
+                                generateInitialCommentMarker(uri.getFragment(), "r");
+                        if (initialDiffComment != null) {
+                            new PullRequestDiffCommentLoadTask(user, repo, pullRequestNumber,
+                                    initialDiffComment, page).execute();
+                            return; // avoid finish() for now
+                        }
+                        IntentUtils.InitialCommentMarker initialComment =
+                                generateInitialCommentMarker(uri.getFragment(), "issuecomment-");
                         intent = PullRequestActivity.makeIntent(this, user, repo, pullRequestNumber,
-                                page, generateInitialCommentMarker(uri.getFragment(), "issue"));
+                                page, initialComment);
                     }
                 }
             } else if ("commit".equals(action) && !StringUtils.isBlank(id)) {
@@ -185,13 +193,13 @@ public class BrowseFilter extends AppCompatActivity {
                     return; // avoid finish() for now
                 } else {
                     IntentUtils.InitialCommentMarker initialComment =
-                            generateInitialCommentMarker(uri.getFragment(), "commit");
+                            generateInitialCommentMarker(uri.getFragment(), "commitcomment-");
                     if (initialComment != null) {
                         new CommitCommentLoadTask(user, repo, id, initialComment).execute();
                         return; // avoid finish() for now
                     }
                     intent = CommitActivity.makeIntent(this, user, repo, id,
-                            generateInitialCommentMarker(uri.getFragment(), "commit"));
+                            generateInitialCommentMarker(uri.getFragment(), "commitcomment-"));
                 }
             } else if ("blob".equals(action) && !StringUtils.isBlank(id) && parts.size() >= 4) {
                 String refAndPath = TextUtils.join("/", parts.subList(3, parts.size()));
@@ -207,8 +215,8 @@ public class BrowseFilter extends AppCompatActivity {
         finish();
     }
 
-    private IntentUtils.InitialCommentMarker generateInitialCommentMarker(String fragment, String type) {
-        String prefix = type + "comment-";
+    private IntentUtils.InitialCommentMarker generateInitialCommentMarker(String fragment,
+            String prefix) {
         if (fragment != null && fragment.startsWith(prefix)) {
             try {
                 long commentId = Long.parseLong(fragment.substring(prefix.length()));
@@ -353,6 +361,78 @@ public class BrowseFilter extends AppCompatActivity {
         }
     }
 
+    private class PullRequestDiffCommentLoadTask extends UrlLoadTask {
+        private final String mRepoOwner;
+        private final String mRepoName;
+        private final int mPullRequestNumber;
+        private final IntentUtils.InitialCommentMarker mMarker;
+        private final int mPage;
+
+        public PullRequestDiffCommentLoadTask(String repoOwner, String repoName,
+                int pullRequestNumber, IntentUtils.InitialCommentMarker marker, int page) {
+            mRepoOwner = repoOwner;
+            mRepoName = repoName;
+            mPullRequestNumber = pullRequestNumber;
+            mMarker = marker;
+            mPage = page;
+        }
+
+        @Override
+        protected Intent run() throws Exception {
+            PullRequest pullRequest =
+                    PullRequestLoader.loadPullRequest(mRepoOwner, mRepoName, mPullRequestNumber);
+            if (pullRequest == null || isFinishing()) {
+                return null;
+            }
+
+            List<CommitComment> comments =
+                    PullRequestCommentsLoader.loadComments(mRepoOwner, mRepoName,
+                            mPullRequestNumber);
+            if (comments == null || isFinishing()) {
+                return null;
+            }
+
+            List<CommitFile> files =
+                    PullRequestFilesLoader.loadFiles(mRepoOwner, mRepoName, mPullRequestNumber);
+            if (files == null || isFinishing()) {
+                return null;
+            }
+
+            boolean foundComment = false;
+            CommitFile resultFile = null;
+            for (CommitComment comment : comments) {
+                if (mMarker.matches(comment.getId(), comment.getCreatedAt())) {
+                    foundComment = true;
+                    for (CommitFile commitFile : files) {
+                        if (commitFile.getFilename().equals(comment.getPath())) {
+                            resultFile = commitFile;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if (!foundComment || isFinishing()) {
+                return null;
+            }
+
+            Intent intent = null;
+            if (resultFile != null) {
+                if (!FileUtils.isImage(resultFile.getFilename())) {
+                    intent = PullRequestDiffViewerActivity.makeIntent(BrowseFilter.this, mRepoOwner,
+                            mRepoName, mPullRequestNumber, pullRequest.getHead().getSha(),
+                            resultFile.getFilename(), resultFile.getPatch(), comments, -1, -1, -1,
+                            false, mMarker);
+                }
+            } else {
+                PullRequestActivity.makeIntent(BrowseFilter.this, mRepoOwner, mRepoName,
+                        mPullRequestNumber, mPage, mMarker);
+            }
+            return intent;
+        }
+    }
+
     private class CommitCommentLoadTask extends UrlLoadTask {
         private final String mRepoOwner;
         private final String mRepoName;
@@ -468,7 +548,7 @@ public class BrowseFilter extends AppCompatActivity {
                 List<CommitComment> comments, DiffHighlightId diffId) {
             return PullRequestDiffViewerActivity.makeIntent(BrowseFilter.this, mRepoOwner,
                     mRepoName, mPullRequestNumber, sha, file.getFilename(), file.getPatch(),
-                    comments, -1, diffId.startLine, diffId.endLine, diffId.right);
+                    comments, -1, diffId.startLine, diffId.endLine, diffId.right, null);
         }
 
         @Override

--- a/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
@@ -237,10 +237,10 @@ public abstract class DiffViewerActivity extends WebViewerActivity implements
             }
 
             int pos = mHighlightIsRight ? rightDiffPosition : leftDiffPosition;
-            if (pos != -1 && pos == mHighlightStartLine) {
+            if (pos != -1 && pos == mHighlightStartLine && highlightStartLine == -1) {
                 highlightStartLine = i;
             }
-            if (pos != -1 && pos == mHighlightEndLine) {
+            if (pos != -1 && pos == mHighlightEndLine && highlightEndLine == -1) {
                 highlightEndLine = i;
             }
 

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -24,6 +24,7 @@ import com.gh4a.Gh4Application;
 import com.gh4a.loader.LoaderResult;
 import com.gh4a.loader.PullRequestCommentsLoader;
 import com.gh4a.utils.ApiHelpers;
+import com.gh4a.utils.IntentUtils;
 
 import org.eclipse.egit.github.core.CommitComment;
 import org.eclipse.egit.github.core.RepositoryId;
@@ -34,14 +35,14 @@ import java.util.List;
 
 public class PullRequestDiffViewerActivity extends DiffViewerActivity {
     public static Intent makeIntent(Context context, String repoOwner, String repoName, int number,
-                String commitSha, String path, String diff,
-                List<CommitComment> comments, int initialLine,
-                int highlightStartLine, int highlightEndLine, boolean highlightIsRight) {
+            String commitSha, String path, String diff, List<CommitComment> comments,
+            int initialLine, int highlightStartLine, int highlightEndLine, boolean highlightIsRight,
+            IntentUtils.InitialCommentMarker initialComment) {
         Intent intent = new Intent(context, PullRequestDiffViewerActivity.class)
                 .putExtra("number", number);
         return DiffViewerActivity.fillInIntent(intent, repoOwner, repoName, commitSha, path,
                 diff, comments, initialLine, highlightStartLine, highlightEndLine,
-                highlightIsRight, null);
+                highlightIsRight, initialComment);
     }
 
     private int mPullRequestNumber;

--- a/app/src/main/java/com/gh4a/adapter/IssueEventAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/IssueEventAdapter.java
@@ -30,6 +30,7 @@ import com.gh4a.loader.IssueEventHolder;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.FileUtils;
 import com.gh4a.utils.HttpImageGetter;
+import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.StringUtils;
 import com.gh4a.utils.UiUtils;
 import com.gh4a.widget.IntentSpan;
@@ -151,7 +152,8 @@ public class IssueEventAdapter extends CommentAdapterBase<IssueEventHolder> {
                                     mRepoOwner, mRepoName, mIssueId,
                                     commitComment.getCommitId(), commitComment.getPath(),
                                     file.getPatch(), null, commitComment.getPosition(),
-                                    -1, -1, false);
+                                    -1, -1, false,
+                                    new IntentUtils.InitialCommentMarker(commitComment.getId()));
                         }
                     }, pos, pos + fileName.length(), 0);
                 }

--- a/app/src/main/java/com/gh4a/fragment/PullRequestFilesFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestFilesFragment.java
@@ -130,7 +130,7 @@ public class PullRequestFilesFragment extends CommitFragment {
         } else {
             intent = PullRequestDiffViewerActivity.makeIntent(getActivity(),
                     mRepoOwner, mRepoName, mPullRequestNumber, mHeadSha, file.getFilename(),
-                    file.getPatch(), mComments, -1, -1, -1, false);
+                    file.getPatch(), mComments, -1, -1, -1, false, null);
         }
 
         startActivityForResult(intent, REQUEST_DIFF_VIEWER);


### PR DESCRIPTION
- Added support for links to pull request file diff comments,
- Fixed an issue where line highlight was sometimes off,
- Going to file from commit comment in pull request comment list now will highlight that comment

Comments made from pull request changed files tab now work correctly for me. Some examples:
https://github.com/Tunous/TestingRepo/pull/48/files#r118826933
https://github.com/Tunous/TestingRepo/pull/48/files#r118826906

But there is also another type of comments. These which were made on individual commits. They don't appear for me in the app so I didn't add a support for their links in this pull request. Example links:
https://github.com/Tunous/TestingRepo/pull/48/commits/4688cfb2a16ce4f35c70e36c02a672c34ec48a50#r118826927
https://github.com/Tunous/TestingRepo/pull/48/commits/4688cfb2a16ce4f35c70e36c02a672c34ec48a50#r118826942

I will take a look at why these don't appear and try to add them later. (Probably in a separate pull request)