### PR TITLE
Handle organization links and user link tab query parameter

### DIFF
--- a/app/src/main/java/com/gh4a/BrowseFilter.java
+++ b/app/src/main/java/com/gh4a/BrowseFilter.java
@@ -23,6 +23,7 @@ import com.gh4a.activities.GistActivity;
 import com.gh4a.activities.IssueActivity;
 import com.gh4a.activities.IssueEditActivity;
 import com.gh4a.activities.IssueListActivity;
+import com.gh4a.activities.OrganizationMemberListActivity;
 import com.gh4a.activities.PullRequestActivity;
 import com.gh4a.activities.PullRequestDiffViewerActivity;
 import com.gh4a.activities.ReleaseInfoActivity;
@@ -106,6 +107,17 @@ public class BrowseFilter extends AppCompatActivity {
         } else if ("blog".equals(first)) {
             if (parts.size() == 1) {
                 intent = new Intent(this, BlogListActivity.class);
+            }
+        } else if ("orgs".equals(first)) {
+            String org = parts.size() >= 2 ? parts.get(1) : null;
+            String action = parts.size() >= 3 ? parts.get(2) : null;
+
+            if (org != null) {
+                if (action == null) {
+                    intent = UserActivity.makeIntent(this, org);
+                } else if ("people".equals(action)) {
+                    intent = OrganizationMemberListActivity.makeIntent(this, org);
+                }
             }
         } else if (first != null) {
             String user = first;

--- a/app/src/main/java/com/gh4a/BrowseFilter.java
+++ b/app/src/main/java/com/gh4a/BrowseFilter.java
@@ -18,6 +18,7 @@ import com.gh4a.activities.CommitActivity;
 import com.gh4a.activities.CommitDiffViewerActivity;
 import com.gh4a.activities.DownloadsActivity;
 import com.gh4a.activities.FileViewerActivity;
+import com.gh4a.activities.FollowerFollowingListActivity;
 import com.gh4a.activities.GistActivity;
 import com.gh4a.activities.IssueActivity;
 import com.gh4a.activities.IssueEditActivity;
@@ -27,15 +28,18 @@ import com.gh4a.activities.PullRequestDiffViewerActivity;
 import com.gh4a.activities.ReleaseInfoActivity;
 import com.gh4a.activities.ReleaseListActivity;
 import com.gh4a.activities.RepositoryActivity;
+import com.gh4a.activities.RepositoryListActivity;
 import com.gh4a.activities.TrendingActivity;
 import com.gh4a.activities.UserActivity;
 import com.gh4a.activities.WikiListActivity;
+import com.gh4a.fragment.RepositoryListContainerFragment;
 import com.gh4a.loader.CommitCommentListLoader;
 import com.gh4a.loader.CommitLoader;
 import com.gh4a.loader.PullRequestCommentsLoader;
 import com.gh4a.loader.PullRequestFilesLoader;
 import com.gh4a.loader.PullRequestLoader;
 import com.gh4a.loader.ReleaseListLoader;
+import com.gh4a.loader.UserLoader;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.FileUtils;
 import com.gh4a.utils.IntentUtils;
@@ -50,6 +54,7 @@ import org.eclipse.egit.github.core.RepositoryBranch;
 import org.eclipse.egit.github.core.RepositoryCommit;
 import org.eclipse.egit.github.core.RepositoryId;
 import org.eclipse.egit.github.core.RepositoryTag;
+import org.eclipse.egit.github.core.User;
 import org.eclipse.egit.github.core.client.IGitHubConstants;
 import org.eclipse.egit.github.core.service.RepositoryService;
 
@@ -109,7 +114,28 @@ public class BrowseFilter extends AppCompatActivity {
             String id = parts.size() >= 4 ? parts.get(3) : null;
 
             if (repo == null && action == null) {
-                intent = UserActivity.makeIntent(this, user);
+                String tab = uri.getQueryParameter("tab");
+                if (tab != null) {
+                    switch (tab) {
+                        case "repositories":
+                            new UserReposLoadTask(user, false).execute();
+                            return; // avoid finish() for now
+                        case "stars":
+                            new UserReposLoadTask(user, true).execute();
+                            return; // avoid finish() for now
+                        case "followers":
+                            new UserFollowersLoadTask(user, true).execute();
+                            return; // avoid finish() for now
+                        case "following":
+                            new UserFollowersLoadTask(user, false).execute();
+                            return; // avoid finish() for now
+                        default:
+                            intent = UserActivity.makeIntent(this, user);
+                            break;
+                    }
+                } else {
+                    intent = UserActivity.makeIntent(this, user);
+                }
             } else if (action == null) {
                 intent = RepositoryActivity.makeIntent(this, user, repo);
             } else if ("downloads".equals(action)) {
@@ -321,6 +347,63 @@ public class BrowseFilter extends AppCompatActivity {
         protected void onError(Exception e) {
             IntentUtils.launchBrowser(BrowseFilter.this, getIntent().getData());
             finish();
+        }
+    }
+
+    private abstract class UserLoadTask extends UrlLoadTask {
+        private final String mUserLogin;
+
+        public UserLoadTask(String userLogin) {
+            super();
+            this.mUserLogin = userLogin;
+        }
+
+        @Override
+        protected Intent run() throws Exception {
+            User user = UserLoader.loadUser(mUserLogin);
+            if (user == null) {
+                return null;
+            }
+            return getIntent(user);
+        }
+
+        protected abstract Intent getIntent(User user);
+    }
+
+    private class UserFollowersLoadTask extends UserLoadTask {
+        private boolean mShowFollowers;
+
+        public UserFollowersLoadTask(String userLogin, boolean showFollowers) {
+            super(userLogin);
+            mShowFollowers = showFollowers;
+        }
+
+        @Override
+        protected Intent getIntent(User user) {
+            if (ApiHelpers.UserType.ORG.equals(user.getType())) {
+                return UserActivity.makeIntent(BrowseFilter.this, user);
+            }
+            return FollowerFollowingListActivity.makeIntent(BrowseFilter.this, user.getLogin(),
+                    mShowFollowers);
+        }
+    }
+
+    private class UserReposLoadTask extends UserLoadTask {
+        private boolean mShowStars;
+
+        public UserReposLoadTask(String userLogin, boolean showStars) {
+            super(userLogin);
+            mShowStars = showStars;
+        }
+
+        @Override
+        protected Intent getIntent(User user) {
+            boolean isOrg = ApiHelpers.UserType.ORG.equals(user.getType());
+            String filter = mShowStars && !isOrg
+                    ? RepositoryListContainerFragment.FILTER_TYPE_STARRED
+                    : null;
+            return RepositoryListActivity.makeIntent(BrowseFilter.this, user.getLogin(), isOrg,
+                    filter);
         }
     }
 

--- a/app/src/main/java/com/gh4a/activities/RepositoryListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryListActivity.java
@@ -29,13 +29,20 @@ import com.gh4a.fragment.RepositoryListContainerFragment;
 public class RepositoryListActivity extends FragmentContainerActivity implements
         RepositoryListContainerFragment.Callback {
     public static Intent makeIntent(Context context, String user, boolean userIsOrg) {
+        return makeIntent(context, user, userIsOrg, null);
+    }
+
+    public static Intent makeIntent(Context context, String user, boolean userIsOrg,
+            String defaultFilter) {
         return new Intent(context, RepositoryListActivity.class)
                 .putExtra("user", user)
-                .putExtra("is_org", userIsOrg);
+                .putExtra("is_org", userIsOrg)
+                .putExtra("filter_type", defaultFilter);
     }
 
     private String mUserLogin;
     private boolean mUserIsOrg;
+    private String mFilterType;
     private RepositoryListContainerFragment mFragment;
     private RepositoryListContainerFragment.FilterDrawerHelper mFilterDrawerHelper;
     private RepositoryListContainerFragment.SortDrawerHelper mSortDrawerHelper;
@@ -60,15 +67,19 @@ public class RepositoryListActivity extends FragmentContainerActivity implements
         Bundle data = getIntent().getExtras();
         mUserLogin = data.getString("user");
         mUserIsOrg = data.getBoolean("is_org");
+        mFilterType = data.getString("filter_type");
 
         mFilterDrawerHelper = RepositoryListContainerFragment.FilterDrawerHelper.create(
                 mUserLogin, mUserIsOrg);
         mSortDrawerHelper = new RepositoryListContainerFragment.SortDrawerHelper();
+        if (mFilterType != null) {
+            mSortDrawerHelper.setFilterType(mFilterType);
+        }
     }
 
     @Override
     protected Fragment onCreateFragment() {
-        return RepositoryListContainerFragment.newInstance(mUserLogin, mUserIsOrg);
+        return RepositoryListContainerFragment.newInstance(mUserLogin, mUserIsOrg, mFilterType);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/activities/RepositoryListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryListActivity.java
@@ -130,4 +130,9 @@ public class RepositoryListActivity extends FragmentContainerActivity implements
     public void supportInvalidateOptionsMenu() {
         // happens when load is done; we ignore it as we don't want to close the IME in that case
     }
+
+    @Override
+    protected Intent navigateUp() {
+        return UserActivity.makeIntent(this, mUserLogin);
+    }
 }

--- a/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
@@ -30,19 +30,27 @@ public class RepositoryListContainerFragment extends Fragment implements
         LoaderCallbacks.ParentCallback, SearchView.OnCloseListener, SearchView.OnQueryTextListener,
         MenuItemCompat.OnActionExpandListener, SwipeRefreshLayout.ChildScrollDelegate {
     public static RepositoryListContainerFragment newInstance(String userLogin, boolean isOrg) {
+        return newInstance(userLogin, isOrg, null);
+    }
+
+    public static RepositoryListContainerFragment newInstance(String userLogin, boolean isOrg,
+            String defaultFilter) {
         RepositoryListContainerFragment f = new RepositoryListContainerFragment();
         Bundle args = new Bundle();
 
         args.putString("user", userLogin);
         args.putBoolean("is_org", isOrg);
+        args.putString("filter_type", defaultFilter);
         f.setArguments(args);
 
         return f;
     }
 
+    public static String FILTER_TYPE_STARRED = "starred";
+
     private String mUserLogin;
     private boolean mIsOrg;
-    private String mFilterType = "all";
+    private String mFilterType;
     private String mSortOrder = "full_name";
     private String mSortDirection = "asc";
     private boolean mSearchVisible;
@@ -67,6 +75,7 @@ public class RepositoryListContainerFragment extends Fragment implements
         Bundle data = getArguments();
         mUserLogin = data.getString("user");
         mIsOrg = data.getBoolean("is_org");
+        mFilterType = data.getString("filter_type", "all");
 
         if (savedInstanceState != null && savedInstanceState.containsKey(STATE_KEY_FILTER_TYPE)) {
             mFilterType = savedInstanceState.getString(STATE_KEY_FILTER_TYPE);

--- a/app/src/main/java/com/gh4a/loader/UserLoader.java
+++ b/app/src/main/java/com/gh4a/loader/UserLoader.java
@@ -1,13 +1,13 @@
 package com.gh4a.loader;
 
-import java.io.IOException;
+import android.content.Context;
+
+import com.gh4a.Gh4Application;
 
 import org.eclipse.egit.github.core.User;
 import org.eclipse.egit.github.core.service.UserService;
 
-import android.content.Context;
-
-import com.gh4a.Gh4Application;
+import java.io.IOException;
 
 public class UserLoader extends BaseLoader<User> {
 
@@ -20,8 +20,12 @@ public class UserLoader extends BaseLoader<User> {
 
     @Override
     public User doLoadInBackground() throws IOException {
+        return loadUser(mLogin);
+    }
+
+    public static User loadUser(String login) throws IOException {
         UserService userService = (UserService)
                 Gh4Application.get().getService(Gh4Application.USER_SERVICE);
-        return userService.getUser(mLogin);
+        return userService.getUser(login);
     }
 }


### PR DESCRIPTION
Added link handling for:

- user repositories: https://github.com/Tunous?tab=repositories
- user starred repositories: https://github.com/Tunous?tab=stars
- user followers: https://github.com/Tunous?tab=followers
- user follows: https://github.com/Tunous?tab=following
- organization profile: https://github.com/orgs/twitter
- organization members: https://github.com/orgs/twitter/people

Also fixed `RepositoryListActivity` up arrow - now it navigates to `UserActivity`.