### PR TITLE
Line link sharing

### DIFF
--- a/app/src/main/assets/codeutils.js
+++ b/app/src/main/assets/codeutils.js
@@ -9,6 +9,22 @@ window.applyLineWrapping = function(enabled) {
     s.textContent = enabled ? 'pre { white-space: pre-wrap }' : '';
 };
 
+window.addClickListeners = function() {
+    var pre = document.getElementById("content");
+    var ol = pre != null ? pre.getElementsByTagName("ol")[0] : null;
+    var lines = ol != null ? ol.getElementsByTagName("li") : null;
+    if (lines != null) {
+        function listener(target, line, event) {
+            if (event.target === target) {
+                NativeClient.onLineTouched(line);
+            }
+        }
+        for (i = 0; i < lines.length; i++) {
+            lines[i].addEventListener('click', listener.bind(null, lines[i], i + 1));
+        }
+    }
+};
+
 window.scrollToHighlight = function() {
     if (!window.highlightTop || !window.highlightBottom || !window.innerHeight) {
         return;

--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -50,9 +50,14 @@ public class CommitDiffViewerActivity extends DiffViewerActivity {
     }
 
     @Override
-    protected String createUrl() {
-        return "https://github.com/" + mRepoOwner + "/" + mRepoName + "/commit/" + mSha
-                + "#diff-" + ApiHelpers.md5(mPath);
+    protected String createUrl(String lineId, long replyId) {
+        String link = "https://github.com/" + mRepoOwner + "/" + mRepoName + "/commit/" + mSha;
+        if (replyId > 0L) {
+            link += "#commitcomment-" + replyId;
+        } else {
+            link += "#diff-" + ApiHelpers.md5(mPath) + lineId;
+        }
+        return link;
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
@@ -17,7 +17,6 @@ package com.gh4a.activities;
 
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.graphics.Point;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.content.Loader;
@@ -32,7 +31,6 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -60,7 +58,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public abstract class DiffViewerActivity extends WebViewerActivity implements
-        ReactionBar.Callback, ReactionBar.ReactionDetailsCache.Listener, View.OnTouchListener {
+        ReactionBar.Callback, ReactionBar.ReactionDetailsCache.Listener {
     protected static Intent fillInIntent(Intent baseIntent, String repoOwner, String repoName,
             String commitSha, String path, String diff, List<CommitComment> comments,
             int initialLine, int highlightStartLine, int highlightEndLine,
@@ -147,8 +145,6 @@ public abstract class DiffViewerActivity extends WebViewerActivity implements
     private final SparseArray<List<CommitComment>> mCommitCommentsByPos = new SparseArray<>();
     private final LongSparseArray<CommitCommentWrapper> mCommitComments = new LongSparseArray<>();
 
-    private final Point mLastTouchDown = new Point();
-
     private static final int MENU_ITEM_VIEW = 10;
 
     private final LoaderCallbacks<List<CommitComment>> mCommentCallback =
@@ -174,8 +170,6 @@ public abstract class DiffViewerActivity extends WebViewerActivity implements
         actionBar.setTitle(FileUtils.getFileName(mPath));
         actionBar.setSubtitle(mRepoOwner + "/" + mRepoName);
         actionBar.setDisplayHomeAsUpEnabled(true);
-
-        mWebView.setOnTouchListener(this);
 
         List<CommitComment> comments = (ArrayList<CommitComment>)
                 getIntent().getSerializableExtra("comments");
@@ -466,14 +460,6 @@ public abstract class DiffViewerActivity extends WebViewerActivity implements
         CommentActionPopup p = new CommentActionPopup(id, line, lineText, leftLine, rightLine,
                 mLastTouchDown.x, mLastTouchDown.y, isComment, isRightLine);
         p.show();
-    }
-
-    @Override
-    public boolean onTouch(View view, MotionEvent event) {
-        if (event.getAction() == MotionEvent.ACTION_DOWN) {
-            mLastTouchDown.set((int) event.getX(), (int) event.getY());
-        }
-        return false;
     }
 
     private void refresh() {

--- a/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
@@ -561,17 +561,11 @@ public abstract class DiffViewerActivity extends WebViewerActivity implements
                     openCommentDialog(0L, 0L, mLineText, mPosition, mLeftLine, mRightLine);
                     break;
                 case R.id.share:
-                    String url = createUrl(
-                            createLineLinkId(mIsRightLine ? mRightLine : mLeftLine, mIsRightLine),
-                            mId);
-                    Intent shareIntent = new Intent(Intent.ACTION_SEND);
-                    shareIntent.setType("text/plain");
-                    shareIntent.putExtra(Intent.EXTRA_SUBJECT,
-                            getString(R.string.share_commit_subject, mSha.substring(0, 7),
-                                    mRepoOwner + "/" + mRepoName));
-                    shareIntent.putExtra(Intent.EXTRA_TEXT, url);
-                    shareIntent = Intent.createChooser(shareIntent, getString(R.string.share_title));
-                    startActivity(shareIntent);
+                    String url = createUrl(createLineLinkId(mIsRightLine ? mRightLine : mLeftLine,
+                            mIsRightLine), mId);
+                    String subject = getString(R.string.share_commit_subject, mSha.substring(0, 7),
+                            mRepoOwner + "/" + mRepoName);
+                    IntentUtils.share(DiffViewerActivity.this, subject, url);
                     break;
             }
             return true;

--- a/app/src/main/java/com/gh4a/activities/FileViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/FileViewerActivity.java
@@ -272,16 +272,9 @@ public class FileViewerActivity extends WebViewerActivity
         switch (item.getItemId()) {
             case R.id.share:
                 if (mLastTouchedLine > 0) {
-                    // TODO: Use new share intent utility method
-                    Intent shareIntent = new Intent(Intent.ACTION_SEND);
-                    shareIntent.setType("text/plain");
-                    shareIntent.putExtra(Intent.EXTRA_SUBJECT,
-                            getString(R.string.share_line_subject, mLastTouchedLine, mPath,
-                                    mRepoOwner + "/" + mRepoName));
-                    shareIntent.putExtra(Intent.EXTRA_TEXT,  createUrl());
-                    shareIntent = Intent.createChooser(shareIntent,
-                            getString(R.string.share_title));
-                    startActivity(shareIntent);
+                    String subject = getString(R.string.share_line_subject, mLastTouchedLine, mPath,
+                            mRepoOwner + "/" + mRepoName);
+                    IntentUtils.share(this, subject, createUrl());
                 }
                 return true;
         }

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -61,9 +61,15 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity {
     }
 
     @Override
-    protected String createUrl() {
-        return "https://github.com/" + mRepoOwner + "/" + mRepoName + "/pull/" + mPullRequestNumber
-                + "/files#diff-" + ApiHelpers.md5(mPath);
+    protected String createUrl(String lineId, long replyId) {
+        String link = "https://github.com/" + mRepoOwner + "/" + mRepoName + "/pull/"
+                + mPullRequestNumber + "/files";
+        if (replyId > 0L) {
+            link += "#r" + replyId;
+        } else {
+            link += "#diff-" + ApiHelpers.md5(mPath) + lineId;
+        }
+        return link;
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/activities/WebViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/WebViewerActivity.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
+import android.graphics.Point;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -35,6 +36,8 @@ import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.View;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
@@ -53,8 +56,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 public abstract class WebViewerActivity extends BaseActivity implements
-        SwipeRefreshLayout.ChildScrollDelegate {
-    protected WebView mWebView;
+        SwipeRefreshLayout.ChildScrollDelegate, View.OnTouchListener {
+
+    protected final Point mLastTouchDown = new Point();
+
+    private WebView mWebView;
     private WebView mPrintWebView;
     private boolean mStarted;
     private boolean mHasData;
@@ -74,7 +80,17 @@ public abstract class WebViewerActivity extends BaseActivity implements
     };
 
     @SuppressWarnings("unused")
-    private class RenderingDoneInterface {
+    private class DisplayJavascriptInterface {
+        @JavascriptInterface
+        public void onLineTouched(final int line) {
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    WebViewerActivity.this.onLineTouched(line, mLastTouchDown.x, mLastTouchDown.y);
+                }
+            });
+        }
+
         @JavascriptInterface
         public void onRenderingDone() {
             mHandler.post(new Runnable() {
@@ -88,7 +104,11 @@ public abstract class WebViewerActivity extends BaseActivity implements
     }
 
     @SuppressWarnings("unused")
-    private class PrintRenderingDoneInterface {
+    private class PrintJavascriptInterface {
+        @JavascriptInterface
+        public void onLineTouched(int line) {
+        }
+
         @JavascriptInterface
         public void onRenderingDone() {
             mHandler.post(new Runnable() {
@@ -178,6 +198,8 @@ public abstract class WebViewerActivity extends BaseActivity implements
 
         mWebView.setBackgroundColor(UiUtils.resolveColor(this, R.attr.colorWebViewBackground));
         mWebView.setWebViewClient(mWebViewClient);
+
+        mWebView.setOnTouchListener(this);
     }
 
     @SuppressWarnings("deprecation")
@@ -238,6 +260,14 @@ public abstract class WebViewerActivity extends BaseActivity implements
         return super.onOptionsItemSelected(item);
     }
 
+    @Override
+    public boolean onTouch(View view, MotionEvent event) {
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            mLastTouchDown.set((int) event.getX(), (int) event.getY());
+        }
+        return false;
+    }
+
     @SuppressWarnings("deprecation")
     @TargetApi(11)
     private void doSearch() {
@@ -257,7 +287,7 @@ public abstract class WebViewerActivity extends BaseActivity implements
         initWebViewSettings(mPrintWebView.getSettings());
 
         if (mRequiresJsInterface) {
-            mPrintWebView.addJavascriptInterface(new PrintRenderingDoneInterface(), "NativeClient");
+            mPrintWebView.addJavascriptInterface(new PrintJavascriptInterface(), "NativeClient");
         } else {
             mPrintWebView.setWebViewClient(new WebViewClient() {
                 @Override
@@ -335,13 +365,16 @@ public abstract class WebViewerActivity extends BaseActivity implements
         }
     }
 
+    protected void onLineTouched(int line, int x, int y) {
+    }
+
     @SuppressLint("AddJavascriptInterface")
     protected void onDataReady() {
         final String cssTheme = Gh4Application.THEME == R.style.DarkTheme
                 ? DARK_CSS_THEME : LIGHT_CSS_THEME;
         final String html = generateHtml(cssTheme, false);
         if (mRequiresJsInterface) {
-            mWebView.addJavascriptInterface(new RenderingDoneInterface(), "NativeClient");
+            mWebView.addJavascriptInterface(new DisplayJavascriptInterface(), "NativeClient");
         }
         mWebView.loadDataWithBaseURL("file:///android_asset/", html, null, "utf-8", null);
         mHasData = true;
@@ -435,7 +468,7 @@ public abstract class WebViewerActivity extends BaseActivity implements
         content.append("</head>");
         content.append("<body onload='prettyPrint(function() { highlightLines(");
         content.append(highlightStart).append(",").append(highlightEnd).append("); ");
-        content.append("NativeClient.onRenderingDone(); })'");
+        content.append("addClickListeners(); NativeClient.onRenderingDone(); })'");
         content.append(" onresize='scrollToHighlight();'>");
         if (title != null) {
             content.append("<h2>").append(title).append("</h2>");

--- a/app/src/main/res/layout/popup_menu_item.xml
+++ b/app/src/main/res/layout/popup_menu_item.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<com.gh4a.widget.StyleableTextView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:minWidth="120dp"
-    android:padding="10dp"
-    android:textAppearance="?android:attr/textAppearanceMedium" />

--- a/app/src/main/res/menu/commit_comment_actions.xml
+++ b/app/src/main/res/menu/commit_comment_actions.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/share"
+        android:title="@string/share" />
+    <item
         android:id="@+id/reply"
         android:title="@string/reply" />
     <item
@@ -9,7 +12,7 @@
     <item
         android:id="@+id/react"
         android:title="@string/add_reaction">
-        <menu></menu>
+        <menu />
     </item>
     <item
         android:id="@+id/edit"

--- a/app/src/main/res/menu/file_line_menu.xml
+++ b/app/src/main/res/menu/file_line_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/share"
+        android:title="@string/share" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,6 +487,7 @@
     <string name="share_user_subject_loginonly">User %1$s</string>
     <string name="share_comment_subject">Comment #%1$d in issue %2$d at %3$s</string>
     <string name="share_commit_comment_subject">Commit comment #%1$d at %2$s</string>
+    <string name="share_line_subject">Line %1$d in file %2$s at %3$s</string>
 
     <!-- Webview text size -->
     <string name="menu_text_size">Code view text size</string>


### PR DESCRIPTION
This is an incomplete change which adds line link sharing _only_ for diffs. It's built on top of the existing popup for comments. I've improved it to use standard Android popup and added Share option to it for this new action. It also works for sharing links to comments.

![image](https://user-images.githubusercontent.com/5156340/26837055-bb6b2d46-4adc-11e7-9d92-7780f0a45c77.png)

Similar popup could be implemented for non-diff files. I didn't do it here as it needs some javascript code to make lines clickable and I'm not really sure what's a nice way to do this. Alternatively, for these files only line numbers could be clickable but similarly, I have no ideas how to add that...

#494