### PR TITLE
Repositories tabs

### DIFF
--- a/app/src/main/java/com/gh4a/activities/RepositoryListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryListActivity.java
@@ -56,7 +56,7 @@ public class RepositoryListActivity extends FragmentContainerActivity implements
         updateRightNavigationDrawer();
 
         ActionBar actionBar = getSupportActionBar();
-        actionBar.setTitle(R.string.user_pub_repos);
+        actionBar.setTitle(R.string.repositories);
         actionBar.setSubtitle(mUserLogin);
         actionBar.setDisplayHomeAsUpEnabled(true);
     }

--- a/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
+++ b/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
@@ -72,7 +72,7 @@ public class HomeActivity extends BasePagerActivity implements
     static {
         START_PAGE_MAPPING.put(R.id.news_feed, "newsfeed");
         START_PAGE_MAPPING.put(R.id.notifications, "notifications");
-        START_PAGE_MAPPING.put(R.id.my_repos, "repos");
+        START_PAGE_MAPPING.put(R.id.repositories, "repos");
         START_PAGE_MAPPING.put(R.id.my_issues, "issues");
         START_PAGE_MAPPING.put(R.id.my_prs, "prs");
         START_PAGE_MAPPING.put(R.id.my_gists, "gists");
@@ -298,7 +298,7 @@ public class HomeActivity extends BasePagerActivity implements
                 return new NewsFeedFactory(this, mUserLogin);
             case R.id.notifications:
                 return new NotificationListFactory(this);
-            case R.id.my_repos:
+            case R.id.repositories:
                 return new RepositoryFactory(this, mUserLogin, getPrefs());
             case R.id.my_issues:
                 return new IssueListFactory(this, mUserLogin, false);

--- a/app/src/main/java/com/gh4a/activities/home/RepositoryFactory.java
+++ b/app/src/main/java/com/gh4a/activities/home/RepositoryFactory.java
@@ -12,7 +12,9 @@ import com.gh4a.fragment.RepositoryListContainerFragment;
 
 public class RepositoryFactory extends FragmentFactory {
     private static final int[] TAB_TITLES = new int[] {
-        R.string.my_repositories
+            R.string.my,
+            R.string.starred,
+            R.string.repo_type_watched
     };
 
     private final String mUserLogin;
@@ -37,7 +39,7 @@ public class RepositoryFactory extends FragmentFactory {
 
     @Override
     protected @StringRes int getTitleResId() {
-        return R.string.my_repositories;
+        return R.string.repositories;
     }
 
     @Override
@@ -117,8 +119,21 @@ public class RepositoryFactory extends FragmentFactory {
     }
 
     @Override
+    protected boolean onCreateOptionsMenu(Menu menu) {
+        boolean result = super.onCreateOptionsMenu(menu);
+        // TODO
+        return result;
+    }
+
+    @Override
     protected Fragment makeFragment(int position) {
-        return RepositoryListContainerFragment.newInstance(mUserLogin, false);
+        String filterType = "all";
+        if (position == 1) {
+            filterType = "starred";
+        } else if (position == 2) {
+            filterType = "watched";
+        }
+        return RepositoryListContainerFragment.newInstance(mUserLogin, false, filterType);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
@@ -360,8 +360,6 @@ public class RepositoryListContainerFragment extends Fragment implements
             FILTER_LOOKUP.put(R.id.filter_type_private, "private");
             FILTER_LOOKUP.put(R.id.filter_type_sources, "sources");
             FILTER_LOOKUP.put(R.id.filter_type_forks, "forks");
-            FILTER_LOOKUP.put(R.id.filter_type_watched, "watched");
-            FILTER_LOOKUP.put(R.id.filter_type_starred, "starred");
         }
 
         public static FilterDrawerHelper create(String userLogin, boolean isOrg) {

--- a/app/src/main/res/layout/user.xml
+++ b/app/src/main/res/layout/user.xml
@@ -248,7 +248,7 @@
                     style="@style/HeaderLabel"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/user_pub_repos" />
+                    android:text="@string/repositories" />
 
                 <ProgressBar
                     android:id="@+id/pb_top_repos"

--- a/app/src/main/res/menu/home_nav_drawer.xml
+++ b/app/src/main/res/menu/home_nav_drawer.xml
@@ -15,8 +15,8 @@
             android:title="@string/notifications"
             app:actionLayout="@layout/notifications_indicator" />
         <item
-            android:id="@+id/my_repos"
-            android:title="@string/my_repositories"
+            android:id="@+id/repositories"
+            android:title="@string/repositories"
             android:icon="@drawable/icon_repositories"/>
         <item
             android:id="@+id/my_issues"

--- a/app/src/main/res/menu/repo_filter_logged_in.xml
+++ b/app/src/main/res/menu/repo_filter_logged_in.xml
@@ -24,12 +24,6 @@
                 <item
                     android:id="@+id/filter_type_forks"
                     android:title="@string/repo_type_forks" />
-                <item
-                    android:id="@+id/filter_type_watched"
-                    android:title="@string/repo_type_watched" />
-                <item
-                    android:id="@+id/filter_type_starred"
-                    android:title="@string/repo_type_starred" />
             </group>
         </menu>
     </item>

--- a/app/src/main/res/menu/repo_filter_org.xml
+++ b/app/src/main/res/menu/repo_filter_org.xml
@@ -21,12 +21,6 @@
                 <item
                     android:id="@+id/filter_type_forks"
                     android:title="@string/repo_type_forks" />
-                <item
-                    android:id="@+id/filter_type_watched"
-                    android:title="@string/repo_type_watched" />
-                <item
-                    android:id="@+id/filter_type_starred"
-                    android:title="@string/repo_type_starred" />
             </group>
         </menu>
     </item>

--- a/app/src/main/res/menu/repo_filter_user.xml
+++ b/app/src/main/res/menu/repo_filter_user.xml
@@ -18,12 +18,6 @@
                 <item
                     android:id="@+id/filter_type_forks"
                     android:title="@string/repo_type_forks" />
-                <item
-                    android:id="@+id/filter_type_watched"
-                    android:title="@string/repo_type_watched" />
-                <item
-                    android:id="@+id/filter_type_starred"
-                    android:title="@string/repo_type_starred" />
             </group>
         </menu>
     </item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,8 @@
     <string name="my_issues">My issues</string>
     <string name="my_pull_requests">My pull requests</string>
     <string name="my_gists">My gists</string>
+    <string name="my">My</string>
+    <string name="repositories">Repositories</string>
     <string name="start_page">Start page</string>
     <string name="start_page_last_selected">Last selected</string>
     <string name="comment_editor_locked_hint">Comments are only available to collaborators</string>
@@ -224,7 +226,6 @@
     <string name="user_followers">Followers</string><!-- For type organization -->
     <string name="user_members">Members</string><!-- For type organization -->
     <string name="user_created_at">Member since %1$s</string>
-    <string name="user_pub_repos">Repositories</string>
     <string name="user_extra_data">%1$d followers\u00a0\u00a0\u00a0%2$d repos</string>
     <string name="user_news_feed">News Feed</string>
     <string name="user_public_activity">Public Activity</string>


### PR DESCRIPTION
A test implementation of repository tabs as suggested in https://github.com/slapperwan/gh4a/pull/578#issuecomment-301339782.

![screenshot_1496770057](https://user-images.githubusercontent.com/5156340/26842769-3c867c12-4aee-11e7-8b9e-a540e36e2c4a.png)
![screenshot_1496770053](https://user-images.githubusercontent.com/5156340/26842768-3c84cd72-4aee-11e7-8f61-747fa58d9a8f.png)

Didn't finish as I'm not sure about this. In finished implementation filters/sort orders should update when changing pages. This could be confusing...