### PR TITLE
Add loading of all and participating notifications

### DIFF
--- a/app/src/main/java/com/gh4a/activities/home/NotificationListFactory.java
+++ b/app/src/main/java/com/gh4a/activities/home/NotificationListFactory.java
@@ -8,7 +8,9 @@ import com.gh4a.fragment.NotificationListFragment;
 
 public class NotificationListFactory extends FragmentFactory {
     private static final int[] TAB_TITLES =  new int[] {
-        R.string.notifications
+            R.string.unread,
+            R.string.repo_type_all,
+            R.string.participating
     };
 
     protected NotificationListFactory(HomeActivity activity) {
@@ -27,6 +29,8 @@ public class NotificationListFactory extends FragmentFactory {
 
     @Override
     protected Fragment makeFragment(int position) {
-        return NotificationListFragment.newInstance();
+        boolean all = position == 1;
+        boolean participating = position == 2;
+        return NotificationListFragment.newInstance(all, participating);
     }
 }

--- a/app/src/main/java/com/gh4a/activities/home/NotificationListFactory.java
+++ b/app/src/main/java/com/gh4a/activities/home/NotificationListFactory.java
@@ -8,7 +8,7 @@ import com.gh4a.fragment.NotificationListFragment;
 
 public class NotificationListFactory extends FragmentFactory {
     private static final int[] TAB_TITLES =  new int[] {
-            R.string.notifications,
+        R.string.notifications
     };
 
     protected NotificationListFactory(HomeActivity activity) {

--- a/app/src/main/java/com/gh4a/activities/home/NotificationListFactory.java
+++ b/app/src/main/java/com/gh4a/activities/home/NotificationListFactory.java
@@ -8,9 +8,7 @@ import com.gh4a.fragment.NotificationListFragment;
 
 public class NotificationListFactory extends FragmentFactory {
     private static final int[] TAB_TITLES =  new int[] {
-            R.string.unread,
-            R.string.repo_type_all,
-            R.string.participating
+            R.string.notifications,
     };
 
     protected NotificationListFactory(HomeActivity activity) {
@@ -29,8 +27,6 @@ public class NotificationListFactory extends FragmentFactory {
 
     @Override
     protected Fragment makeFragment(int position) {
-        boolean all = position == 1;
-        boolean participating = position == 2;
-        return NotificationListFragment.newInstance(all, participating);
+        return NotificationListFragment.newInstance();
     }
 }

--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -39,15 +39,20 @@ import java.util.Date;
 
 public class NotificationListFragment extends LoadingListFragmentBase implements
         RootAdapter.OnItemClickListener<NotificationHolder>,NotificationAdapter.OnNotificationActionCallback {
-    public static NotificationListFragment newInstance() {
-        return new NotificationListFragment();
+    public static NotificationListFragment newInstance(boolean all, boolean participating) {
+        NotificationListFragment fragment = new NotificationListFragment();
+        Bundle args = new Bundle();
+        args.putBoolean("all", all);
+        args.putBoolean("participating", participating);
+        fragment.setArguments(args);
+        return fragment;
     }
 
     private final LoaderCallbacks<NotificationListLoadResult> mNotificationsCallback =
             new LoaderCallbacks<NotificationListLoadResult>(this) {
         @Override
         protected Loader<LoaderResult<NotificationListLoadResult>> onCreateLoader() {
-            return new NotificationListLoader(getContext());
+            return new NotificationListLoader(getContext(), mAll, mParticipating);
         }
 
         @Override
@@ -67,6 +72,8 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
     private Date mNotificationsLoadTime;
     private MenuItem mMarkAllAsReadMenuItem;
     private ParentCallback mCallback;
+    private boolean mAll;
+    private boolean mParticipating;
 
     public interface ParentCallback {
         void setNotificationsIndicatorVisible(boolean visible);
@@ -87,6 +94,10 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
+
+        Bundle args = getArguments();
+        mAll = args.getBoolean("all");
+        mParticipating = args.getBoolean("participating");
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -39,11 +39,9 @@ import java.util.Date;
 
 public class NotificationListFragment extends LoadingListFragmentBase implements
         RootAdapter.OnItemClickListener<NotificationHolder>,NotificationAdapter.OnNotificationActionCallback {
-    public static NotificationListFragment newInstance(boolean all, boolean participating) {
+    public static NotificationListFragment newInstance() {
         NotificationListFragment fragment = new NotificationListFragment();
         Bundle args = new Bundle();
-        args.putBoolean("all", all);
-        args.putBoolean("participating", participating);
         fragment.setArguments(args);
         return fragment;
     }
@@ -96,10 +94,6 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
-
-        Bundle args = getArguments();
-        mAll = args.getBoolean("all");
-        mParticipating = args.getBoolean("participating");
     }
 
     @Override
@@ -178,7 +172,8 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
+        int itemId = item.getItemId();
+        switch (itemId) {
             case R.id.mark_all_as_read:
                 new AlertDialog.Builder(getActivity())
                         .setMessage(R.string.mark_all_as_read_question)
@@ -192,9 +187,28 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
                         .setNegativeButton(R.string.cancel, null)
                         .show();
                 return true;
+            case R.id.notification_filter_unread:
+            case R.id.notification_filter_all:
+            case R.id.notification_filter_participating:
+                mAll = itemId == R.id.notification_filter_all;
+                mParticipating = itemId == R.id.notification_filter_participating;
+                item.setChecked(true);
+                reloadNotification();
+                return true;
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    private void reloadNotification() {
+        if (mAdapter != null) {
+            mAdapter.clear();
+        }
+        setContentShown(false);
+        updateMenuItemVisibility();
+
+        getLoaderManager().destroyLoader(0);
+        getLoaderManager().initLoader(0, null, mNotificationsCallback);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -64,7 +64,9 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
             mAdapter.notifyDataSetChanged();
             updateEmptyState();
             updateMenuItemVisibility();
-            mCallback.setNotificationsIndicatorVisible(!result.notifications.isEmpty());
+            if (!mAll && !mParticipating) {
+                mCallback.setNotificationsIndicatorVisible(!result.notifications.isEmpty());
+            }
         }
     };
 
@@ -235,7 +237,9 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
 
     private void markAsRead(Repository repository, Notification notification) {
         if (mAdapter.markAsRead(repository, notification)) {
-            mCallback.setNotificationsIndicatorVisible(false);
+            if (!mAll && !mParticipating) {
+                mCallback.setNotificationsIndicatorVisible(false);
+            }
         }
         updateMenuItemVisibility();
     }

--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -40,10 +40,7 @@ import java.util.Date;
 public class NotificationListFragment extends LoadingListFragmentBase implements
         RootAdapter.OnItemClickListener<NotificationHolder>,NotificationAdapter.OnNotificationActionCallback {
     public static NotificationListFragment newInstance() {
-        NotificationListFragment fragment = new NotificationListFragment();
-        Bundle args = new Bundle();
-        fragment.setArguments(args);
-        return fragment;
+        return new NotificationListFragment();
     }
 
     private final LoaderCallbacks<NotificationListLoadResult> mNotificationsCallback =

--- a/app/src/main/java/com/gh4a/loader/HasNotificationsLoader.java
+++ b/app/src/main/java/com/gh4a/loader/HasNotificationsLoader.java
@@ -20,7 +20,7 @@ public class HasNotificationsLoader extends BaseLoader<Boolean> {
     public Boolean doLoadInBackground() throws IOException {
         NotificationService notificationService = (NotificationService)
                 Gh4Application.get().getService(Gh4Application.NOTIFICATION_SERVICE);
-        PageIterator<Notification> notifications = notificationService.pageNotifications(1);
+        PageIterator<Notification> notifications = notificationService.pageNotifications(1, false, false);
         return notifications.hasNext() && !notifications.next().isEmpty();
     }
 }

--- a/app/src/main/java/com/gh4a/loader/NotificationHolder.java
+++ b/app/src/main/java/com/gh4a/loader/NotificationHolder.java
@@ -24,6 +24,7 @@ public class NotificationHolder {
     public NotificationHolder(@NonNull Notification notification) {
         this.notification = notification;
         repository = notification.getRepository();
+        mRead = !notification.isUnread();
     }
 
     public boolean isLastRepositoryNotification() {

--- a/app/src/main/res/menu/notification_list_menu.xml
+++ b/app/src/main/res/menu/notification_list_menu.xml
@@ -1,9 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+      xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/mark_all_as_read"
         android:icon="@drawable/mark_read_all_white"
         android:title="@string/mark_all_as_read"
         app:showAsAction="always" />
+
+    <item
+        android:id="@+id/notifications_type"
+        android:icon="@drawable/filter"
+        android:title="@string/issue_filter"
+        app:showAsAction="ifRoom">
+
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                    android:id="@+id/notification_filter_unread"
+                    android:checked="true"
+                    android:title="@string/unread" />
+                <item
+                    android:id="@+id/notification_filter_all"
+                    android:title="@string/repo_type_all" />
+                <item
+                    android:id="@+id/notification_filter_participating"
+                    android:title="@string/participating" />
+            </group>
+        </menu>
+    </item>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="browser_logout_completed_dialog_text">You can now proceed in the login process for the new account.</string>
     <string name="go_to_logout_page">Go to logout page</string>
     <string name="continue_login">Continue new login</string>
+    <string name="unread">Unread</string>
 
     <string name="reaction_plus_one" translatable="false">+1</string>
     <string name="reaction_minus_one" translatable="false">-1</string>

--- a/github-api/src/main/java/org/eclipse/egit/github/core/service/NotificationService.java
+++ b/github-api/src/main/java/org/eclipse/egit/github/core/service/NotificationService.java
@@ -49,6 +49,10 @@ public class NotificationService extends GitHubService {
 	 */
 	public static final String FIELD_IGNORED = "ignored";
 
+	public static final String FIELD_ALL = "all";
+
+	public  static final String FIELD_PARTICIPATING = "participating";
+
 	/**
 	 * Notification reason for being assigned to the issue
 	 */
@@ -118,27 +122,32 @@ public class NotificationService extends GitHubService {
 	 * @return non-null but possibly empty list of notifications
 	 * @throws IOException if something went wrong
 	 */
-	public List<Notification> getNotifications() throws IOException {
-		return getAll(pageNotifications());
+	public List<Notification> getNotifications(boolean all,
+			boolean participating) throws IOException {
+		return getAll(pageNotifications(all, participating));
 	}
 
 	/**
 	 * Page notifications for currently authenticated user
 	 *
 	 * @return iterator over pages of notifications
+	 ** @param all
+	 *** @param participating
 	 */
-	public PageIterator<Notification> pageNotifications() {
-		return pageNotifications(PAGE_SIZE);
+	public PageIterator<Notification> pageNotifications(boolean all, boolean participating) {
+		return pageNotifications(PAGE_SIZE, all, participating);
 	}
 
 	/**
 	 * Page notifications for currently authenticated user
 	 *
 	 * @param size the number of pages
-	 * @return iterator over pages of notifications
+	 * @param all
+	 **@param participating @return iterator over pages of notifications
 	 */
-	public PageIterator<Notification> pageNotifications(int size) {
-		return pageNotifications(PAGE_FIRST, size);
+	public PageIterator<Notification> pageNotifications(int size, boolean all,
+			boolean participating) {
+		return pageNotifications(PAGE_FIRST, size, all, participating);
 	}
 
 	/**
@@ -146,13 +155,21 @@ public class NotificationService extends GitHubService {
 	 *
 	 * @param start the number of first page to load
 	 * @param size  the number of pages
-	 * @return iterator over pages of notifications
+	 * @param all
+	 *@param participating @return iterator over pages of notifications
 	 */
-	public PageIterator<Notification> pageNotifications(int start, int size) {
+	public PageIterator<Notification> pageNotifications(int start, int size, boolean all,
+			boolean participating) {
 		PagedRequest<Notification> request = createPagedRequest(start, size);
 		request.setUri(SEGMENT_NOTIFICATIONS);
 		request.setType(new TypeToken<List<Notification>>() {
 		}.getType());
+
+		Map<String, String> params = new HashMap<>();
+		params.put(FIELD_ALL, String.valueOf(all));
+		params.put(FIELD_PARTICIPATING, String.valueOf(participating));
+		request.setParams(params);
+
 		return createPageIterator(request);
 	}
 


### PR DESCRIPTION
Added as fragment tabs but maybe it is better to use filters in the right drawer. Switching to other tabs would be rare so there is no need to waste data by loading all the tabs when you enter notifications screen just to see unread notifications. Alternatively, maybe there is a way to not load data in other fragments until you switch to them?