### PR TITLE
Fix search expanded state being restored incorrectly

### DIFF
--- a/app/src/main/java/com/gh4a/activities/IssueListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueListActivity.java
@@ -237,8 +237,8 @@ public class IssueListActivity extends BasePagerActivity implements
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState, PersistableBundle outPersistentState) {
-        super.onSaveInstanceState(outState, outPersistentState);
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
         outState.putString(STATE_KEY_SEARCH_QUERY, mSearchQuery);
         outState.putBoolean(STATE_KEY_SEARCH_MODE, mSearchMode);
     }

--- a/app/src/main/java/com/gh4a/activities/IssueListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueListActivity.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.PersistableBundle;
 import android.support.annotation.StringRes;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
@@ -90,6 +89,7 @@ public class IssueListActivity extends BasePagerActivity implements
     private String mSelectedAssignee;
     private String mSearchQuery;
     private boolean mSearchMode;
+    private boolean mSearchIsExpanded;
     private int mSelectedParticipatingStatus = 0;
 
     private FloatingActionButton mCreateFab;
@@ -104,6 +104,7 @@ public class IssueListActivity extends BasePagerActivity implements
 
     private static final String STATE_KEY_SEARCH_QUERY = "search_query";
     private static final String STATE_KEY_SEARCH_MODE = "search_mode";
+    private static final String STATE_KEY_SEARCH_IS_EXPANDED = "search_is_expanded";
 
     private static final String LIST_QUERY = "is:%s %s repo:%s/%s %s %s %s %s";
     private static final String SEARCH_QUERY = "is:%s %s repo:%s/%s %s";
@@ -194,6 +195,7 @@ public class IssueListActivity extends BasePagerActivity implements
         if (savedInstanceState != null) {
             mSearchQuery = savedInstanceState.getString(STATE_KEY_SEARCH_QUERY);
             mSearchMode = savedInstanceState.getBoolean(STATE_KEY_SEARCH_MODE);
+            mSearchIsExpanded = savedInstanceState.getBoolean(STATE_KEY_SEARCH_IS_EXPANDED);
         }
 
         if (!mIsPullRequest && Gh4Application.get().isAuthorized()) {
@@ -241,6 +243,7 @@ public class IssueListActivity extends BasePagerActivity implements
         super.onSaveInstanceState(outState);
         outState.putString(STATE_KEY_SEARCH_QUERY, mSearchQuery);
         outState.putBoolean(STATE_KEY_SEARCH_MODE, mSearchMode);
+        outState.putBoolean(STATE_KEY_SEARCH_IS_EXPANDED, mSearchIsExpanded);
     }
 
     @Override
@@ -396,7 +399,7 @@ public class IssueListActivity extends BasePagerActivity implements
         MenuItemCompat.setOnActionExpandListener(searchItem, this);
 
         final SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-        if (mSearchQuery != null) {
+        if (mSearchIsExpanded) {
             MenuItemCompat.expandActionView(searchItem);
             searchView.setQuery(mSearchQuery, false);
         }
@@ -417,11 +420,13 @@ public class IssueListActivity extends BasePagerActivity implements
 
     @Override
     public boolean onMenuItemActionExpand(MenuItem item) {
+        mSearchIsExpanded = true;
         return true;
     }
 
     @Override
     public boolean onMenuItemActionCollapse(MenuItem item) {
+        mSearchIsExpanded = false;
         mSearchQuery = null;
         setSearchMode(false);
         return true;
@@ -429,6 +434,7 @@ public class IssueListActivity extends BasePagerActivity implements
 
     @Override
     public boolean onClose() {
+        mSearchIsExpanded = false;
         mSearchQuery = null;
         setSearchMode(false);
         return true;

--- a/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
@@ -59,6 +59,7 @@ public class RepositoryListContainerFragment extends Fragment implements
     private RepositorySearchFragment mSearchFragment;
     private MenuItem mFilterItem;
     private String mSearchQuery;
+    private boolean mSearchIsExpanded;
 
     public interface Callback {
         void initiateFilter();
@@ -69,6 +70,7 @@ public class RepositoryListContainerFragment extends Fragment implements
     private static final String STATE_KEY_SORT_DIRECTION = "sort_direction";
     private static final String STATE_KEY_SEARCH_VISIBLE = "search_visible";
     private static final String STATE_KEY_QUERY = "search_query";
+    private static final String STATE_KEY_SEARCH_IS_EXPANDED = "search_is_expanded";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -83,6 +85,7 @@ public class RepositoryListContainerFragment extends Fragment implements
             mSortDirection = savedInstanceState.getString(STATE_KEY_SORT_DIRECTION);
             mSearchVisible = savedInstanceState.getBoolean(STATE_KEY_SEARCH_VISIBLE);
             mSearchQuery = savedInstanceState.getString(STATE_KEY_QUERY);
+            mSearchIsExpanded = savedInstanceState.getBoolean(STATE_KEY_SEARCH_IS_EXPANDED);
         }
 
         setHasOptionsMenu(true);
@@ -146,6 +149,7 @@ public class RepositoryListContainerFragment extends Fragment implements
         outState.putString(STATE_KEY_SORT_DIRECTION, mSortDirection);
         outState.putBoolean(STATE_KEY_SEARCH_VISIBLE, mSearchVisible);
         outState.putString(STATE_KEY_QUERY, mSearchQuery);
+        outState.putBoolean(STATE_KEY_SEARCH_IS_EXPANDED, mSearchIsExpanded);
     }
 
     public void setFilterType(String type) {
@@ -245,7 +249,7 @@ public class RepositoryListContainerFragment extends Fragment implements
             MenuItemCompat.setOnActionExpandListener(searchItem, this);
 
             final SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
-            if (mSearchQuery != null) {
+            if (mSearchIsExpanded) {
                 MenuItemCompat.expandActionView(searchItem);
                 searchView.setQuery(mSearchQuery, false);
             }
@@ -311,6 +315,7 @@ public class RepositoryListContainerFragment extends Fragment implements
 
     @Override
     public boolean onClose() {
+        mSearchIsExpanded = false;
         mSearchQuery = null;
         setSearchVisibility(false);
         return false;
@@ -318,11 +323,13 @@ public class RepositoryListContainerFragment extends Fragment implements
 
     @Override
     public boolean onMenuItemActionExpand(MenuItem item) {
+        mSearchIsExpanded = true;
         return true;
     }
 
     @Override
     public boolean onMenuItemActionCollapse(MenuItem item) {
+        mSearchIsExpanded = false;
         mSearchQuery = null;
         setSearchVisibility(false);
         return true;


### PR DESCRIPTION
The expanded state was restored based on whether the search query was set to `null` or not. This method was not working correctly due to one issue: After collapsing, the search view's `onQueryTextChange` method was called again with an empty string as a parameter value, which in turn resulted in search view getting incorrectly expanded after restoring the state.

The solution was to add another field which tracks whether the search view should be expanded separately from the value of the search query.

Closes #594