### PR TITLE
Add open in browser action to release list and release info screens

### DIFF
--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -17,12 +17,15 @@ package com.gh4a.activities;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.content.Loader;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -38,6 +41,7 @@ import com.gh4a.loader.ReleaseLoader;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.AvatarHandler;
 import com.gh4a.utils.HttpImageGetter;
+import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.StringUtils;
 import com.gh4a.utils.UiUtils;
 import com.gh4a.widget.StyleableTextView;
@@ -128,6 +132,21 @@ public class ReleaseInfoActivity extends BaseActivity implements
         mRepoName = extras.getString("repo");
         mRelease = (Release) extras.getSerializable("release");
         mReleaseId = extras.getLong("id");
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.release, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.browser) {
+            IntentUtils.launchBrowser(this, Uri.parse(mRelease.getHtmlUrl()));
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/res/menu/release.xml
+++ b/app/src/main/res/menu/release.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/browser"
+        android:icon="@drawable/web_site"
+        android:title="@string/open_in_browser"
+        app:showAsAction="never" />
+</menu>


### PR DESCRIPTION
I've decided to set showAsAction to "never" as opening in browser is not a common action and I prefer the more minimal look of the toolbar when it displays only 3-dots icon.

Closes #633