### PR TITLE
Fix crash when reactions update after leaving activity

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -20,6 +20,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Typeface;
 import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.RecyclerView;
@@ -436,7 +437,12 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         }
         if (mReactionMenuHelper != null) {
             mReactionMenuHelper.update();
-            getActivity().supportInvalidateOptionsMenu();
+            FragmentActivity activity = getActivity();
+            if (activity != null) {
+                // The activity could be already destroyed when this method is called because
+                // it is executed from background AsyncTask.
+                activity.supportInvalidateOptionsMenu();
+            }
         }
     }
 


### PR DESCRIPTION
A basic solution with if statement. It does fix the problem but there is a possibility that similar crash could occur in other `onReactionsUpdated` listeners.

It would be better to somehow cancel the [FetchReactionTask](https://github.com/slapperwan/gh4a/blob/f734ec952f7c2a4e39f436748d9e0c1160c78856/app/src/main/java/com/gh4a/widget/ReactionBar.java#L396) and ToggleReactionTask when the activity is destroyed but I'm not sure how to implement that in a clean way.

Closes #662