### PR TITLE
Refactor link parsing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,8 @@ dependencies {
     playstoreCompile('com.crashlytics.sdk.android:crashlytics:2.6.5@aar') {
         transitive = true;
     }
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.robolectric:robolectric:3.4.2'
 }
 
 def Properties props = new Properties()

--- a/app/src/main/java/com/gh4a/resolver/BrowseFilter.java
+++ b/app/src/main/java/com/gh4a/resolver/BrowseFilter.java
@@ -5,32 +5,10 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.text.TextUtils;
 
 import com.gh4a.Gh4Application;
 import com.gh4a.R;
-import com.gh4a.activities.BlogListActivity;
-import com.gh4a.activities.CommitActivity;
-import com.gh4a.activities.DownloadsActivity;
-import com.gh4a.activities.GistActivity;
-import com.gh4a.activities.IssueActivity;
-import com.gh4a.activities.IssueEditActivity;
-import com.gh4a.activities.IssueListActivity;
-import com.gh4a.activities.OrganizationMemberListActivity;
-import com.gh4a.activities.PullRequestActivity;
-import com.gh4a.activities.ReleaseListActivity;
-import com.gh4a.activities.RepositoryActivity;
-import com.gh4a.activities.TrendingActivity;
-import com.gh4a.activities.UserActivity;
-import com.gh4a.activities.WikiListActivity;
 import com.gh4a.utils.IntentUtils;
-import com.gh4a.utils.StringUtils;
-
-import org.eclipse.egit.github.core.client.IGitHubConstants;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class BrowseFilter extends AppCompatActivity {
     public static Intent makeRedirectionIntent(Context context, Uri uri,
@@ -40,11 +18,6 @@ public class BrowseFilter extends AppCompatActivity {
         intent.putExtra("initial_comment", initialComment);
         return intent;
     }
-
-    private static final List<String> RESERVED_NAMES = Arrays.asList(
-        "apps", "integrations", "login", "logout",
-        "marketplace", "sessions", "settings", "updates"
-    );
 
     public void onCreate(Bundle savedInstanceState) {
         setTheme(Gh4Application.THEME == R.style.DarkTheme
@@ -58,269 +31,22 @@ public class BrowseFilter extends AppCompatActivity {
             return;
         }
 
-        List<String> parts = new ArrayList<>(uri.getPathSegments());
-        Intent intent = null;
-
-        String first = parts.isEmpty() ? null : parts.get(0);
-        if (IGitHubConstants.HOST_GISTS.equals(uri.getHost())) {
-            if (!parts.isEmpty()) {
-                intent = GistActivity.makeIntent(this, parts.get(parts.size() - 1));
-            }
-        } else if (RESERVED_NAMES.contains(first)) { //noinspection StatementWithEmptyBody
-            // forward to browser
-        } else if ("explore".equals(first)) {
-            intent = new Intent(this, TrendingActivity.class);
-        } else if ("blog".equals(first)) {
-            if (parts.size() == 1) {
-                intent = new Intent(this, BlogListActivity.class);
-            }
-        } else if ("orgs".equals(first)) {
-            String org = parts.size() >= 2 ? parts.get(1) : null;
-            String action = parts.size() >= 3 ? parts.get(2) : null;
-
-            if (org != null) {
-                if (action == null) {
-                    intent = UserActivity.makeIntent(this, org);
-                } else if ("people".equals(action)) {
-                    intent = OrganizationMemberListActivity.makeIntent(this, org);
-                }
-            }
-        } else if (first != null) {
-            String user = first;
-            String repo = parts.size() >= 2 ? parts.get(1) : null;
-            String action = parts.size() >= 3 ? parts.get(2) : null;
-            String id = parts.size() >= 4 ? parts.get(3) : null;
-
-            if (repo == null && action == null) {
-                String tab = uri.getQueryParameter("tab");
-                if (tab != null) {
-                    switch (tab) {
-                        case "repositories":
-                            new UserReposLoadTask(this, user, false).execute();
-                            return; // avoid finish() for now
-                        case "stars":
-                            new UserReposLoadTask(this, user, true).execute();
-                            return; // avoid finish() for now
-                        case "followers":
-                            new UserFollowersLoadTask(this, user, true).execute();
-                            return; // avoid finish() for now
-                        case "following":
-                            new UserFollowersLoadTask(this, user, false).execute();
-                            return; // avoid finish() for now
-                        default:
-                            intent = UserActivity.makeIntent(this, user);
-                            break;
-                    }
-                } else {
-                    intent = UserActivity.makeIntent(this, user);
-                }
-            } else if (action == null) {
-                intent = RepositoryActivity.makeIntent(this, user, repo);
-            } else if ("downloads".equals(action)) {
-                intent = DownloadsActivity.makeIntent(this, user, repo);
-            } else if ("releases".equals(action)) {
-                if ("tag".equals(id)) {
-                    final String release = parts.size() >= 5 ? parts.get(4) : null;
-                    new ReleaseLoadTask(this, user, repo, release).execute();
-                    return; // avoid finish() for now
-                } else {
-                    intent = ReleaseListActivity.makeIntent(this, user, repo);
-                }
-            } else if ("tree".equals(action) || "commits".equals(action)) {
-                int page = "tree".equals(action)
-                        ? RepositoryActivity.PAGE_FILES : RepositoryActivity.PAGE_COMMITS;
-                int refStart = 3;
-                if (parts.size() >= 6
-                        && TextUtils.equals(parts.get(3), "refs")
-                        && TextUtils.equals(parts.get(4), "heads")) {
-                    refStart = 5;
-                }
-                String refAndPath = TextUtils.join("/", parts.subList(refStart, parts.size()));
-                new RefPathDisambiguationTask(this, user, repo, refAndPath, page).execute();
-                return; // avoid finish() for now
-            } else if ("issues".equals(action)) {
-                if (!StringUtils.isBlank(id)) {
-                    if ("new".equals(id)) {
-                        intent = IssueEditActivity.makeCreateIntent(this, user, repo);
-                    } else {
-                        try {
-                            intent = IssueActivity.makeIntent(this, user, repo,
-                                    Integer.parseInt(id),
-                                    generateInitialCommentMarker(uri.getFragment(), "issuecomment-"));
-                        } catch (NumberFormatException e) {
-                            // ignored
-                        }
-                    }
-                } else {
-                    intent = IssueListActivity.makeIntent(this, user, repo);
-                }
-            } else if ("pulls".equals(action)) {
-                intent = IssueListActivity.makeIntent(this, user, repo, true);
-            } else if ("wiki".equals(action)) {
-                intent = WikiListActivity.makeIntent(this, user, repo, null);
-            } else if ("pull".equals(action) && !StringUtils.isBlank(id)) {
-                int pullRequestNumber = -1;
-                try {
-                    pullRequestNumber = Integer.parseInt(id);
-                } catch (NumberFormatException e) {
-                    // ignored
-                }
-
-                if (pullRequestNumber > 0) {
-                    DiffHighlightId diffId = extractDiffId(uri.getFragment(), "diff-", true);
-
-                    if (diffId != null) {
-                        new PullRequestDiffLoadTask(this, user, repo, diffId, pullRequestNumber
-                        )
-                                .execute();
-                        return; // avoid finish() for now
-                    } else {
-                        String target = parts.size() >= 5 ? parts.get(4) : null;
-                        int page = "commits".equals(target) ? PullRequestActivity.PAGE_COMMITS
-                                : "files".equals(target) ? PullRequestActivity.PAGE_FILES : -1;
-                        IntentUtils.InitialCommentMarker initialDiffComment =
-                                generateInitialCommentMarkerWithoutFallback(uri.getFragment(), "r");
-                        if (initialDiffComment != null) {
-                            new PullRequestDiffCommentLoadTask(this, user, repo, pullRequestNumber,
-                                    initialDiffComment, page).execute();
-                            return; // avoid finish() for now
-                        }
-
-                        IntentUtils.InitialCommentMarker reviewMarker =
-                                generateInitialCommentMarkerWithoutFallback(uri.getFragment(),
-                                        "pullrequestreview-");
-                        if (reviewMarker != null) {
-                            new PullRequestReviewLoadTask(this, user, repo, pullRequestNumber,
-                                    reviewMarker).execute();
-                            return; // avoid finish() for now
-                        }
-
-                        IntentUtils.InitialCommentMarker reviewCommentMarker =
-                                generateInitialCommentMarkerWithoutFallback(uri.getFragment(),
-                                        "discussion_r");
-                        if (reviewCommentMarker != null) {
-                            new PullRequestReviewCommentLoadTask(this, user, repo,
-                                    pullRequestNumber, reviewCommentMarker, true).execute();
-                            return; // avoid finish() for now
-                        }
-
-                        DiffHighlightId reviewDiffHunkId =
-                                extractDiffId(uri.getFragment(), "discussion-diff-", false);
-                        if (reviewDiffHunkId != null) {
-                            new PullRequestReviewDiffLoadTask(this, user, repo, reviewDiffHunkId,
-                                    pullRequestNumber).execute();
-                            return; // avoid finish() for now
-                        }
-
-                        IntentUtils.InitialCommentMarker initialComment =
-                                generateInitialCommentMarker(uri.getFragment(), "issuecomment-");
-                        intent = PullRequestActivity.makeIntent(this, user, repo, pullRequestNumber,
-                                page, initialComment);
-                    }
-                }
-            } else if ("commit".equals(action) && !StringUtils.isBlank(id)) {
-                DiffHighlightId diffId = extractDiffId(uri.getFragment(), "diff-", true);
-                if (diffId != null) {
-                    new CommitDiffLoadTask(this, user, repo, diffId, id).execute();
-                    return; // avoid finish() for now
-                } else {
-                    IntentUtils.InitialCommentMarker initialComment =
-                            generateInitialCommentMarker(uri.getFragment(), "commitcomment-");
-                    if (initialComment != null) {
-                        new CommitCommentLoadTask(this, user, repo, id, initialComment, true)
-                                .execute();
-                        return; // avoid finish() for now
-                    }
-                    intent = CommitActivity.makeIntent(this, user, repo, id, null);
-                }
-            } else if ("blob".equals(action) && !StringUtils.isBlank(id) && parts.size() >= 4) {
-                String refAndPath = TextUtils.join("/", parts.subList(3, parts.size()));
-                new RefPathDisambiguationTask(this, user, repo, refAndPath, uri.getFragment()
-                ).execute();
-                return; // avoid finish() for now
-            }
-        }
-        if (intent != null) {
-            startActivity(intent);
-        } else {
+        LinkParser.ParseResult result = LinkParser.parseUri(this, uri);
+        if (result == null) {
             IntentUtils.launchBrowser(this, uri);
-        }
-        finish();
-    }
-
-    private IntentUtils.InitialCommentMarker generateInitialCommentMarkerWithoutFallback(
-            String fragment, String prefix) {
-        if (fragment != null && fragment.startsWith(prefix)) {
-            try {
-                long commentId = Long.parseLong(fragment.substring(prefix.length()));
-                return new IntentUtils.InitialCommentMarker(commentId);
-            } catch (NumberFormatException e) {
-                // fall through
-            }
-        }
-        return null;
-    }
-
-    private IntentUtils.InitialCommentMarker generateInitialCommentMarker(String fragment,
-            String prefix) {
-        IntentUtils.InitialCommentMarker initialCommentMarker =
-                generateInitialCommentMarkerWithoutFallback(fragment, prefix);
-        if (initialCommentMarker == null) {
-            return getIntent().getParcelableExtra("initial_comment");
-        }
-        return initialCommentMarker;
-    }
-
-    private DiffHighlightId extractDiffId(String fragment, String prefix, boolean isMd5Hash) {
-        if (fragment == null || !fragment.startsWith(prefix)) {
-            return null;
+            finish();
+            return;
         }
 
-        boolean right = false;
-        int typePos = fragment.indexOf('L', prefix.length());
-        if (typePos < 0) {
-            right = true;
-            typePos = fragment.indexOf('R', prefix.length());
+        if (result.intent != null) {
+            startActivity(result.intent);
+            finish();
+            return;
         }
 
-        String fileHash = typePos > 0
-                ? fragment.substring(prefix.length(), typePos)
-                : fragment.substring(prefix.length());
-        if (isMd5Hash && fileHash.length() != 32) { // MD5 hash length
-            return null;
-        }
-        if (typePos < 0) {
-            return new DiffHighlightId(fileHash, -1, -1, false);
-        }
+        //noinspection ConstantConditions
+        result.loadTask.execute();
 
-        try {
-            char type = fragment.charAt(typePos);
-            String linePart = fragment.substring(typePos + 1);
-            int startLine, endLine, dashPos = linePart.indexOf("-" + type);
-            if (dashPos > 0) {
-                startLine = Integer.valueOf(linePart.substring(0, dashPos));
-                endLine = Integer.valueOf(linePart.substring(dashPos + 2));
-            } else {
-                startLine = Integer.valueOf(linePart);
-                endLine = startLine;
-            }
-            return new DiffHighlightId(fileHash, startLine, endLine, right);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    public static class DiffHighlightId {
-        public final String fileHash;
-        public final int startLine;
-        public final int endLine;
-        public final boolean right;
-
-        public DiffHighlightId(String fileHash, int startLine, int endLine, boolean right) {
-            this.fileHash = fileHash;
-            this.startLine = startLine;
-            this.endLine = endLine;
-            this.right = right;
-        }
+        // Avoid finish() for now
     }
 }

--- a/app/src/main/java/com/gh4a/resolver/CommitCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitCommentLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.activities.CommitActivity;
@@ -17,10 +18,14 @@ import org.eclipse.egit.github.core.RepositoryCommit;
 import java.util.List;
 
 public class CommitCommentLoadTask extends UrlLoadTask {
-    private final String mRepoOwner;
-    private final String mRepoName;
-    private final String mCommitSha;
-    private final IntentUtils.InitialCommentMarker mMarker;
+    @VisibleForTesting
+    protected final String mRepoOwner;
+    @VisibleForTesting
+    protected final String mRepoName;
+    @VisibleForTesting
+    protected final String mCommitSha;
+    @VisibleForTesting
+    protected final IntentUtils.InitialCommentMarker mMarker;
 
     public CommitCommentLoadTask(FragmentActivity activity, String repoOwner, String repoName,
             String commitSha, IntentUtils.InitialCommentMarker marker,

--- a/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.activities.CommitDiffViewerActivity;
@@ -14,17 +15,18 @@ import org.eclipse.egit.github.core.RepositoryCommit;
 import java.util.List;
 
 public class CommitDiffLoadTask extends DiffLoadTask {
-    private String mSha;
+    @VisibleForTesting
+    protected String mSha;
 
     public CommitDiffLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            BrowseFilter.DiffHighlightId diffId, String sha) {
+            DiffHighlightId diffId, String sha) {
         super(activity, repoOwner, repoName, diffId);
         mSha = sha;
     }
 
     @Override
-    protected Intent getLaunchIntent(String sha, CommitFile file,
-            List<CommitComment> comments, BrowseFilter.DiffHighlightId diffId) {
+    protected Intent getLaunchIntent(String sha, CommitFile file, List<CommitComment> comments,
+            DiffHighlightId diffId) {
         return CommitDiffViewerActivity.makeIntent(mActivity, mRepoOwner, mRepoName,
                 sha, file.getFilename(), file.getPatch(), comments, diffId.startLine,
                 diffId.endLine, diffId.right, null);

--- a/app/src/main/java/com/gh4a/resolver/DiffHighlightId.java
+++ b/app/src/main/java/com/gh4a/resolver/DiffHighlightId.java
@@ -1,0 +1,15 @@
+package com.gh4a.resolver;
+
+public class DiffHighlightId {
+    public final String fileHash;
+    public final int startLine;
+    public final int endLine;
+    public final boolean right;
+
+    public DiffHighlightId(String fileHash, int startLine, int endLine, boolean right) {
+        this.fileHash = fileHash;
+        this.startLine = startLine;
+        this.endLine = endLine;
+        this.right = right;
+    }
+}

--- a/app/src/main/java/com/gh4a/resolver/DiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/DiffLoadTask.java
@@ -15,10 +15,10 @@ import java.util.List;
 public abstract class DiffLoadTask extends UrlLoadTask {
     protected final String mRepoOwner;
     protected final String mRepoName;
-    protected final BrowseFilter.DiffHighlightId mDiffId;
+    protected final DiffHighlightId mDiffId;
 
     public DiffLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            BrowseFilter.DiffHighlightId diffId) {
+            DiffHighlightId diffId) {
         super(activity);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
@@ -57,5 +57,5 @@ public abstract class DiffLoadTask extends UrlLoadTask {
     protected abstract String getSha() throws Exception;
     protected abstract List<CommitComment> getComments() throws Exception;
     protected abstract Intent getLaunchIntent(String sha, CommitFile file,
-            List<CommitComment> comments, BrowseFilter.DiffHighlightId diffId);
+            List<CommitComment> comments, DiffHighlightId diffId);
 }

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -1,0 +1,406 @@
+package com.gh4a.resolver;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentActivity;
+import android.text.TextUtils;
+
+import com.gh4a.activities.BlogListActivity;
+import com.gh4a.activities.CommitActivity;
+import com.gh4a.activities.DownloadsActivity;
+import com.gh4a.activities.GistActivity;
+import com.gh4a.activities.IssueActivity;
+import com.gh4a.activities.IssueEditActivity;
+import com.gh4a.activities.IssueListActivity;
+import com.gh4a.activities.OrganizationMemberListActivity;
+import com.gh4a.activities.PullRequestActivity;
+import com.gh4a.activities.ReleaseListActivity;
+import com.gh4a.activities.RepositoryActivity;
+import com.gh4a.activities.TrendingActivity;
+import com.gh4a.activities.UserActivity;
+import com.gh4a.activities.WikiListActivity;
+import com.gh4a.utils.IntentUtils;
+import com.gh4a.utils.StringUtils;
+
+import org.eclipse.egit.github.core.client.IGitHubConstants;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class LinkParser {
+    private static final List<String> RESERVED_NAMES = Arrays.asList(
+            "apps", "integrations", "login", "logout",
+            "marketplace", "sessions", "settings", "updates"
+    );
+
+    private LinkParser() {
+    }
+
+    /**
+     * Parses the specified {@code uri} and returns a result which will tell where to redirect the
+     * user.
+     *
+     * @return {@code null} to redirect to browser, {@code ParseResult} with specified {@code
+     * intent} to redirect to activity for that intent or {@code ParseResult} with specified {@code
+     * loadTask} to execute that task in background.
+     */
+    @Nullable
+    public static ParseResult parseUri(FragmentActivity activity, @NonNull Uri uri) {
+        List<String> parts = new ArrayList<>(uri.getPathSegments());
+
+        if (IGitHubConstants.HOST_GISTS.equals(uri.getHost())) {
+            return parseGistLink(activity, parts);
+        }
+
+        if (parts.isEmpty()) {
+            return null;
+        }
+
+        String first = parts.get(0);
+        if (RESERVED_NAMES.contains(first)) {
+            return null;
+        }
+
+        switch (first) {
+            case "explore":
+                return new ParseResult(new Intent(activity, TrendingActivity.class));
+            case "blog":
+                return parseBlogLink(activity, parts);
+            case "orgs":
+                return parseOrganizationLink(activity, parts);
+        }
+
+        //noinspection UnnecessaryLocalVariable
+        String user = first;
+        String repo = parts.size() >= 2 ? parts.get(1) : null;
+        String action = parts.size() >= 3 ? parts.get(2) : null;
+        String id = parts.size() >= 4 ? parts.get(3) : null;
+
+        if (repo == null && action == null) {
+            return parseUserLink(activity, uri, user);
+        }
+
+        if (action == null) {
+            return new ParseResult(RepositoryActivity.makeIntent(activity, user, repo));
+        }
+
+        switch (action) {
+            case "downloads":
+                return new ParseResult(DownloadsActivity.makeIntent(activity, user, repo));
+            case "releases":
+                return parseReleaseLink(activity, parts, user, repo, id);
+            case "tree":
+            case "commits":
+                return parseCommitsLink(activity, parts, user, repo, action);
+            case "issues":
+                return parseIssuesLink(activity, uri, user, repo, id);
+            case "pulls":
+                return new ParseResult(IssueListActivity.makeIntent(activity, user, repo, true));
+            case "wiki":
+                return new ParseResult(WikiListActivity.makeIntent(activity, user, repo, null));
+            case "pull":
+                return parsePullRequestLink(activity, uri, parts, user, repo, id);
+            case "commit":
+                return parseCommitLink(activity, uri, user, repo, id);
+            case "blob":
+                return parseBlobLink(activity, uri, parts, user, repo, id);
+        }
+        return null;
+    }
+
+    @Nullable
+    private static ParseResult parseGistLink(FragmentActivity activity, List<String> parts) {
+        if (!parts.isEmpty()) {
+            String gistId = parts.get(parts.size() - 1);
+            return new ParseResult(GistActivity.makeIntent(activity, gistId));
+        }
+        return null;
+    }
+
+    @Nullable
+    private static ParseResult parseBlogLink(FragmentActivity activity, List<String> parts) {
+        if (parts.size() == 1) {
+            return new ParseResult(new Intent(activity, BlogListActivity.class));
+        }
+        return null;
+    }
+
+    @Nullable
+    private static ParseResult parseOrganizationLink(FragmentActivity activity,
+            List<String> parts) {
+        String org = parts.size() >= 2 ? parts.get(1) : null;
+        String action = parts.size() >= 3 ? parts.get(2) : null;
+
+        if (org == null) {
+            return null;
+        }
+        if ("people".equals(action)) {
+            return new ParseResult(OrganizationMemberListActivity.makeIntent(activity, org));
+        }
+        return new ParseResult(UserActivity.makeIntent(activity, org));
+    }
+
+    @NonNull
+    private static ParseResult parseUserLink(FragmentActivity activity, @NonNull Uri uri,
+            String user) {
+        String tab = uri.getQueryParameter("tab");
+        if (tab != null) {
+            switch (tab) {
+                case "repositories":
+                    return new ParseResult(new UserReposLoadTask(activity, user, false));
+                case "stars":
+                    return new ParseResult(new UserReposLoadTask(activity, user, true));
+                case "followers":
+                    return new ParseResult(new UserFollowersLoadTask(activity, user, true));
+                case "following":
+                    return new ParseResult(new UserFollowersLoadTask(activity, user, false));
+                default:
+                    return new ParseResult(UserActivity.makeIntent(activity, user));
+            }
+        }
+        return new ParseResult(UserActivity.makeIntent(activity, user));
+    }
+
+    @NonNull
+    private static ParseResult parseReleaseLink(FragmentActivity activity, List<String> parts,
+            String user, String repo, String id) {
+        if ("tag".equals(id)) {
+            final String release = parts.size() >= 5 ? parts.get(4) : null;
+            if (release != null) {
+                return new ParseResult(new ReleaseLoadTask(activity, user, repo, release));
+            }
+        }
+        return new ParseResult(ReleaseListActivity.makeIntent(activity, user, repo));
+    }
+
+    @NonNull
+    private static ParseResult parseCommitsLink(FragmentActivity activity, List<String> parts,
+            String user, String repo, String action) {
+        int page = "tree".equals(action)
+                ? RepositoryActivity.PAGE_FILES
+                : RepositoryActivity.PAGE_COMMITS;
+
+        int refStart = 3;
+        if (parts.size() >= 6
+                && TextUtils.equals(parts.get(3), "refs")
+                && TextUtils.equals(parts.get(4), "heads")) {
+            refStart = 5;
+        }
+        String refAndPath = TextUtils.join("/", parts.subList(refStart, parts.size()));
+        return new ParseResult(new RefPathDisambiguationTask(activity, user, repo, refAndPath,
+                page));
+    }
+
+    @Nullable
+    private static ParseResult parseIssuesLink(FragmentActivity activity, @NonNull Uri uri,
+            String user, String repo, String id) {
+        if (StringUtils.isBlank(id)) {
+            return new ParseResult(IssueListActivity.makeIntent(activity, user, repo));
+        }
+        if ("new".equals(id)) {
+            return new ParseResult(IssueEditActivity.makeCreateIntent(activity, user, repo));
+        }
+        try {
+            int issueNumber = Integer.parseInt(id);
+            IntentUtils.InitialCommentMarker initialComment =
+                    generateInitialCommentMarker(activity, uri.getFragment(), "issuecomment-");
+            return new ParseResult(IssueActivity.makeIntent(activity, user, repo, issueNumber,
+                    initialComment));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private static ParseResult parsePullRequestLink(FragmentActivity activity, @NonNull Uri uri,
+            List<String> parts, String user, String repo, String id) {
+        if (StringUtils.isBlank(id)) {
+            return null;
+        }
+
+        int pullRequestNumber;
+        try {
+            pullRequestNumber = Integer.parseInt(id);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        if (pullRequestNumber <= 0) {
+            return null;
+        }
+
+        DiffHighlightId diffId =
+                extractDiffId(uri.getFragment(), "diff-", true);
+
+        if (diffId != null) {
+            return new ParseResult(new PullRequestDiffLoadTask(activity, user, repo, diffId,
+                    pullRequestNumber));
+        }
+
+        String target = parts.size() >= 5 ? parts.get(4) : null;
+        int page = parsePullRequestPage(target);
+
+        IntentUtils.InitialCommentMarker initialDiffComment =
+                generateInitialCommentMarkerWithoutFallback(uri.getFragment(), "r");
+        if (initialDiffComment != null) {
+            return new ParseResult(new PullRequestDiffCommentLoadTask(activity, user, repo,
+                    pullRequestNumber, initialDiffComment, page));
+        }
+
+        IntentUtils.InitialCommentMarker reviewMarker =
+                generateInitialCommentMarkerWithoutFallback(uri.getFragment(),
+                        "pullrequestreview-");
+        if (reviewMarker != null) {
+            return new ParseResult(new PullRequestReviewLoadTask(activity, user, repo,
+                    pullRequestNumber, reviewMarker));
+        }
+
+        IntentUtils.InitialCommentMarker reviewCommentMarker =
+                generateInitialCommentMarkerWithoutFallback(uri.getFragment(),
+                        "discussion_r");
+        if (reviewCommentMarker != null) {
+            return new ParseResult(new PullRequestReviewCommentLoadTask(activity, user, repo,
+                    pullRequestNumber, reviewCommentMarker, true));
+        }
+
+        DiffHighlightId reviewDiffHunkId =
+                extractDiffId(uri.getFragment(), "discussion-diff-", false);
+        if (reviewDiffHunkId != null) {
+            return new ParseResult(new PullRequestReviewDiffLoadTask(activity, user, repo,
+                    reviewDiffHunkId, pullRequestNumber));
+        }
+
+        IntentUtils.InitialCommentMarker initialComment =
+                generateInitialCommentMarker(activity, uri.getFragment(), "issuecomment-");
+        return new ParseResult(PullRequestActivity.makeIntent(activity, user, repo,
+                pullRequestNumber, page, initialComment));
+    }
+
+    private static int parsePullRequestPage(String target) {
+        if (target == null) {
+            return -1;
+        }
+        switch (target) {
+            case "commits":
+                return PullRequestActivity.PAGE_COMMITS;
+            case "files":
+                return PullRequestActivity.PAGE_FILES;
+        }
+        return -1;
+    }
+
+    @Nullable
+    private static ParseResult parseCommitLink(FragmentActivity activity, @NonNull Uri uri,
+            String user, String repo, String id) {
+        if (StringUtils.isBlank(id)) {
+            return null;
+        }
+        DiffHighlightId diffId =
+                extractDiffId(uri.getFragment(), "diff-", true);
+        if (diffId != null) {
+            return new ParseResult(new CommitDiffLoadTask(activity, user, repo, diffId, id));
+        }
+
+        IntentUtils.InitialCommentMarker initialComment =
+                generateInitialCommentMarker(activity, uri.getFragment(), "commitcomment-");
+        if (initialComment != null) {
+            return new ParseResult(new CommitCommentLoadTask(activity, user, repo, id,
+                    initialComment, true));
+        }
+        return new ParseResult(CommitActivity.makeIntent(activity, user, repo, id, null));
+    }
+
+    @Nullable
+    private static ParseResult parseBlobLink(FragmentActivity activity, @NonNull Uri uri,
+            List<String> parts, String user, String repo, String id) {
+        if (StringUtils.isBlank(id) || parts.size() < 4) {
+            return null;
+        }
+        String refAndPath = TextUtils.join("/", parts.subList(3, parts.size()));
+        return new ParseResult(new RefPathDisambiguationTask(activity, user, repo, refAndPath,
+                uri.getFragment()));
+    }
+
+    private static IntentUtils.InitialCommentMarker generateInitialCommentMarkerWithoutFallback(
+            String fragment, String prefix) {
+        if (fragment == null || !fragment.startsWith(prefix)) {
+            return null;
+        }
+        try {
+            long commentId = Long.parseLong(fragment.substring(prefix.length()));
+            return new IntentUtils.InitialCommentMarker(commentId);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static IntentUtils.InitialCommentMarker generateInitialCommentMarker(
+            FragmentActivity activity, String fragment, String prefix) {
+        IntentUtils.InitialCommentMarker initialCommentMarker =
+                generateInitialCommentMarkerWithoutFallback(fragment, prefix);
+        if (initialCommentMarker == null) {
+            return activity.getIntent().getParcelableExtra("initial_comment");
+        }
+        return initialCommentMarker;
+    }
+
+    private static DiffHighlightId extractDiffId(String fragment, String prefix,
+            boolean isMd5Hash) {
+        if (fragment == null || !fragment.startsWith(prefix)) {
+            return null;
+        }
+
+        boolean right = false;
+        int typePos = fragment.indexOf('L', prefix.length());
+        if (typePos < 0) {
+            right = true;
+            typePos = fragment.indexOf('R', prefix.length());
+        }
+
+        String fileHash = typePos > 0
+                ? fragment.substring(prefix.length(), typePos)
+                : fragment.substring(prefix.length());
+        if (isMd5Hash && fileHash.length() != 32) { // MD5 hash length
+            return null;
+        }
+        if (typePos < 0) {
+            return new DiffHighlightId(fileHash, -1, -1, false);
+        }
+
+        try {
+            char type = fragment.charAt(typePos);
+            String linePart = fragment.substring(typePos + 1);
+            int startLine, endLine, dashPos = linePart.indexOf("-" + type);
+            if (dashPos > 0) {
+                startLine = Integer.valueOf(linePart.substring(0, dashPos));
+                endLine = Integer.valueOf(linePart.substring(dashPos + 2));
+            } else {
+                startLine = Integer.valueOf(linePart);
+                endLine = startLine;
+            }
+            return new DiffHighlightId(fileHash, startLine, endLine, right);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public static class ParseResult {
+        @Nullable
+        public final Intent intent;
+
+        @Nullable
+        public final UrlLoadTask loadTask;
+
+        public ParseResult(@NonNull UrlLoadTask loadTask) {
+            this.intent = null;
+            this.loadTask = loadTask;
+        }
+
+        public ParseResult(@NonNull Intent intent) {
+            this.intent = intent;
+            this.loadTask = null;
+        }
+    }
+}

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffCommentLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.activities.PullRequestActivity;
@@ -18,11 +19,16 @@ import org.eclipse.egit.github.core.PullRequest;
 import java.util.List;
 
 public class PullRequestDiffCommentLoadTask extends UrlLoadTask {
-    private final String mRepoOwner;
-    private final String mRepoName;
-    private final int mPullRequestNumber;
-    private final IntentUtils.InitialCommentMarker mMarker;
-    private final int mPage;
+    @VisibleForTesting
+    protected final String mRepoOwner;
+    @VisibleForTesting
+    protected final String mRepoName;
+    @VisibleForTesting
+    protected final int mPullRequestNumber;
+    @VisibleForTesting
+    protected final IntentUtils.InitialCommentMarker mMarker;
+    @VisibleForTesting
+    protected final int mPage;
 
     public PullRequestDiffCommentLoadTask(FragmentActivity activity, String repoOwner,
             String repoName, int pullRequestNumber, IntentUtils.InitialCommentMarker marker,

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.activities.PullRequestDiffViewerActivity;
@@ -15,17 +16,18 @@ import org.eclipse.egit.github.core.PullRequest;
 import java.util.List;
 
 public class PullRequestDiffLoadTask extends DiffLoadTask {
-    private final int mPullRequestNumber;
+    @VisibleForTesting
+    protected final int mPullRequestNumber;
 
     public PullRequestDiffLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            BrowseFilter.DiffHighlightId diffId, int pullRequestNumber) {
+            DiffHighlightId diffId, int pullRequestNumber) {
         super(activity, repoOwner, repoName, diffId);
         mPullRequestNumber = pullRequestNumber;
     }
 
     @Override
-    protected Intent getLaunchIntent(String sha, CommitFile file,
-            List<CommitComment> comments, BrowseFilter.DiffHighlightId diffId) {
+    protected Intent getLaunchIntent(String sha, CommitFile file, List<CommitComment> comments,
+            DiffHighlightId diffId) {
         return PullRequestDiffViewerActivity.makeIntent(mActivity, mRepoOwner,
                 mRepoName, mPullRequestNumber, sha, file.getFilename(), file.getPatch(),
                 comments, -1, diffId.startLine, diffId.endLine, diffId.right, null);

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewCommentLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.Gh4Application;
@@ -19,10 +20,14 @@ import java.util.List;
 import java.util.Map;
 
 public class PullRequestReviewCommentLoadTask extends UrlLoadTask {
-    private final String mRepoOwner;
-    private final String mRepoName;
-    private final int mPullRequestNumber;
-    private final IntentUtils.InitialCommentMarker mMarker;
+    @VisibleForTesting
+    protected final String mRepoOwner;
+    @VisibleForTesting
+    protected final String mRepoName;
+    @VisibleForTesting
+    protected final int mPullRequestNumber;
+    @VisibleForTesting
+    protected final IntentUtils.InitialCommentMarker mMarker;
 
     public PullRequestReviewCommentLoadTask(FragmentActivity activity, String repoOwner,
             String repoName, int pullRequestNumber, IntentUtils.InitialCommentMarker marker,

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewDiffLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.Gh4Application;
@@ -15,13 +16,17 @@ import org.eclipse.egit.github.core.service.PullRequestService;
 import java.util.List;
 
 public class PullRequestReviewDiffLoadTask extends UrlLoadTask {
-    private final String mRepoOwner;
-    private final String mRepoName;
-    private final BrowseFilter.DiffHighlightId mDiffId;
-    private final int mPullRequestNumber;
+    @VisibleForTesting
+    protected final String mRepoOwner;
+    @VisibleForTesting
+    protected final String mRepoName;
+    @VisibleForTesting
+    protected final DiffHighlightId mDiffId;
+    @VisibleForTesting
+    protected final int mPullRequestNumber;
 
     public PullRequestReviewDiffLoadTask(FragmentActivity activity, String repoOwner,
-            String repoName, BrowseFilter.DiffHighlightId diffId, int pullRequestNumber) {
+            String repoName, DiffHighlightId diffId, int pullRequestNumber) {
         super(activity);
         mRepoOwner = repoOwner;
         mRepoName = repoName;

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.Gh4Application;
@@ -12,10 +13,14 @@ import org.eclipse.egit.github.core.Review;
 import org.eclipse.egit.github.core.service.PullRequestService;
 
 public class PullRequestReviewLoadTask extends UrlLoadTask {
-    private final String mRepoOwner;
-    private final String mRepoName;
-    private final int mPullRequestNumber;
-    private final IntentUtils.InitialCommentMarker mMarker;
+    @VisibleForTesting
+    protected final String mRepoOwner;
+    @VisibleForTesting
+    protected final String mRepoName;
+    @VisibleForTesting
+    protected final int mPullRequestNumber;
+    @VisibleForTesting
+    protected final IntentUtils.InitialCommentMarker mMarker;
 
     public PullRequestReviewLoadTask(FragmentActivity activity, String repoOwner, String repoName,
             int pullRequestNumber, IntentUtils.InitialCommentMarker marker) {

--- a/app/src/main/java/com/gh4a/resolver/RefPathDisambiguationTask.java
+++ b/app/src/main/java/com/gh4a/resolver/RefPathDisambiguationTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
 import android.util.Pair;
@@ -20,12 +21,18 @@ import java.util.regex.Pattern;
 public class RefPathDisambiguationTask extends UrlLoadTask {
     private static final Pattern SHA1_PATTERN = Pattern.compile("[a-z0-9]{40}");
 
-    private final String mRepoOwner;
-    private final String mRepoName;
-    private final String mRefAndPath;
-    private final int mInitialPage;
-    private final String mFragment;
-    private final boolean mGoToFileViewer;
+    @VisibleForTesting
+    protected final String mRepoOwner;
+    @VisibleForTesting
+    protected final String mRepoName;
+    @VisibleForTesting
+    protected final String mRefAndPath;
+    @VisibleForTesting
+    protected final int mInitialPage;
+    @VisibleForTesting
+    protected final String mFragment;
+    @VisibleForTesting
+    protected final boolean mGoToFileViewer;
 
     public RefPathDisambiguationTask(FragmentActivity activity, String repoOwner,
             String repoName, String refAndPath, int initialPage) {

--- a/app/src/main/java/com/gh4a/resolver/ReleaseLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/ReleaseLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
 
@@ -12,9 +13,12 @@ import org.eclipse.egit.github.core.Release;
 import java.util.List;
 
 public class ReleaseLoadTask extends UrlLoadTask {
-    private final String mRepoOwner;
-    private final String mRepoName;
-    private final String mTagName;
+    @VisibleForTesting
+    protected final String mRepoOwner;
+    @VisibleForTesting
+    protected final String mRepoName;
+    @VisibleForTesting
+    protected final String mTagName;
 
     public ReleaseLoadTask(FragmentActivity activity, String repoOwner, String repoName,
             String tagName) {

--- a/app/src/main/java/com/gh4a/resolver/UserFollowersLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/UserFollowersLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.activities.FollowerFollowingListActivity;
@@ -10,7 +11,8 @@ import com.gh4a.utils.ApiHelpers;
 import org.eclipse.egit.github.core.User;
 
 public class UserFollowersLoadTask extends UserLoadTask {
-    private boolean mShowFollowers;
+    @VisibleForTesting
+    protected boolean mShowFollowers;
 
     public UserFollowersLoadTask(FragmentActivity activity, String userLogin,
             boolean showFollowers) {

--- a/app/src/main/java/com/gh4a/resolver/UserLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/UserLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.loader.UserLoader;
@@ -8,7 +9,8 @@ import com.gh4a.loader.UserLoader;
 import org.eclipse.egit.github.core.User;
 
 public abstract class UserLoadTask extends UrlLoadTask {
-    private final String mUserLogin;
+    @VisibleForTesting
+    protected final String mUserLogin;
 
     public UserLoadTask(FragmentActivity activity, String userLogin) {
         super(activity);

--- a/app/src/main/java/com/gh4a/resolver/UserReposLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/UserReposLoadTask.java
@@ -1,6 +1,7 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentActivity;
 
 import com.gh4a.activities.RepositoryListActivity;
@@ -10,7 +11,8 @@ import com.gh4a.utils.ApiHelpers;
 import org.eclipse.egit.github.core.User;
 
 public class UserReposLoadTask extends UserLoadTask {
-    private boolean mShowStars;
+    @VisibleForTesting
+    protected boolean mShowStars;
 
     public UserReposLoadTask(FragmentActivity activity, String userLogin, boolean showStars) {
         super(activity, userLogin);

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -1,0 +1,817 @@
+package com.gh4a.resolver;
+
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+
+import com.gh4a.BuildConfig;
+import com.gh4a.activities.BlogListActivity;
+import com.gh4a.activities.CommitActivity;
+import com.gh4a.activities.DownloadsActivity;
+import com.gh4a.activities.GistActivity;
+import com.gh4a.activities.IssueActivity;
+import com.gh4a.activities.IssueEditActivity;
+import com.gh4a.activities.IssueListActivity;
+import com.gh4a.activities.OrganizationMemberListActivity;
+import com.gh4a.activities.PullRequestActivity;
+import com.gh4a.activities.ReleaseListActivity;
+import com.gh4a.activities.RepositoryActivity;
+import com.gh4a.activities.TrendingActivity;
+import com.gh4a.activities.UserActivity;
+import com.gh4a.activities.WikiListActivity;
+import com.gh4a.utils.IntentUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@SuppressWarnings("ConstantConditions")
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
+public class LinkParserTest {
+    private FragmentActivity mActivity;
+
+    @Before
+    public void createActivity() {
+        mActivity = Robolectric.buildActivity(BrowseFilter.class).get();
+    }
+
+    @Test
+    public void gistLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://gist.github.com"));
+    }
+
+    @Test
+    public void linkToGist__opensGistActivity() {
+        LinkParser.ParseResult result = parseLink("https://gist.github.com/gistId");
+        assertRedirectsTo(result, GistActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("Gist id is incorrect", extras.getString("id"), is("gistId"));
+    }
+
+    @Test
+    public void linkToGist_withUserInPath__opensGistActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://gist.github.com/user/gistId");
+        assertRedirectsTo(result, GistActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("Gist id is incorrect", extras.getString("id"), is("gistId"));
+    }
+
+    @Test
+    public void githubLink__opensMainActivity() {
+        assertRedirectsToBrowser(parseLink("https://github.com"));
+    }
+
+    @Test
+    public void appsLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/apps"));
+    }
+
+    @Test
+    public void integrationsLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/integrations"));
+    }
+
+    @Test
+    public void loginLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/login"));
+    }
+
+    @Test
+    public void logoutLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/logout"));
+    }
+
+    @Test
+    public void marketplaceLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/marketplace"));
+    }
+
+    @Test
+    public void sessionsLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/sessions"));
+    }
+
+    @Test
+    public void settingsLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/settings"));
+    }
+
+    @Test
+    public void updatesLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/updates"));
+    }
+
+    @Test
+    public void exploreLink__opensTrendingActivity() throws Exception {
+        assertRedirectsTo(parseLink("https://github.com/explore"), TrendingActivity.class);
+    }
+
+    @Test
+    public void blogLink__opensBlogListActivity() throws Exception {
+        assertRedirectsTo(parseLink("https://github.com/blog"), BlogListActivity.class);
+    }
+
+    @Test
+    public void blogLink_withBlogInPath__opensBrowser() throws Exception {
+        assertRedirectsToBrowser(parseLink("https://github.com/blog/blog-title"));
+    }
+
+    @Test
+    public void orgsLink__opensBrowser() throws Exception {
+        assertRedirectsToBrowser(parseLink("https://github.com/orgs"));
+    }
+
+    @Test
+    public void organizationLink__opensUserActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/orgs/android");
+        assertRedirectsTo(result, UserActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("Organization name is incorrect", extras.getString("login"), is("android"));
+    }
+
+    @Test
+    public void organisationLink_leadingToMembers__opensOrganizationMemberListActivity()
+            throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/orgs/android/people");
+        assertRedirectsTo(result, OrganizationMemberListActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("Organization name is incorrect", extras.getString("login"), is("android"));
+    }
+
+    @Test
+    public void userLink__opensUserActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan");
+        assertRedirectsTo(result, UserActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("login"), is("slapperwan"));
+    }
+
+    @Test
+    public void userLink_withRepositoriesTab__loadsUserRepos() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=repositories");
+        UserReposLoadTask loadTask = assertThatLoadTaskIs(result.loadTask, UserReposLoadTask.class);
+        assertThat("Loading starred repos is set to true", loadTask.mShowStars, is(false));
+        assertThat("User name is incorrect", loadTask.mUserLogin, is("slapperwan"));
+    }
+
+    @Test
+    public void userLink_withStarsTab__loadsUserStarredRepos() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=stars");
+        UserReposLoadTask loadTask = assertThatLoadTaskIs(result.loadTask, UserReposLoadTask.class);
+        assertThat("Loading starred repos is set to false", loadTask.mShowStars, is(true));
+        assertThat("User name is incorrect", loadTask.mUserLogin, is("slapperwan"));
+    }
+
+    @Test
+    public void userLink_withFollowersTab__loadsUserFollowers() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=followers");
+        UserFollowersLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, UserFollowersLoadTask.class);
+        assertThat("Loading followers is set to false", loadTask.mShowFollowers, is(true));
+        assertThat("User name is incorrect", loadTask.mUserLogin, is("slapperwan"));
+    }
+
+    @Test
+    public void userLink_withFollowingTab__loadsUserFollows() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=following");
+        UserFollowersLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, UserFollowersLoadTask.class);
+        assertThat("Loading followers is set to true", loadTask.mShowFollowers, is(false));
+        assertThat("User name is incorrect", loadTask.mUserLogin, is("slapperwan"));
+    }
+
+    @Test
+    public void userLink_withUnknownTab__opensUserActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=unknown");
+        assertRedirectsTo(result, UserActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("login"), is("slapperwan"));
+    }
+
+    @Test
+    public void repositoryLink__opensRepositoryActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a");
+        assertRedirectsTo(result, RepositoryActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Ref is set", extras.getString("ref"), is(nullValue()));
+        assertThat("Initial path is set", extras.getString("initial_path"), is(nullValue()));
+        assertThat("Initial page did not lead to overview", extras.getInt("initial_page"),
+                is(RepositoryActivity.PAGE_REPO_OVERVIEW));
+    }
+
+    @Test
+    public void downloadsLink__opensDownloadsActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/downloads");
+        assertRedirectsTo(result, DownloadsActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+    }
+
+    @Test
+    public void releasesLink__opensReleaseListActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/releases");
+        assertRedirectsTo(result, ReleaseListActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+    }
+
+    @Test
+    public void releaseLink_withoutTagId__opensReleaseListActivity() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/releases/tag");
+        assertRedirectsTo(result, ReleaseListActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+    }
+
+    @Test
+    public void releaseLink_withTagId__loadsRelease() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/releases/tag/tagName");
+        ReleaseLoadTask loadTask = assertThatLoadTaskIs(result.loadTask, ReleaseLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Tag name is incorrect", loadTask.mTagName, is("tagName"));
+    }
+
+    @Test
+    public void issuesLink__opensIssueListActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/issues");
+        assertRedirectsTo(result, IssueListActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Issue type is pull request", extras.getBoolean("is_pull_request"), is(false));
+    }
+
+    @Test
+    public void newIssueLink__opensIssueEditActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/issues/new");
+        assertRedirectsTo(result, IssueEditActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Issue to edit is set", extras.getSerializable("issue"), is(nullValue()));
+    }
+
+    @Test
+    public void issueLink__opensIssueActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/issues/42");
+        assertRedirectsTo(result, IssueActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Issue number is incorrect", extras.getInt("number"), is(42));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void issueLink_withIncorrectNumber__opensBrowser() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/issues/34no");
+        assertRedirectsToBrowser(result);
+    }
+
+    @Test
+    public void issueLink_withCommentMarker__opensIssueActivity_andHasCommentMarker()
+            throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/issues/42#issuecomment-1234");
+        assertRedirectsTo(result, IssueActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Issue number is incorrect", extras.getInt("number"), is(42));
+        IntentUtils.InitialCommentMarker commentMarker = extras.getParcelable("initial_comment");
+        assertThat("Comment marker is missing", commentMarker, is(notNullValue()));
+        assertThat("Comment id is incorrect", commentMarker.commentId, is(1234L));
+    }
+
+    @Test
+    public void issueLink_withIncorrectCommentMarker_opensIssueActivity() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/issues/42#issuecomment-A3");
+        assertRedirectsTo(result, IssueActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Issue number is incorrect", extras.getInt("number"), is(42));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void pullRequestsLink__opensIssueListActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/pulls");
+        assertRedirectsTo(result, IssueListActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Issue type is not pull request", extras.getBoolean("is_pull_request"),
+                is(true));
+    }
+
+    @Test
+    public void wikiLink__opensWikiListActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/wiki");
+        assertRedirectsTo(result, WikiListActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Initial page is set", extras.getString("initial_page"), is(nullValue()));
+    }
+
+    @Test
+    public void pullRequestLink_withoutId__opensBrowser() throws Exception {
+        assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull"));
+    }
+
+    @Test
+    public void pullRequestLink_withInvalidId__opensBrowser() throws Exception {
+        assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull/-1"));
+        assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull/fwbi"));
+        assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull/0"));
+    }
+
+    @Test
+    public void pullRequestLink__opensPullRequestActivity() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/pull/12");
+        assertRedirectsTo(result, PullRequestActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Pull request number is incorrect", extras.getInt("number"), is(12));
+        assertThat("Initial page is set", extras.getInt("initial_page"), is(-1));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void pullRequestLink_withCommentMarker__opensPullRequestActivity_andHasCommentMarker()
+            throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/14#issuecomment-7546");
+        assertRedirectsTo(result, PullRequestActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Pull request number is incorrect", extras.getInt("number"), is(14));
+        assertThat("Initial page is set", extras.getInt("initial_page"), is(-1));
+        IntentUtils.InitialCommentMarker commentMarker = extras.getParcelable("initial_comment");
+        assertThat("Comment marker is missing", commentMarker, is(notNullValue()));
+        assertThat("Comment id is incorrect", commentMarker.commentId, is(7546L));
+    }
+
+    @Test
+    public void pullRequestLink_withCommitsPage__opensPullRequestCommits() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/23/commits");
+        assertRedirectsTo(result, PullRequestActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Pull request number is incorrect", extras.getInt("number"), is(23));
+        assertThat("Initial page is incorrect", extras.getInt("initial_page"),
+                is(PullRequestActivity.PAGE_COMMITS));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void pullRequestLink_withFilesPage__opensPullRequestFiles() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/23/files");
+        assertRedirectsTo(result, PullRequestActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Pull request number is incorrect", extras.getInt("number"), is(23));
+        assertThat("Initial page is incorrect", extras.getInt("initial_page"),
+                is(PullRequestActivity.PAGE_FILES));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void pullRequestLink_withUnknownPage__opensPullRequest() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/23/unknown");
+        assertRedirectsTo(result, PullRequestActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Pull request number is incorrect", extras.getInt("number"), is(23));
+        assertThat("Initial page is set", extras.getInt("initial_page"), is(-1));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void pullRequestLink_withDiffMarker__loadsDiff() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
+                        "#diff-38f43208e0c158ca7b78e175b8846bc6");
+        PullRequestDiffLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, PullRequestDiffLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        DiffHighlightId diffId = loadTask.mDiffId;
+        assertThat("Diff id is missing", diffId, is(notNullValue()));
+        assertThat("File hash is incorrect", diffId.fileHash,
+                is("38f43208e0c158ca7b78e175b8846bc6"));
+        assertThat("Start line is set", diffId.startLine, is(-1));
+        assertThat("End line is set", diffId.endLine, is(-1));
+        assertThat("Is right line", diffId.right, is(false));
+    }
+
+    @Test
+    public void pullRequestLink_withDiffMarker_andLeftNumber__loadsDiff() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
+                        "#diff-38f43208e0c158ca7b78e175b8846bc6L24");
+        PullRequestDiffLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, PullRequestDiffLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        DiffHighlightId diffId = loadTask.mDiffId;
+        assertThat("Diff id is missing", diffId, is(notNullValue()));
+        assertThat("File hash is incorrect", diffId.fileHash,
+                is("38f43208e0c158ca7b78e175b8846bc6"));
+        assertThat("Start line is incorrect", diffId.startLine, is(24));
+        assertThat("End line is incorrect", diffId.endLine, is(24));
+        assertThat("Is right line", diffId.right, is(false));
+    }
+
+    @Test
+    public void pullRequestLink_withDiffMarker_andLineRange__loadsDiff() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
+                        "#diff-38f43208e0c158ca7b78e175b8846bc6L24-L26");
+        PullRequestDiffLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, PullRequestDiffLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        DiffHighlightId diffId = loadTask.mDiffId;
+        assertThat("Diff id is missing", diffId, is(notNullValue()));
+        assertThat("File hash is incorrect", diffId.fileHash,
+                is("38f43208e0c158ca7b78e175b8846bc6"));
+        assertThat("Start line is incorrect", diffId.startLine, is(24));
+        assertThat("End line is incorrect", diffId.endLine, is(26));
+        assertThat("Is right line", diffId.right, is(false));
+    }
+
+    @Test
+    public void pullRequestLink_withDiffMarker_andInvalidNumber__opensPullRequest() throws
+            Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
+                        "#diff-38f43208e0c158ca7b78e175b8846bc6LA3");
+        assertRedirectsTo(result, PullRequestActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Pull request number is incorrect", extras.getInt("number"), is(665));
+        assertThat("Initial page is incorrect", extras.getInt("initial_page"),
+                is(PullRequestActivity.PAGE_FILES));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void pullRequestLink_withDiffMarker_andRightNumber__loadsDiff() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
+                        "#diff-38f43208e0c158ca7b78e175b8846bc6R24");
+        PullRequestDiffLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, PullRequestDiffLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        DiffHighlightId diffId = loadTask.mDiffId;
+        assertThat("Diff id is missing", diffId, is(notNullValue()));
+        assertThat("File hash is incorrect", diffId.fileHash,
+                is("38f43208e0c158ca7b78e175b8846bc6"));
+        assertThat("Start line is incorrect", diffId.startLine, is(24));
+        assertThat("End line is incorrect", diffId.endLine, is(24));
+        assertThat("Is not right line", diffId.right, is(true));
+    }
+
+    @Test
+    public void pullRequestLink_withDiffMarker_andIncorrectHash__loadsDiff() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
+                        "#diff-38f43208e0c158ca7b78e1");
+        assertRedirectsTo(result, PullRequestActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Pull request number is incorrect", extras.getInt("number"), is(665));
+        assertThat("Initial page is incorrect", extras.getInt("initial_page"),
+                is(PullRequestActivity.PAGE_FILES));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void pullRequestReviewLink__loadsReview() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665#pullrequestreview-59822171");
+        PullRequestReviewLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, PullRequestReviewLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Pull request number is incorrect", loadTask.mPullRequestNumber, is(665));
+        assertThat("Comment marker is missing", loadTask.mMarker, is(notNullValue()));
+        assertThat("Comment id is incorrect", loadTask.mMarker.commentId, is(59822171L));
+    }
+
+    @Test
+    public void pullRequestReviewCommentLink__loadsReviewComment() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665#discussion_r136306029");
+        PullRequestReviewCommentLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, PullRequestReviewCommentLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Pull request number is incorrect", loadTask.mPullRequestNumber, is(665));
+        assertThat("Comment marker is missing", loadTask.mMarker, is(notNullValue()));
+        assertThat("Comment id is incorrect", loadTask.mMarker.commentId, is(136306029L));
+    }
+
+    @Test
+    public void pullRequestReviewDiffLink__loadsReviewDiff() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/pull/665" +
+                "#discussion-diff-136304421R590");
+        PullRequestReviewDiffLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, PullRequestReviewDiffLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Pull request number is incorrect", loadTask.mPullRequestNumber, is(665));
+        assertThat("Diff id is missing", loadTask.mDiffId, is(notNullValue()));
+        assertThat("Comment id is incorrect", loadTask.mDiffId.fileHash, is("136304421"));
+        assertThat("Start line is incorrect", loadTask.mDiffId.startLine, is(590));
+        assertThat("End line is incorrect", loadTask.mDiffId.endLine, is(590));
+        assertThat("Is left line", loadTask.mDiffId.right, is(true));
+    }
+
+    @Test
+    public void pullRequestDiffCommentLink__loadsReviewDiff() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/pull/665/files#r136306029");
+        PullRequestDiffCommentLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, PullRequestDiffCommentLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Pull request number is incorrect", loadTask.mPullRequestNumber, is(665));
+        assertThat("Page is incorrect", loadTask.mPage, is(PullRequestActivity.PAGE_FILES));
+        assertThat("Comment marker is missing", loadTask.mMarker, is(notNullValue()));
+        assertThat("Comment id is incorrect", loadTask.mMarker.commentId, is(136306029L));
+    }
+
+    @Test
+    public void commitLink__opensCommitActivity() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/commit/commitSha");
+        assertRedirectsTo(result, CommitActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Pull request number is set", extras.getInt("pr"), is(-1));
+        assertThat("Commit sha is incorrect", extras.getString("sha"), is("commitSha"));
+        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
+                is(nullValue()));
+    }
+
+    @Test
+    public void commitLink_withoutCommitSha__opensBrowser() throws Exception {
+        assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/commit"));
+    }
+
+    @Test
+    public void commitLink_withDiffMarker__loadsCommitDiff() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/commit/" +
+                        "57a054f85ade77ebb80eecd671aace770b312bf5" +
+                        "#diff-1d86a926c5d4666eb76b2326aa28ee89L160");
+        CommitDiffLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, CommitDiffLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Commit sha is incorrect", loadTask.mSha,
+                is("57a054f85ade77ebb80eecd671aace770b312bf5"));
+        DiffHighlightId diffId = loadTask.mDiffId;
+        assertThat("Diff id is missing", diffId, is(notNullValue()));
+        assertThat("File has is incorrect", diffId.fileHash,
+                is("1d86a926c5d4666eb76b2326aa28ee89"));
+        assertThat("Start line is incorrect", diffId.startLine, is(160));
+        assertThat("End line is incorrect", diffId.endLine, is(160));
+        assertThat("Is right line", diffId.right, is(false));
+    }
+
+    @Test
+    public void commitLink_withCommentMarker__opensCommitActivity() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/commit/commitSha#commitcomment-12");
+        CommitCommentLoadTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, CommitCommentLoadTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Commit sha is incorrect", loadTask.mCommitSha, is("commitSha"));
+        IntentUtils.InitialCommentMarker commentMarker = loadTask.mMarker;
+        assertThat("Comment marker is missing", commentMarker, is(notNullValue()));
+        assertThat("Comment id is incorrect", commentMarker.commentId, is(12L));
+    }
+
+    @Test
+    public void commitsLink__handlesRefAndPath_andRedirectsToCommitsPage() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/commits");
+        RefPathDisambiguationTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Ref and path is not empty", loadTask.mRefAndPath, isEmptyString());
+        assertThat("Page does not lead to commits", loadTask.mInitialPage,
+                is(RepositoryActivity.PAGE_COMMITS));
+        assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
+        assertThat("Goes to file viewer", loadTask.mGoToFileViewer, is(false));
+    }
+
+    @Test
+    public void commitsLink_withBranch__handlesRefAndPath_andRedirectsToCommitsPage()
+            throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/commits/master");
+        RefPathDisambiguationTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Ref and path is incorrect", loadTask.mRefAndPath, is("master"));
+        assertThat("Page does not lead to commits", loadTask.mInitialPage,
+                is(RepositoryActivity.PAGE_COMMITS));
+        assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
+        assertThat("Goes to file viewer", loadTask.mGoToFileViewer, is(false));
+    }
+
+    @Test
+    public void commitsLink_withRefsHeads__handlesRefAndPath_andRedirectsToCommitsPage()
+            throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/commits/refs/heads/master");
+        RefPathDisambiguationTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Ref and path is incorrect", loadTask.mRefAndPath, is("master"));
+        assertThat("Page does not lead to commits", loadTask.mInitialPage,
+                is(RepositoryActivity.PAGE_COMMITS));
+        assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
+        assertThat("Goes to file viewer", loadTask.mGoToFileViewer, is(false));
+    }
+
+    @Test
+    public void treeLink__handlesRefAndPath_andRedirectsToFilesPage() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/tree");
+        RefPathDisambiguationTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Ref and path is not empty", loadTask.mRefAndPath, isEmptyString());
+        assertThat("Page does not lead to files", loadTask.mInitialPage,
+                is(RepositoryActivity.PAGE_FILES));
+        assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
+        assertThat("Goes to file viewer", loadTask.mGoToFileViewer, is(false));
+    }
+
+    @Test
+    public void treeLink_withBranch__handlesRefAndPath_andRedirectsToFilesPage() throws Exception {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/tree/master");
+        RefPathDisambiguationTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Ref and path is incorrect", loadTask.mRefAndPath, is("master"));
+        assertThat("Page does not lead to files", loadTask.mInitialPage,
+                is(RepositoryActivity.PAGE_FILES));
+        assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
+        assertThat("Goes to file viewer", loadTask.mGoToFileViewer, is(false));
+    }
+
+    @Test
+    public void treeLink_withRefsHeads__handlesRefAndPath_andRedirectsToFilesPage()
+            throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/tree/refs/heads/master");
+        RefPathDisambiguationTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Ref and path is incorrect", loadTask.mRefAndPath, is("master"));
+        assertThat("Page does not lead to files", loadTask.mInitialPage,
+                is(RepositoryActivity.PAGE_FILES));
+        assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
+        assertThat("Goes to file viewer", loadTask.mGoToFileViewer, is(false));
+    }
+
+    @Test
+    public void blobLink__handlesRefAndPath_andRedirectsToFileViewer() throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/blob/master/README.md");
+        RefPathDisambiguationTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Ref and path is incorrect", loadTask.mRefAndPath, is("master/README.md"));
+        assertThat("Page is set", loadTask.mInitialPage, is(-1));
+        assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
+        assertThat("Does not go to file viewer", loadTask.mGoToFileViewer, is(true));
+    }
+
+    @Test
+    public void blobLink_withLineMarker__handlesRefAndPath_andRedirectsToFileViewer()
+            throws Exception {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/blob/master/build.gradle#L10");
+        RefPathDisambiguationTask loadTask =
+                assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
+        assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
+        assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
+        assertThat("Ref and path is incorrect", loadTask.mRefAndPath, is("master/build.gradle"));
+        assertThat("Page is set", loadTask.mInitialPage, is(-1));
+        assertThat("Fragment is incorrect", loadTask.mFragment, is("L10"));
+        assertThat("Does not go to file viewer", loadTask.mGoToFileViewer, is(true));
+    }
+
+    @Test
+    public void blobLink_withoutBranchAndPath__opensBrowser() throws Exception {
+        assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/blob"));
+    }
+
+    @Test
+    public void unknownRepositoryLink__opensBrowser() throws Exception {
+        assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/unknown"));
+    }
+
+    private LinkParser.ParseResult parseLink(String uriString) {
+        return LinkParser.parseUri(mActivity, Uri.parse(uriString));
+    }
+
+    private static void assertRedirectsTo(LinkParser.ParseResult result, Class<?> cls) {
+        assertThat("Parse result must not be null to redirect to activity", result,
+                is(notNullValue()));
+        assertThat("Load task must be null to redirect to activity", result.loadTask,
+                is(nullValue()));
+        assertThat("Target intent is missing", result.intent, is(notNullValue()));
+        assertThat("Target intent is incorrect", result.intent.getComponent().getClassName(),
+                is(cls.getName()));
+    }
+
+    private static void assertRedirectsToBrowser(LinkParser.ParseResult result) {
+        assertThat("Parse result does not redirect to browser (must be null)", result,
+                is(nullValue()));
+    }
+
+    private static <T extends UrlLoadTask> T assertThatLoadTaskIs(UrlLoadTask loadTask,
+            Class<T> cls) {
+        assertThat("Load task is of incorrect type", loadTask, is(instanceOf(cls)));
+        //noinspection unchecked
+        return (T) loadTask;
+    }
+}


### PR DESCRIPTION
I've moved the parsing algorithm out of BrowseFilter to a separate class
so it was possible to introduce unit tests. There are now 68 tests which
result in 100% test coverage of the new LinkParser.

Only behavior change in the app introduced by this commit is that
"https:github.com" url now opens the main application screen instead of
a browser.