### PR TITLE
Refreshing issues while in search mode clears input #686

### DIFF
--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -440,7 +440,6 @@ public abstract class BaseActivity extends AppCompatActivity implements
 
     @Override
     public void onRefresh() {
-        supportInvalidateOptionsMenu();
         mSwipeLayout.setRefreshing(false);
     }
 


### PR DESCRIPTION
Removing the line solves the bug. Since `onRefresh()` method from `BaseActivity` seems called a lot, how should have test side-effects of removing the line ?