### PR TITLE
swap repo menu item position

### DIFF
--- a/app/src/main/res/menu/repo_list_menu.xml
+++ b/app/src/main/res/menu/repo_list_menu.xml
@@ -2,14 +2,14 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/filter"
-        android:icon="@drawable/filter"
-        android:title="@string/issue_filter"
-        app:showAsAction="ifRoom" />
-    <item
         android:id="@+id/search"
         android:icon="@drawable/action_search"
         android:title="@string/search"
         app:showAsAction="always|collapseActionView"
         app:actionViewClass="android.support.v7.widget.SearchView" />
+    <item
+        android:id="@+id/filter"
+        android:icon="@drawable/filter"
+        android:title="@string/issue_filter"
+        app:showAsAction="ifRoom" />
 </menu>


### PR DESCRIPTION
In my opinion, it's rather awkward that the menu item to open the right drawer is not the rightmost icon. So, I swapped them.