### PR TITLE
Move watched repositories to Notifications screen

### DIFF
--- a/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
+++ b/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
@@ -297,7 +297,7 @@ public class HomeActivity extends BaseFragmentPagerActivity implements
             case R.id.news_feed:
                 return new NewsFeedFactory(this, mUserLogin);
             case R.id.notifications:
-                return new NotificationListFactory(this);
+                return new NotificationListFactory(this, mUserLogin);
             case R.id.my_repos:
                 return new RepositoryFactory(this, mUserLogin, getPrefs());
             case R.id.my_issues:

--- a/app/src/main/java/com/gh4a/activities/home/NotificationListFactory.java
+++ b/app/src/main/java/com/gh4a/activities/home/NotificationListFactory.java
@@ -5,18 +5,23 @@ import android.support.v4.app.Fragment;
 
 import com.gh4a.R;
 import com.gh4a.fragment.NotificationListFragment;
+import com.gh4a.fragment.WatchedRepositoryListFragment;
 
 public class NotificationListFactory extends FragmentFactory {
-    private static final int[] TAB_TITLES =  new int[] {
-        R.string.notifications
+    private static final int[] TAB_TITLES = new int[] {
+            R.string.notifications, R.string.watching
     };
 
-    protected NotificationListFactory(HomeActivity activity) {
+    private final String mUserLogin;
+
+    protected NotificationListFactory(HomeActivity activity, String userLogin) {
         super(activity);
+        mUserLogin = userLogin;
     }
 
     @Override
-    protected @StringRes int getTitleResId() {
+    @StringRes
+    protected int getTitleResId() {
         return R.string.notifications;
     }
 
@@ -27,6 +32,9 @@ public class NotificationListFactory extends FragmentFactory {
 
     @Override
     protected Fragment makeFragment(int position) {
+        if (position == 1) {
+            return WatchedRepositoryListFragment.newInstance(mUserLogin);
+        }
         return NotificationListFragment.newInstance();
     }
 }

--- a/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
@@ -196,9 +196,6 @@ public class RepositoryListContainerFragment extends Fragment implements
                 mMainFragment = StarredRepositoryListFragment.newInstance(mUserLogin,
                         mSortOrder, mSortDirection);
                 break;
-            case "watched":
-                mMainFragment = WatchedRepositoryListFragment.newInstance(mUserLogin);
-                break;
             default:
                 mMainFragment = RepositoryListFragment.newInstance(mUserLogin, mIsOrg,
                         mFilterType, mSortOrder, mSortDirection);
@@ -367,7 +364,6 @@ public class RepositoryListContainerFragment extends Fragment implements
             FILTER_LOOKUP.put(R.id.filter_type_private, "private");
             FILTER_LOOKUP.put(R.id.filter_type_sources, "sources");
             FILTER_LOOKUP.put(R.id.filter_type_forks, "forks");
-            FILTER_LOOKUP.put(R.id.filter_type_watched, "watched");
             FILTER_LOOKUP.put(R.id.filter_type_starred, "starred");
         }
 
@@ -431,9 +427,8 @@ public class RepositoryListContainerFragment extends Fragment implements
         }
 
         public int getMenuResId() {
-            return TextUtils.equals(mFilterType, "starred") ? R.menu.repo_starred_sort
-                    : TextUtils.equals(mFilterType, "watched") ? 0
-                    : R.menu.repo_sort;
+            return TextUtils.equals(mFilterType, "starred")
+                    ? R.menu.repo_starred_sort : R.menu.repo_sort;
         }
 
         public void selectSortType(Menu menu, String order, String direction) {

--- a/app/src/main/res/menu/repo_filter_logged_in.xml
+++ b/app/src/main/res/menu/repo_filter_logged_in.xml
@@ -25,9 +25,6 @@
                     android:id="@+id/filter_type_forks"
                     android:title="@string/repo_type_forks" />
                 <item
-                    android:id="@+id/filter_type_watched"
-                    android:title="@string/repo_type_watched" />
-                <item
                     android:id="@+id/filter_type_starred"
                     android:title="@string/repo_type_starred" />
             </group>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="quote">Quote</string>
     <string name="fork">Fork</string>
     <string name="notifications">Notifications</string>
+    <string name="watching">Watching</string>
     <string name="mark_all_as_read">Mark all as read</string>
     <string name="mark_as_read">Mark as read</string>
     <string name="unsubscribe">Unsubscribe</string>


### PR DESCRIPTION
This reproduces the behavior present on GitHub web interface where notifications and watched repositories are grouped under 2 tabs in the same page.

Related to #578 and #624