### PR TITLE
Improved milestone selection dialog

### DIFF
--- a/app/src/main/java/com/gh4a/dialogs/BasePagerDialog.java
+++ b/app/src/main/java/com/gh4a/dialogs/BasePagerDialog.java
@@ -1,0 +1,82 @@
+package com.gh4a.dialogs;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import com.gh4a.R;
+
+public abstract class BasePagerDialog extends DialogFragment implements View.OnClickListener {
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.dialog_pager, container, false);
+
+        ViewPager pager = view.findViewById(R.id.dialog_pager);
+        pager.setAdapter(new FragmentPagerAdapter(getChildFragmentManager()) {
+            @Override
+            public Fragment getItem(int position) {
+                return makeFragment(position);
+            }
+
+            @Override
+            public CharSequence getPageTitle(int position) {
+                return getString(getTabTitleResIds()[position]);
+            }
+
+            @Override
+            public int getCount() {
+                int[] titleResIds = getTabTitleResIds();
+                return titleResIds != null ? titleResIds.length : 0;
+            }
+        });
+
+        Button cancelButton = view.findViewById(R.id.cancel_button);
+        cancelButton.setOnClickListener(this);
+
+        Button deselectButton = view.findViewById(R.id.deselect_button);
+        if (showDeselectButton()) {
+            deselectButton.setVisibility(View.VISIBLE);
+            deselectButton.setOnClickListener(this);
+        }
+
+        return view;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        int width = getResources().getDimensionPixelSize(R.dimen.pager_dialog_width);
+        int height = getResources().getDimensionPixelSize(R.dimen.pager_dialog_height);
+        getDialog().getWindow().setLayout(width, height);
+    }
+
+    @Override
+    public void onClick(View v) {
+        switch (v.getId()) {
+            case R.id.cancel_button:
+                dismiss();
+                break;
+            case R.id.deselect_button:
+                onDeselect();
+                break;
+        }
+    }
+
+    protected abstract int[] getTabTitleResIds();
+
+    protected abstract Fragment makeFragment(int position);
+
+    protected abstract boolean showDeselectButton();
+
+    protected void onDeselect() {
+    }
+}

--- a/app/src/main/java/com/gh4a/dialogs/MilestoneDialog.java
+++ b/app/src/main/java/com/gh4a/dialogs/MilestoneDialog.java
@@ -1,0 +1,104 @@
+package com.gh4a.dialogs;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import com.gh4a.R;
+import com.gh4a.fragment.IssueMilestoneListFragment;
+
+import org.eclipse.egit.github.core.Milestone;
+
+public class MilestoneDialog extends DialogFragment implements View.OnClickListener,
+        IssueMilestoneListFragment.SelectionCallback {
+    private static final String EXTRA_OWNER = "owner";
+    private static final String EXTRA_REPO = "repo";
+
+    public static MilestoneDialog newInstance(String repoOwner, String repoName) {
+        MilestoneDialog dialog = new MilestoneDialog();
+        Bundle args = new Bundle();
+        args.putString(EXTRA_OWNER, repoOwner);
+        args.putString(EXTRA_REPO, repoName);
+        dialog.setArguments(args);
+        return dialog;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
+        Bundle args = getArguments();
+        final String repoOwner = args.getString(EXTRA_OWNER);
+        final String repoName = args.getString(EXTRA_REPO);
+
+        View view = inflater.inflate(R.layout.dialog_milestone, container, false);
+
+        ViewPager pager = view.findViewById(R.id.dialog_pager);
+        pager.setAdapter(new FragmentPagerAdapter(getChildFragmentManager()) {
+            @Override
+            public Fragment getItem(int position) {
+                return IssueMilestoneListFragment.newInstance(
+                        repoOwner,
+                        repoName,
+                        position == 1,
+                        false);
+            }
+
+            @Override
+            public CharSequence getPageTitle(int position) {
+                return position == 1 ? "Closed" : "Open";
+            }
+
+            @Override
+            public int getCount() {
+                return 2;
+            }
+        });
+
+        Button cancelButton = view.findViewById(R.id.cancel_button);
+        cancelButton.setOnClickListener(this);
+
+        Button deselectButton = view.findViewById(R.id.deselect_button);
+        deselectButton.setOnClickListener(this);
+
+        return view;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        int width = getResources().getDimensionPixelSize(R.dimen.pager_dialog_width);
+        int height = getResources().getDimensionPixelSize(R.dimen.pager_dialog_height);
+        getDialog().getWindow().setLayout(width, height);
+    }
+
+    @Override
+    public void onClick(View v) {
+        switch (v.getId()) {
+            case R.id.cancel_button:
+                dismiss();
+                break;
+            case R.id.deselect_button:
+                onMilestoneSelected(null);
+                break;
+        }
+    }
+
+    @Override
+    public void onMilestoneSelected(@Nullable Milestone milestone) {
+        FragmentActivity activity = getActivity();
+        if (activity instanceof IssueMilestoneListFragment.SelectionCallback) {
+            ((IssueMilestoneListFragment.SelectionCallback) activity)
+                    .onMilestoneSelected(milestone);
+        }
+        dismiss();
+    }
+}

--- a/app/src/main/java/com/gh4a/dialogs/MilestoneDialog.java
+++ b/app/src/main/java/com/gh4a/dialogs/MilestoneDialog.java
@@ -2,25 +2,21 @@ package com.gh4a.dialogs;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.view.ViewPager;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.Button;
 
 import com.gh4a.R;
 import com.gh4a.fragment.IssueMilestoneListFragment;
 
 import org.eclipse.egit.github.core.Milestone;
 
-public class MilestoneDialog extends DialogFragment implements View.OnClickListener,
-        IssueMilestoneListFragment.SelectionCallback {
+public class MilestoneDialog extends BasePagerDialog
+        implements IssueMilestoneListFragment.SelectionCallback {
     private static final String EXTRA_OWNER = "owner";
     private static final String EXTRA_REPO = "repo";
+    private static final int[] TITLES = new int[] {
+            R.string.open, R.string.closed
+    };
 
     public static MilestoneDialog newInstance(String repoOwner, String repoName) {
         MilestoneDialog dialog = new MilestoneDialog();
@@ -31,65 +27,39 @@ public class MilestoneDialog extends DialogFragment implements View.OnClickListe
         return dialog;
     }
 
-    @Nullable
+    private String mRepoOwner;
+    private String mRepoName;
+
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
         Bundle args = getArguments();
-        final String repoOwner = args.getString(EXTRA_OWNER);
-        final String repoName = args.getString(EXTRA_REPO);
-
-        View view = inflater.inflate(R.layout.dialog_milestone, container, false);
-
-        ViewPager pager = view.findViewById(R.id.dialog_pager);
-        pager.setAdapter(new FragmentPagerAdapter(getChildFragmentManager()) {
-            @Override
-            public Fragment getItem(int position) {
-                return IssueMilestoneListFragment.newInstance(
-                        repoOwner,
-                        repoName,
-                        position == 1,
-                        false);
-            }
-
-            @Override
-            public CharSequence getPageTitle(int position) {
-                return position == 1 ? "Closed" : "Open";
-            }
-
-            @Override
-            public int getCount() {
-                return 2;
-            }
-        });
-
-        Button cancelButton = view.findViewById(R.id.cancel_button);
-        cancelButton.setOnClickListener(this);
-
-        Button deselectButton = view.findViewById(R.id.deselect_button);
-        deselectButton.setOnClickListener(this);
-
-        return view;
+        mRepoOwner = args.getString(EXTRA_OWNER);
+        mRepoName = args.getString(EXTRA_REPO);
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
-        int width = getResources().getDimensionPixelSize(R.dimen.pager_dialog_width);
-        int height = getResources().getDimensionPixelSize(R.dimen.pager_dialog_height);
-        getDialog().getWindow().setLayout(width, height);
+    protected int[] getTabTitleResIds() {
+        return TITLES;
     }
 
     @Override
-    public void onClick(View v) {
-        switch (v.getId()) {
-            case R.id.cancel_button:
-                dismiss();
-                break;
-            case R.id.deselect_button:
-                onMilestoneSelected(null);
-                break;
-        }
+    protected Fragment makeFragment(int position) {
+        return IssueMilestoneListFragment.newInstance(
+                mRepoOwner,
+                mRepoName,
+                position == 1,
+                false);
+    }
+
+    @Override
+    protected boolean showDeselectButton() {
+        return true;
+    }
+
+    @Override
+    protected void onDeselect() {
+        onMilestoneSelected(null);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/IssueMilestoneListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueMilestoneListFragment.java
@@ -18,6 +18,8 @@ package com.gh4a.fragment;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.support.v4.content.Loader;
 import android.support.v7.widget.RecyclerView;
 
@@ -82,9 +84,14 @@ public class IssueMilestoneListFragment extends ListDataBaseFragment<Milestone> 
 
     @Override
     public void onItemClick(Milestone milestone) {
-        startActivityForResult(IssueMilestoneEditActivity.makeEditIntent(
-                getActivity(), mRepoOwner, mRepoName, milestone, mFromPullRequest),
-                REQUEST_EDIT_MILESTONE);
+        Fragment parentFragment = getParentFragment();
+        if (parentFragment instanceof SelectionCallback) {
+            ((SelectionCallback) parentFragment).onMilestoneSelected(milestone);
+        } else {
+            startActivityForResult(IssueMilestoneEditActivity.makeEditIntent(
+                    getActivity(), mRepoOwner, mRepoName, milestone, mFromPullRequest),
+                    REQUEST_EDIT_MILESTONE);
+        }
     }
 
     @Override
@@ -103,5 +110,9 @@ public class IssueMilestoneListFragment extends ListDataBaseFragment<Milestone> 
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }
+    }
+
+    public interface SelectionCallback {
+        void onMilestoneSelected(@Nullable Milestone milestone);
     }
 }

--- a/app/src/main/res/layout/dialog_milestone.xml
+++ b/app/src/main/res/layout/dialog_milestone.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/dialog_pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/cancel_button">
+
+        <android.support.design.widget.TabLayout
+            android:id="@+id/dialog_pager_tabs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </android.support.v4.view.ViewPager>
+
+    <Button
+        android:id="@+id/deselect_button"
+        style="@style/Widget.AppCompat.Button.Borderless.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_gravity="right|end"
+        android:layout_toLeftOf="@+id/cancel_button"
+        android:text="@string/deselect" />
+
+    <Button
+        android:id="@+id/cancel_button"
+        style="@style/Widget.AppCompat.Button.Borderless.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true"
+        android:layout_gravity="right|end"
+        android:text="@string/cancel" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/dialog_pager.xml
+++ b/app/src/main/res/layout/dialog_pager.xml
@@ -25,7 +25,8 @@
         android:layout_alignParentBottom="true"
         android:layout_gravity="right|end"
         android:layout_toLeftOf="@+id/cancel_button"
-        android:text="@string/deselect" />
+        android:text="@string/deselect"
+        android:visibility="gone" />
 
     <Button
         android:id="@+id/cancel_button"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -33,4 +33,7 @@
     <dimen name="divider_span_height">1dp</dimen>
 
     <dimen name="code_diff_padding">8dp</dimen>
+
+    <dimen name="pager_dialog_width">336dp</dimen>
+    <dimen name="pager_dialog_height">448dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -518,4 +518,5 @@
     <string name="wiki_print_document_title">Wiki page %1$s in %2$s/%3$s</string>
 
     <string name="repository_owner_avatar">Repository owner avatar</string>
+    <string name="deselect">Deselect</string>
 </resources>


### PR DESCRIPTION
I've changed the milestone selection dialog to consist of view pager that allows for selection of closed milestones.

I'm not 100% sure about the look of this. We could modify a bit the appearance of milestones to highlight which one is selected. And I'm not really sure if the "deselect" button is a good idea. Sadly I don't have a better one. Also, we might want to colorize the pager tabs.

What is missing is the functionality of old "Manage milestones" buttons. We could add it like in old dialog (perhaps stack buttons) but I'm open to other suggestions.

Preview:
![milestone-dialog](https://user-images.githubusercontent.com/5156340/30775821-c51aea42-a09b-11e7-82ee-733e7875597a.gif)

Closes #570 

_From unrelated notes, I've added new wip label because I don't like adding WIP to titles._