### PR TITLE
Change applicationId on debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,7 @@ android {
         targetSdkVersion 26
         versionCode 56
         versionName "4.2.2"
+        applicationId "com.gh4a"
 
         buildConfigField 'String', 'CLIENT_ID', ClientId
         buildConfigField 'String', 'CLIENT_SECRET', ClientSecret
@@ -42,6 +43,7 @@ android {
 
     buildTypes {
         debug {
+            applicationIdSuffix '.debug'
             zipAlignEnabled true
         }
         release {

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="app_name">OctoDroid Debug</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -157,12 +157,12 @@
 
         <provider
             android:name=".db.BookmarksProvider"
-            android:authorities="com.gh4a"
+            android:authorities="${applicationId}"
             android:exported="false" />
 
         <provider
             android:name=".db.SuggestionsProvider"
-            android:authorities="com.gh4a.SuggestionsProvider"
+            android:authorities="${applicationId}.SuggestionsProvider"
             android:exported="false" />
 
         <receiver

--- a/app/src/main/java/com/gh4a/db/BookmarksProvider.java
+++ b/app/src/main/java/com/gh4a/db/BookmarksProvider.java
@@ -16,12 +16,16 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.gh4a.R;
+import com.gh4a.BuildConfig;
+
+import java.util.Locale;
 
 public class BookmarksProvider extends ContentProvider {
     private static final String TAG = "BookmarksProvider";
 
     public interface Columns extends BaseColumns {
-        Uri CONTENT_URI = Uri.parse("content://com.gh4a/bookmarks");
+        Uri CONTENT_URI = Uri.parse(String.format(Locale.US,
+                "content://%s/bookmarks", BuildConfig.APPLICATION_ID));
 
         String NAME = "name";
         String TYPE = "type";
@@ -40,8 +44,8 @@ public class BookmarksProvider extends ContentProvider {
             sURIMatcher = new UriMatcher(UriMatcher.NO_MATCH);
 
     static {
-        sURIMatcher.addURI("com.gh4a", "bookmarks", MATCH_ALL);
-        sURIMatcher.addURI("com.gh4a", "bookmarks/#", MATCH_ID);
+        sURIMatcher.addURI(BuildConfig.APPLICATION_ID, "bookmarks", MATCH_ALL);
+        sURIMatcher.addURI(BuildConfig.APPLICATION_ID, "bookmarks/#", MATCH_ID);
     }
 
     private DbHelper mDbHelper;

--- a/app/src/main/java/com/gh4a/db/SuggestionsProvider.java
+++ b/app/src/main/java/com/gh4a/db/SuggestionsProvider.java
@@ -12,11 +12,16 @@ import android.provider.BaseColumns;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import com.gh4a.BuildConfig;
+
+import java.util.Locale;
+
 public class SuggestionsProvider extends ContentProvider {
     private static final String TAG = "SuggestionsProvider";
 
     public interface Columns extends BaseColumns {
-        Uri CONTENT_URI = Uri.parse("content://com.gh4a.SuggestionsProvider/suggestions");
+        Uri CONTENT_URI = Uri.parse(String.format(Locale.US,
+                "content://%s.SuggestionsProvider/suggestions", BuildConfig.APPLICATION_ID));
 
         String TYPE = "type";
         String SUGGESTION = "suggestion";
@@ -33,7 +38,9 @@ public class SuggestionsProvider extends ContentProvider {
             sURIMatcher = new UriMatcher(UriMatcher.NO_MATCH);
 
     static {
-        sURIMatcher.addURI("com.gh4a.SuggestionsProvider", "suggestions", MATCH_ALL);
+        sURIMatcher.addURI(
+                String.format(Locale.US, "%s.SuggestionsProvider", BuildConfig.APPLICATION_ID),
+                "suggestions", MATCH_ALL);
     }
 
     private DbHelper mDbHelper;


### PR DESCRIPTION
This allows installing debug and release builds side-by-side, so you can test WIP changes without uninstalling the current stable version.

When I've done this in the past, there's sometimes places where you'll get unintended dialogs prompting which app you want to complete the action in (for example, when both apps define the same intent filter). These can be fixed as we find them, and also they're acceptable since the people running debug versions know to expect that.

So far I have not done much testing, but I have started using this locally and it seems to work fine. The only duplicate intent filter I found so far is opening `gh4a://` links during github authorization. I don't have time to fix that right now, but I think this is ok to merge even so (or you can do it).

TODO:

- [x] Fix crash on opening any repo home page