### PR TITLE
keep simplexml annotated methods too

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -17,8 +17,7 @@
 # Keep SimpleXML
 -keep class org.simpleframework.xml.**{ *; }
 -keepclassmembers class * {
-    @org.simpleframework.xml.* <fields>;
-    @org.simpleframework.xml.* <init>(...);
+    @org.simpleframework.xml.** *;
 }
 # Keep attributes for SimpleXML
 -keepattributes ElementList, Root


### PR DESCRIPTION
example: Feed.apply() is currently optimized away by proguard in release build, resulting in blank entries in recent wiki updates list and blank github blog previews (title of blog entry is shown).

We could just add `@org.simpleframework.xml.core.* <methods>` but IMHO replacing with `@org.simpleframework.xml.** *` is more future-proof.