### PR TITLE
Some fixes

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/PullRequestFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestFragment.java
@@ -36,8 +36,8 @@ import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.Optional;
 import com.gh4a.utils.RxUtils;
-import com.gh4a.widget.PullRequestBranchInfoView;
 import com.gh4a.widget.CommitStatusBox;
+import com.gh4a.widget.PullRequestBranchInfoView;
 
 import com.meisolsson.githubsdk.model.GitHubCommentBase;
 import com.meisolsson.githubsdk.model.GitHubFile;
@@ -298,7 +298,7 @@ public class PullRequestFragment extends IssueFragmentBase {
         }));
 
         Single<List<TimelineItem.TimelineComment>> commitCommentWithoutReviewSingle = Single.zip(
-                prCommentSingle.compose(RxUtils.filter(comment -> comment.pullRequestReviewId() == 0)),
+                prCommentSingle.compose(RxUtils.filter(comment -> comment.pullRequestReviewId() == null)),
                 filesByNameSingle,
                 (comments, files) -> {
                     List<TimelineItem.TimelineComment> items = new ArrayList<>();


### PR DESCRIPTION
Stacktrace for NPE:
```
E/AndroidRuntime(729): FATAL EXCEPTION: main
E/AndroidRuntime(729): Process: com.gh4a, PID: 729
E/AndroidRuntime(729): io.reactivex.exceptions.CompositeException: 1 exceptions occurred. 
E/AndroidRuntime(729): 	at io.reactivex.internal.observers.ConsumerSingleObserver.onError(ConsumerSingleObserver.java:47)
E/AndroidRuntime(729): 	at com.philosophicalhacker.lib.ReactiveLoaders$LoaderSingle$1.onError(ReactiveLoaders.java:51)
E/AndroidRuntime(729): 	at com.philosophicalhacker.lib.RxLoaderCallbacks.onLoadFinished(RxLoaderCallbacks.java:33)
E/AndroidRuntime(729): 	at android.support.v4.app.LoaderManagerImpl$LoaderObserver.onChanged(LoaderManagerImpl.java:248)
E/AndroidRuntime(729): 	at android.arch.lifecycle.LiveData.considerNotify(LiveData.java:109)
E/AndroidRuntime(729): 	at android.arch.lifecycle.LiveData.dispatchingValue(LiveData.java:126)
E/AndroidRuntime(729): 	at android.arch.lifecycle.LiveData.setValue(LiveData.java:282)
E/AndroidRuntime(729): 	at android.arch.lifecycle.MutableLiveData.setValue(MutableLiveData.java:33)
E/AndroidRuntime(729): 	at android.support.v4.app.LoaderManagerImpl$LoaderInfo.setValue(LoaderManagerImpl.java:188)
E/AndroidRuntime(729): 	at android.support.v4.app.LoaderManagerImpl$LoaderInfo.onLoadComplete(LoaderManagerImpl.java:173)
E/AndroidRuntime(729): 	at android.support.v4.content.Loader.deliverResult(Loader.java:130)
E/AndroidRuntime(729): 	at com.philosophicalhacker.lib.RxLoaderCallbacks$RxAndroidLoader.safeDeliverResult(RxLoaderCallbacks.java:109)
E/AndroidRuntime(729): 	at com.philosophicalhacker.lib.RxLoaderCallbacks$RxAndroidLoader.access$000(RxLoaderCallbacks.java:44)
E/AndroidRuntime(729): 	at com.philosophicalhacker.lib.RxLoaderCallbacks$RxAndroidLoader$2.accept(RxLoaderCallbacks.java:85)
E/AndroidRuntime(729): 	at com.philosophicalhacker.lib.RxLoaderCallbacks$RxAndroidLoader$2.accept(RxLoaderCallbacks.java:82)
E/AndroidRuntime(729): 	at io.reactivex.internal.observers.ConsumerSingleObserver.onError(ConsumerSingleObserver.java:44)
E/AndroidRuntime(729): 	at io.reactivex.internal.operators.single.SingleObserveOn$ObserveOnSingleObserver.run(SingleObserveOn.java:79)
E/AndroidRuntime(729): 	at io.reactivex.android.schedulers.HandlerScheduler$ScheduledRunnable.run(HandlerScheduler.java:109)
E/AndroidRuntime(729): 	at android.os.Handler.handleCallback(Handler.java:751)
E/AndroidRuntime(729): 	at android.os.Handler.dispatchMessage(Handler.java:95)
E/AndroidRuntime(729): 	at android.os.Looper.loop(Looper.java:154)
E/AndroidRuntime(729): 	at android.app.ActivityThread.main(ActivityThread.java:6186)
E/AndroidRuntime(729): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(729): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
E/AndroidRuntime(729): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
E/AndroidRuntime(729):   ComposedException 1 :
E/AndroidRuntime(729): 	java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Integer.intValue()' on a null object reference
E/AndroidRuntime(729): 		at com.gh4a.fragment.PullRequestFragment.lambda$onCreateDataSingle$13$PullRequestFragment(PullRequestFragment.java:301)
E/AndroidRuntime(729): 		at com.gh4a.fragment.PullRequestFragment$$Lambda$14.test(Unknown Source)
E/AndroidRuntime(729): 		at com.gh4a.utils.RxUtils.lambda$null$0$RxUtils(RxUtils.java:37)
E/AndroidRuntime(729): 		at com.gh4a.utils.RxUtils$$Lambda$13.apply(Unknown Source)
E/AndroidRuntime(729): 		at io.reactivex.internal.operators.single.SingleMap$MapSingleObserver.onSuccess(SingleMap.java:56)
E/AndroidRuntime(729): 		at io.reactivex.internal.operators.single.SingleCache.subscribeActual(SingleCache.java:59)
E/AndroidRuntime(729): 		at io.reactivex.Single.subscribe(Single.java:2692)
E/AndroidRuntime(729): 		at io.reactivex.internal.operators.single.SingleMap.subscribeActual(SingleMap.java:33)
E/AndroidRuntime(729): 		at io.reactivex.Single.subscribe(Single.java:2692)
E/AndroidRuntime(729): 		at io.reactivex.internal.operators.single.SingleZipArray.subscribeActual(SingleZipArray.java:69)
E/AndroidRuntime(729): 		at io.reactivex.Single.subscribe(Single.java:2692)
E/AndroidRuntime(729): 		at io.reactivex.internal.operators.single.SingleZipArray.subscribeActual(SingleZipArray.java:69)
E/AndroidRuntime(729): 		at io.reactivex.Single.subscribe(Single.java:2692)
E/AndroidRuntime(729): 		at io.reactivex.internal.operators.single.SingleSubscribeOn$SubscribeOnObserver.run(SingleSubscribeOn.java:89)
E/AndroidRuntime(729): 		at io.reactivex.Scheduler$1.run(Scheduler.java:138)
E/AndroidRuntime(729): 		at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:59)
E/AndroidRuntime(729): 		at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:51)
E/AndroidRuntime(729): 		at java.util.concurrent.FutureTask.run(FutureTask.java:237)
E/AndroidRuntime(729): 		at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:272)
E/AndroidRuntime(729): 		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
E/AndroidRuntime(729): 		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
E/AndroidRuntime(729): 		at java.lang.Thread.run(Thread.java:761)
```