### PR TITLE
Prevent white splash on cold start

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:allowBackup="true"
         android:icon="@drawable/octodroid"
         android:label="@string/app_name"
-        android:theme="@style/LightTheme"
+        android:theme="@style/TransparentLightTheme"
         android:fullBackupContent="@xml/backup_descriptor">
         <activity
             android:name=".activities.Github4AndroidActivity"


### PR DESCRIPTION
Currently gh4a sets the user theme in BaseActivity::onCreate() https://github.com/slapperwan/gh4a/blob/b07d0d4ab5d22739823f592212fc6b516e08c8c8/app/src/main/java/com/gh4a/BaseActivity.java#L138-L139 but still the white splash is frequently shown on budget devices during a cold start of the app, which is extremely annoying in case the dark theme is used in the app and in the entire UI of the device (lots of apps have this problem, BTW).

This patch makes it so that a transparent default theme is shown before the actual theme is applied. On a slower device nothing will be shown after the user launched the app until the main screen is presented so one might think that could perplex some users, but I think they are used to their device being slow and encounter such pauses regularly. On a fast device there'll be no perceivable difference to the old behavior.