### PR TITLE
Repository ui polish

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -227,24 +227,23 @@ public class RepositoryFragment extends LoadingFragmentBase implements
         tvRepoName.setText(repoName);
         tvRepoName.setMovementMethod(UiUtils.CHECKING_LINK_METHOD);
 
-        TextView tvParentRepo = mContentView.findViewById(R.id.tv_parent);
-        if (mRepository.isFork() && mRepository.parent() != null) {
-            Repository parent = mRepository.parent();
-            tvParentRepo.setVisibility(View.VISIBLE);
-            tvParentRepo.setText(getString(R.string.forked_from,
-                    parent.owner().login() + "/" + parent.name()));
-            tvParentRepo.setOnClickListener(this);
-            tvParentRepo.setTag(parent);
-        } else {
-            tvParentRepo.setVisibility(View.GONE);
-        }
-
         fillTextView(R.id.tv_desc, 0, mRepository.description());
         fillTextView(R.id.tv_url, 0, !StringUtils.isBlank(mRepository.homepage())
                 ? mRepository.homepage() : mRepository.htmlUrl());
 
         final String owner = mRepository.owner().login();
         final String name = mRepository.name();
+
+        OverviewRow forkParentRow = mContentView.findViewById(R.id.fork_parent_row);
+        if (mRepository.isFork() && mRepository.parent() != null) {
+            Repository parent = mRepository.parent();
+            forkParentRow.setVisibility(View.VISIBLE);
+            forkParentRow.setText(getString(R.string.forked_from,
+                    parent.owner().login() + "/" + parent.name()));
+            forkParentRow.setClickIntent(RepositoryActivity.makeIntent(getActivity(), parent));
+        } else {
+            forkParentRow.setVisibility(View.GONE);
+        }
 
         OverviewRow privateRow = mContentView.findViewById(R.id.private_row);
         privateRow.setVisibility(mRepository.isPrivate() ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -228,8 +228,7 @@ public class RepositoryFragment extends LoadingFragmentBase implements
         tvRepoName.setMovementMethod(UiUtils.CHECKING_LINK_METHOD);
 
         fillTextView(R.id.tv_desc, 0, mRepository.description());
-        fillTextView(R.id.tv_url, 0, !StringUtils.isBlank(mRepository.homepage())
-                ? mRepository.homepage() : mRepository.htmlUrl());
+        fillTextView(R.id.tv_url, 0, mRepository.homepage());
 
         final String owner = mRepository.owner().login();
         final String name = mRepository.name();

--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -19,8 +19,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Typeface;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.LoaderManager;
+import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.style.ForegroundColorSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -237,9 +241,8 @@ public class RepositoryFragment extends LoadingFragmentBase implements
         if (mRepository.isFork() && mRepository.parent() != null) {
             Repository parent = mRepository.parent();
             forkParentRow.setVisibility(View.VISIBLE);
-            forkParentRow.setText(getString(R.string.forked_from,
-                    parent.owner().login() + "/" + parent.name()));
-            forkParentRow.setClickIntent(RepositoryActivity.makeIntent(getActivity(), parent));
+            forkParentRow.setText(getForkedFromTextWithHighlight(parent));
+            forkParentRow.setClickIntent(RepositoryActivity.makeIntent(getActivity(), parent), false);
         } else {
             forkParentRow.setVisibility(View.GONE);
         }
@@ -260,23 +263,23 @@ public class RepositoryFragment extends LoadingFragmentBase implements
 
         OverviewRow issuesRow = mContentView.findViewById(R.id.issues_row);
         issuesRow.setVisibility(mRepository.hasIssues() ? View.VISIBLE : View.GONE);
-        issuesRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name));
+        issuesRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name), true);
 
         OverviewRow pullsRow = mContentView.findViewById(R.id.pulls_row);
-        pullsRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name, true));
+        pullsRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name, true), true);
 
         OverviewRow forksRow = mContentView.findViewById(R.id.forks_row);
         forksRow.setText(getResources().getQuantityString(R.plurals.fork,
                 mRepository.forksCount(), mRepository.forksCount()));
-        forksRow.setClickIntent(ForkListActivity.makeIntent(getActivity(), owner, name));
+        forksRow.setClickIntent(ForkListActivity.makeIntent(getActivity(), owner, name), true);
 
         mStarsRow = mContentView.findViewById(R.id.stars_row);
         mStarsRow.setIconClickListener(this);
-        mStarsRow.setClickIntent(StargazerListActivity.makeIntent(getActivity(), owner, name));
+        mStarsRow.setClickIntent(StargazerListActivity.makeIntent(getActivity(), owner, name), true);
 
         mWatcherRow = mContentView.findViewById(R.id.watchers_row);
         mWatcherRow.setIconClickListener(this);
-        mWatcherRow.setClickIntent(WatcherListActivity.makeIntent(getActivity(), owner, name));
+        mWatcherRow.setClickIntent(WatcherListActivity.makeIntent(getActivity(), owner, name), true);
 
         if (!Gh4Application.get().isAuthorized()) {
             updateWatcherUi();
@@ -292,6 +295,15 @@ public class RepositoryFragment extends LoadingFragmentBase implements
         updateClickableLabel(R.id.tv_collaborators_label,
                 permissions != null && permissions.push());
         updateClickableLabel(R.id.tv_wiki_label, mRepository.hasWiki());
+    }
+
+    @NonNull
+    private SpannableString getForkedFromTextWithHighlight(Repository parent) {
+        String forkedFromText = getString(R.string.forked_from, parent.fullName());
+        SpannableString spannableString = new SpannableString(forkedFromText);
+        ForegroundColorSpan colorSpan = new ForegroundColorSpan(UiUtils.resolveColor(getContext(), android.R.attr.textColorLink));
+        spannableString.setSpan(colorSpan, forkedFromText.indexOf(parent.fullName()), forkedFromText.length(), Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+        return spannableString;
     }
 
     private void updateClickableLabel(int id, boolean enable) {

--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -252,6 +252,12 @@ public class RepositoryFragment extends LoadingFragmentBase implements
                 ? View.GONE : View.VISIBLE);
         languageRow.setText(getString(R.string.repo_language, mRepository.language()));
 
+        boolean showOverviewRowDivider = forkParentRow.getVisibility() == View.VISIBLE
+                || privateRow.getVisibility() == View.VISIBLE
+                || languageRow.getVisibility() == View.VISIBLE;
+        mContentView.findViewById(R.id.repository_overview_row_divider)
+                .setVisibility(showOverviewRowDivider ? View.VISIBLE : View.GONE);
+
         OverviewRow issuesRow = mContentView.findViewById(R.id.issues_row);
         issuesRow.setVisibility(mRepository.hasIssues() ? View.VISIBLE : View.GONE);
         issuesRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name));

--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -246,6 +246,9 @@ public class RepositoryFragment extends LoadingFragmentBase implements
         final String owner = mRepository.owner().login();
         final String name = mRepository.name();
 
+        OverviewRow privateRow = mContentView.findViewById(R.id.private_row);
+        privateRow.setVisibility(mRepository.isPrivate() ? View.VISIBLE : View.GONE);
+
         OverviewRow languageRow = mContentView.findViewById(R.id.language_row);
         languageRow.setVisibility(StringUtils.isBlank(mRepository.language())
                 ? View.GONE : View.VISIBLE);
@@ -285,10 +288,6 @@ public class RepositoryFragment extends LoadingFragmentBase implements
         updateClickableLabel(R.id.tv_collaborators_label,
                 permissions != null && permissions.push());
         updateClickableLabel(R.id.tv_wiki_label, mRepository.hasWiki());
-
-        mContentView.findViewById(R.id.tv_private).setVisibility(
-                mRepository.isPrivate() ? View.VISIBLE : View.GONE);
-
     }
 
     private void updateClickableLabel(int id, boolean enable) {

--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -242,7 +242,7 @@ public class RepositoryFragment extends LoadingFragmentBase implements
             Repository parent = mRepository.parent();
             forkParentRow.setVisibility(View.VISIBLE);
             forkParentRow.setText(getForkedFromTextWithHighlight(parent));
-            forkParentRow.setClickIntent(RepositoryActivity.makeIntent(getActivity(), parent), false);
+            forkParentRow.setClickIntent(RepositoryActivity.makeIntent(getActivity(), parent));
         } else {
             forkParentRow.setVisibility(View.GONE);
         }
@@ -263,23 +263,23 @@ public class RepositoryFragment extends LoadingFragmentBase implements
 
         OverviewRow issuesRow = mContentView.findViewById(R.id.issues_row);
         issuesRow.setVisibility(mRepository.hasIssues() ? View.VISIBLE : View.GONE);
-        issuesRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name), true);
+        issuesRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name));
 
         OverviewRow pullsRow = mContentView.findViewById(R.id.pulls_row);
-        pullsRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name, true), true);
+        pullsRow.setClickIntent(IssueListActivity.makeIntent(getActivity(), owner, name, true));
 
         OverviewRow forksRow = mContentView.findViewById(R.id.forks_row);
         forksRow.setText(getResources().getQuantityString(R.plurals.fork,
                 mRepository.forksCount(), mRepository.forksCount()));
-        forksRow.setClickIntent(ForkListActivity.makeIntent(getActivity(), owner, name), true);
+        forksRow.setClickIntent(ForkListActivity.makeIntent(getActivity(), owner, name));
 
         mStarsRow = mContentView.findViewById(R.id.stars_row);
         mStarsRow.setIconClickListener(this);
-        mStarsRow.setClickIntent(StargazerListActivity.makeIntent(getActivity(), owner, name), true);
+        mStarsRow.setClickIntent(StargazerListActivity.makeIntent(getActivity(), owner, name));
 
         mWatcherRow = mContentView.findViewById(R.id.watchers_row);
         mWatcherRow.setIconClickListener(this);
-        mWatcherRow.setClickIntent(WatcherListActivity.makeIntent(getActivity(), owner, name), true);
+        mWatcherRow.setClickIntent(WatcherListActivity.makeIntent(getActivity(), owner, name));
 
         if (!Gh4Application.get().isAuthorized()) {
             updateWatcherUi();

--- a/app/src/main/java/com/gh4a/fragment/UserFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/UserFragment.java
@@ -151,15 +151,15 @@ public class UserFragment extends LoadingFragmentBase implements
         if (isUser) {
             mFollowersRow.setIconClickListener(canFollowUser() ? this : null);
             mFollowersRow.setClickIntent(FollowerFollowingListActivity.makeIntent(
-                    getActivity(), mUser.login(), true), true);
+                    getActivity(), mUser.login(), true));
 
             followingRow.setText(getResources().getQuantityString(R.plurals.following,
                     mUser.following(), mUser.following()));
             followingRow.setClickIntent(FollowerFollowingListActivity.makeIntent(
-                    getActivity(), mUser.login(), false), true);
+                    getActivity(), mUser.login(), false));
         } else {
             membersRow.setClickIntent(OrganizationMemberListActivity.makeIntent(
-                    getActivity(), mUser.login()), true);
+                    getActivity(), mUser.login()));
         }
 
         OverviewRow gistsRow = mContentView.findViewById(R.id.gists_row);
@@ -167,13 +167,13 @@ public class UserFragment extends LoadingFragmentBase implements
         if (isUser) {
             int totalCount = orZero(mUser.publicGists()) + orZero(mUser.privateGists());
             gistsRow.setText(getResources().getQuantityString(R.plurals.gist, totalCount, totalCount));
-            gistsRow.setClickIntent(GistListActivity.makeIntent(getActivity(), mUser.login()), true);
+            gistsRow.setClickIntent(GistListActivity.makeIntent(getActivity(), mUser.login()));
         }
 
         OverviewRow reposRow = mContentView.findViewById(R.id.repos_row);
         int repoCount = orZero(mUser.totalPrivateRepos()) + orZero(mUser.publicRepos());
         reposRow.setText(getResources().getQuantityString(R.plurals.repository, repoCount, repoCount));
-        reposRow.setClickIntent(RepositoryListActivity.makeIntent(getActivity(), mUser.login(), !isUser), true);
+        reposRow.setClickIntent(RepositoryListActivity.makeIntent(getActivity(), mUser.login(), !isUser));
 
         TextView tvName = mContentView.findViewById(R.id.tv_name);
         String name = StringUtils.isBlank(mUser.name()) ? mUser.login() : mUser.name();

--- a/app/src/main/java/com/gh4a/fragment/UserFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/UserFragment.java
@@ -151,15 +151,15 @@ public class UserFragment extends LoadingFragmentBase implements
         if (isUser) {
             mFollowersRow.setIconClickListener(canFollowUser() ? this : null);
             mFollowersRow.setClickIntent(FollowerFollowingListActivity.makeIntent(
-                    getActivity(), mUser.login(), true));
+                    getActivity(), mUser.login(), true), true);
 
             followingRow.setText(getResources().getQuantityString(R.plurals.following,
                     mUser.following(), mUser.following()));
             followingRow.setClickIntent(FollowerFollowingListActivity.makeIntent(
-                    getActivity(), mUser.login(), false));
+                    getActivity(), mUser.login(), false), true);
         } else {
             membersRow.setClickIntent(OrganizationMemberListActivity.makeIntent(
-                    getActivity(), mUser.login()));
+                    getActivity(), mUser.login()), true);
         }
 
         OverviewRow gistsRow = mContentView.findViewById(R.id.gists_row);
@@ -167,13 +167,13 @@ public class UserFragment extends LoadingFragmentBase implements
         if (isUser) {
             int totalCount = orZero(mUser.publicGists()) + orZero(mUser.privateGists());
             gistsRow.setText(getResources().getQuantityString(R.plurals.gist, totalCount, totalCount));
-            gistsRow.setClickIntent(GistListActivity.makeIntent(getActivity(), mUser.login()));
+            gistsRow.setClickIntent(GistListActivity.makeIntent(getActivity(), mUser.login()), true);
         }
 
         OverviewRow reposRow = mContentView.findViewById(R.id.repos_row);
         int repoCount = orZero(mUser.totalPrivateRepos()) + orZero(mUser.publicRepos());
         reposRow.setText(getResources().getQuantityString(R.plurals.repository, repoCount, repoCount));
-        reposRow.setClickIntent(RepositoryListActivity.makeIntent(getActivity(), mUser.login(), !isUser));
+        reposRow.setClickIntent(RepositoryListActivity.makeIntent(getActivity(), mUser.login(), !isUser), true);
 
         TextView tvName = mContentView.findViewById(R.id.tv_name);
         String name = StringUtils.isBlank(mUser.name()) ? mUser.login() : mUser.name();

--- a/app/src/main/java/com/gh4a/widget/OverviewRow.java
+++ b/app/src/main/java/com/gh4a/widget/OverviewRow.java
@@ -78,10 +78,10 @@ public class OverviewRow extends LinearLayoutCompat implements View.OnClickListe
         mProgress.setVisibility(text != null ? View.GONE : View.VISIBLE);
     }
 
-    public void setClickIntent(Intent intent) {
+    public void setClickIntent(Intent intent, Boolean displayRedirectArrow) {
         mClickIntent = intent;
         if (intent != null) {
-            mRedirectNotice.setVisibility(View.VISIBLE);
+            mRedirectNotice.setVisibility(displayRedirectArrow ? View.VISIBLE : View.GONE);
             setOnClickListener(this);
         } else {
             mRedirectNotice.setVisibility(View.GONE);

--- a/app/src/main/java/com/gh4a/widget/OverviewRow.java
+++ b/app/src/main/java/com/gh4a/widget/OverviewRow.java
@@ -83,11 +83,17 @@ public class OverviewRow extends LinearLayoutCompat implements View.OnClickListe
     public void setClickIntent(Intent intent) {
         mClickIntent = intent;
         if (intent != null) {
-            mRedirectNotice.setVisibility(mDisplayRedirectArrowWhenClickable ? View.VISIBLE : View.GONE);
             setOnClickListener(this);
         } else {
-            mRedirectNotice.setVisibility(View.GONE);
             setClickable(false);
+        }
+    }
+
+    @Override
+    public void setClickable(boolean clickable) {
+        super.setClickable(clickable);
+        if (mDisplayRedirectArrowWhenClickable) {
+            mRedirectNotice.setVisibility(clickable ? VISIBLE : GONE);
         }
     }
 

--- a/app/src/main/java/com/gh4a/widget/OverviewRow.java
+++ b/app/src/main/java/com/gh4a/widget/OverviewRow.java
@@ -31,6 +31,7 @@ public class OverviewRow extends LinearLayoutCompat implements View.OnClickListe
 
     private String mActionHintChecked;
     private String mActionHintUnchecked;
+    private boolean mDisplayRedirectArrowWhenClickable;
 
     public OverviewRow(Context context) {
         this(context, null);
@@ -58,6 +59,7 @@ public class OverviewRow extends LinearLayoutCompat implements View.OnClickListe
 
         mActionHintChecked = a.getString(R.styleable.OverviewRow_rowIconActionHintOn);
         mActionHintUnchecked = a.getString(R.styleable.OverviewRow_rowIconActionHintOff);
+        mDisplayRedirectArrowWhenClickable = a.getBoolean(R.styleable.OverviewRow_displayRedirectArrowWhenClickable, true);
 
         a.recycle();
     }
@@ -78,10 +80,10 @@ public class OverviewRow extends LinearLayoutCompat implements View.OnClickListe
         mProgress.setVisibility(text != null ? View.GONE : View.VISIBLE);
     }
 
-    public void setClickIntent(Intent intent, Boolean displayRedirectArrow) {
+    public void setClickIntent(Intent intent) {
         mClickIntent = intent;
         if (intent != null) {
-            mRedirectNotice.setVisibility(displayRedirectArrow ? View.VISIBLE : View.GONE);
+            mRedirectNotice.setVisibility(mDisplayRedirectArrowWhenClickable ? View.VISIBLE : View.GONE);
             setOnClickListener(this);
         } else {
             mRedirectNotice.setVisibility(View.GONE);

--- a/app/src/main/res/drawable/icon_following.xml
+++ b/app/src/main/res/drawable/icon_following.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M16.5,12c1.38,0 2.49,-1.12 2.49,-2.5S17.88,7 16.5,7C15.12,7 14,8.12 14,9.5s1.12,2.5 2.5,2.5zM9,11c1.66,0 2.99,-1.34 2.99,-3S10.66,5 9,5C7.34,5 6,6.34 6,8s1.34,3 3,3zM16.5,14c-1.83,0 -5.5,0.92 -5.5,2.75L11,19h11v-2.25c0,-1.83 -3.67,-2.75 -5.5,-2.75zM9,13c-2.33,0 -7,1.17 -7,3.5L2,19h7v-2.25c0,-0.85 0.33,-2.34 2.37,-3.47C10.5,13.1 9.66,13 9,13z"/>
+</vector>

--- a/app/src/main/res/drawable/icon_private.xml
+++ b/app/src/main/res/drawable/icon_private.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/app/src/main/res/layout/repository.xml
+++ b/app/src/main/res/layout/repository.xml
@@ -61,6 +61,7 @@
                     android:id="@+id/fork_parent_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    app:displayRedirectArrowWhenClickable="false"
                     app:rowIcon="@drawable/icon_fork"
                     app:rowText="Forked from other/repository" />
 

--- a/app/src/main/res/layout/repository.xml
+++ b/app/src/main/res/layout/repository.xml
@@ -66,23 +66,18 @@
                     android:textColorLink="?android:attr/textColorLink"
                     tools:text="https://example.com" />
 
-                <com.gh4a.widget.StyleableTextView
-                    android:id="@+id/tv_private"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
-                    android:drawableLeft="?attr/privateSmallIcon"
-                    android:drawablePadding="4dp"
-                    android:paddingLeft="@dimen/content_padding"
-                    android:paddingRight="@dimen/content_padding"
-                    android:text="@string/repo_type_private"
-                    android:textAppearance="@style/TextAppearance.VerySmall.Bold"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
-
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="16dp" />
+
+                <com.gh4a.widget.OverviewRow
+                    android:id="@+id/private_row"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    app:rowIcon="@drawable/icon_private"
+                    app:rowText="@string/repo_type_private"
+                    tools:visibility="visible" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/language_row"

--- a/app/src/main/res/layout/repository.xml
+++ b/app/src/main/res/layout/repository.xml
@@ -32,19 +32,6 @@
                     tools:text="Username/Repository" />
 
                 <com.gh4a.widget.StyleableTextView
-                    android:id="@+id/tv_parent"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="8dp"
-                    android:paddingLeft="@dimen/content_padding"
-                    android:paddingRight="@dimen/content_padding"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorLink"
-                    app:ghFont="italic"
-                    tools:text="forked from other/repository" />
-
-                <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_desc"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -69,6 +56,13 @@
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="16dp" />
+
+                <com.gh4a.widget.OverviewRow
+                    android:id="@+id/fork_parent_row"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:rowIcon="@drawable/icon_fork"
+                    app:rowText="Forked from other/repository" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/private_row"

--- a/app/src/main/res/layout/repository.xml
+++ b/app/src/main/res/layout/repository.xml
@@ -80,12 +80,14 @@
                     android:visibility="gone"
                     tools:visibility="visible" />
 
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="16dp" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/language_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
                     app:rowIcon="@drawable/icon_language"
                     tools:rowText="Written in Java" />
 

--- a/app/src/main/res/layout/repository.xml
+++ b/app/src/main/res/layout/repository.xml
@@ -53,7 +53,7 @@
                     android:textColorLink="?android:attr/textColorLink"
                     tools:text="https://example.com" />
 
-                <View
+                <Space
                     android:layout_width="match_parent"
                     android:layout_height="16dp" />
 
@@ -68,10 +68,8 @@
                     android:id="@+id/private_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
                     app:rowIcon="@drawable/icon_private"
-                    app:rowText="@string/repo_type_private"
-                    tools:visibility="visible" />
+                    app:rowText="@string/repo_type_private" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/language_row"
@@ -79,6 +77,11 @@
                     android:layout_height="wrap_content"
                     app:rowIcon="@drawable/icon_language"
                     tools:rowText="Written in Java" />
+
+                <Space
+                    android:id="@+id/repository_overview_row_divider"
+                    android:layout_width="match_parent"
+                    android:layout_height="8dp" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/issues_row"

--- a/app/src/main/res/layout/repository.xml
+++ b/app/src/main/res/layout/repository.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.NestedScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v4.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@id/main_content"
@@ -19,9 +18,9 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:orientation="vertical"
                 android:paddingTop="@dimen/content_padding"
-                android:paddingBottom="@dimen/content_padding"
-                android:orientation="vertical">
+                android:paddingBottom="@dimen/content_padding">
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_repo_name"
@@ -36,8 +35,8 @@
                     android:id="@+id/tv_parent"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="8dp"
                     android:layout_marginTop="8dp"
+                    android:layout_marginBottom="8dp"
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
                     android:textAppearance="?android:attr/textAppearanceSmall"
@@ -81,30 +80,35 @@
                     android:visibility="gone"
                     tools:visibility="visible" />
 
+
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/language_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    app:rowIcon="@drawable/icon_language" />
+                    app:rowIcon="@drawable/icon_language"
+                    tools:rowText="Written in Java" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/issues_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowIcon="@drawable/icon_issues" />
+                    app:rowIcon="@drawable/icon_issues"
+                    tools:rowText="50 issues" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/pulls_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowIcon="@drawable/icon_pull_request" />
+                    app:rowIcon="@drawable/icon_pull_request"
+                    tools:rowText="9 pull requests" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/forks_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowIcon="@drawable/icon_fork" />
+                    app:rowIcon="@drawable/icon_fork"
+                    tools:rowText="12 forks" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/stars_row"
@@ -112,16 +116,17 @@
                     android:layout_height="wrap_content"
                     app:rowIcon="@drawable/icon_star"
                     app:rowIconActionHintOff="@string/repo_star_action"
-                    app:rowIconActionHintOn="@string/repo_unstar_action" />
+                    app:rowIconActionHintOn="@string/repo_unstar_action"
+                    tools:rowText="5 stars" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/watchers_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowText="54 Watchers"
                     app:rowIcon="@drawable/icon_watch"
                     app:rowIconActionHintOff="@string/repo_watch_action"
-                    app:rowIconActionHintOn="@string/repo_unwatch_action" />
+                    app:rowIconActionHintOn="@string/repo_unwatch_action"
+                    tools:rowText="54 Watchers" />
 
             </LinearLayout>
         </android.support.v7.widget.CardView>
@@ -149,17 +154,17 @@
                 <ProgressBar
                     android:id="@+id/pb_readme"
                     style="@style/LoadingProgress"
-                    android:layout_marginBottom="@dimen/content_padding"
                     android:layout_marginTop="@dimen/content_padding"
+                    android:layout_marginBottom="@dimen/content_padding"
                     android:visibility="gone" />
 
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/readme"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingBottom="@dimen/content_padding"
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
+                    android:paddingBottom="@dimen/content_padding"
                     android:textIsSelectable="true"
                     android:visibility="gone"
                     tools:text="Readme text"

--- a/app/src/main/res/layout/user.xml
+++ b/app/src/main/res/layout/user.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.NestedScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<android.support.v4.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -14,14 +13,13 @@
         android:orientation="vertical">
 
         <!-- user info section -->
-        <android.support.v7.widget.CardView
-            style="?attr/cardViewTheme">
+        <android.support.v7.widget.CardView style="?attr/cardViewTheme">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/overview_header_spacing"
                 android:layout_marginTop="@dimen/overview_header_spacing"
+                android:layout_marginBottom="@dimen/overview_header_spacing"
                 android:orientation="vertical"
                 android:paddingTop="@dimen/content_padding"
                 android:paddingBottom="@dimen/content_padding">
@@ -100,49 +98,52 @@
                     android:id="@+id/join_date_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowIcon="@drawable/icon_calendar" />
+                    app:rowIcon="@drawable/icon_calendar"
+                    tools:rowText="Member since 09 February 2019" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/members_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowIcon="@drawable/icon_members" />
+                    app:rowIcon="@drawable/icon_members"
+                    tools:rowText="5 members" />
 
-                <!-- FIXME: icon -->
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/followers_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:rowIcon="@drawable/icon_members"
                     app:rowIconActionHintOff="@string/user_follow_action"
-                    app:rowIconActionHintOn="@string/user_unfollow_action" />
+                    app:rowIconActionHintOn="@string/user_unfollow_action"
+                    tools:rowText="Followed by 82 users" />
 
-                <!-- FIXME: icon -->
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/following_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowIcon="@drawable/icon_members" />
+                    app:rowIcon="@drawable/icon_following"
+                    tools:rowText="Following 33 users" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/repos_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowIcon="@drawable/icon_repositories" />
+                    app:rowIcon="@drawable/icon_repositories"
+                    tools:rowText="39 repositories" />
 
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/gists_row"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:rowIcon="@drawable/icon_gists" />
+                    app:rowIcon="@drawable/icon_gists"
+                    tools:rowText="12 gists" />
 
             </LinearLayout>
 
         </android.support.v7.widget.CardView>
 
         <!-- Repository section -->
-        <android.support.v7.widget.CardView
-            style="?attr/cardViewTheme">
+        <android.support.v7.widget.CardView style="?attr/cardViewTheme">
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -147,5 +147,6 @@
         <attr name="rowIcon" format="color|reference" />
         <attr name="rowIconActionHintOn" format="string" />
         <attr name="rowIconActionHintOff" format="string" />
+        <attr name="displayRedirectArrowWhenClickable" format="boolean" />
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
     <string name="history">History</string>
     <string name="deleted">(deleted)</string>
     <string name="go_to">Go to</string>
-    <string name="forked_from">forked from %1$s</string>
+    <string name="forked_from">Forked from %1$s</string>
     <string name="menu_user">User %1$s</string>
     <string name="menu_repo">Repo %1$s</string>
     <string name="menu_compare">Compare %1$s</string>


### PR DESCRIPTION
Few changes and fixes to the repository information screen. Main differences are:
- Moved information telling that the repository is private to appear like other rows.
- Moved information about fork parent to also appear like other rows. I'm not sure about this change since now the icon is the same as for forks count row but I also didn't like how it looked like previously. Perhaps there is some other better looking way to display this information?
- Removed information about repository url if no custom homepage was set. This is a bit controversial change but I think it is useless to display default url when it's posible to get that link through share/open in browser actions.

<img src="https://user-images.githubusercontent.com/5156340/52178350-ae720e00-27cd-11e9-9bb1-ee9fd365a169.jpg" height="580" /> <img src="https://user-images.githubusercontent.com/5156340/52178351-ae720e00-27cd-11e9-8ee2-0d8afea3ae6c.jpg" height="580" />
