### PR TITLE
Bump androidsvg-aar from 1.3 to 1.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation 'com.github.maniac103:rxloader:master-SNAPSHOT'
     implementation 'com.github.maniac103:githubsdk:0.5.1.9'
     implementation 'com.larswerkman:HoloColorPicker:1.5@aar'
-    implementation 'com.caverock:androidsvg-aar:1.3'
+    implementation 'com.caverock:androidsvg-aar:1.4'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.1.+'
     implementation 'org.ocpsoft.prettytime:prettytime:4.0.1.Final'
     implementation 'com.github.castorflex.smoothprogressbar:library:1.1.0'


### PR DESCRIPTION
This allows us to bump the compileSdk to 28.

https://bigbadaboom.github.io/androidsvg/release_notes.html