### PR TITLE
Change method name 'encode' to 'encodeHtml'

### DIFF
--- a/app/src/main/java/com/gh4a/utils/HtmlUtils.java
+++ b/app/src/main/java/com/gh4a/utils/HtmlUtils.java
@@ -176,7 +176,7 @@ public class HtmlUtils {
      * @param imageGetter
      * @return html
      */
-    public static CharSequence encode(final Context context, final String html,
+    public static CharSequence encodeHtml(final Context context, final String html,
                                       final ImageGetter imageGetter) {
         if (TextUtils.isEmpty(html))
             return "";

--- a/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
+++ b/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
@@ -196,7 +196,7 @@ public class HttpImageGetter {
         }
 
         void encode(Context context, String html) {
-            CharSequence encoded = HtmlUtils.encode(context, html, this);
+            CharSequence encoded = HtmlUtils.encodeHtml(context, html, this);
             synchronized (this) {
                 mHtml = encoded;
             }


### PR DESCRIPTION
This class is used to provide utilities for handling Html.  The method named 'encode' is to encode an html pagge. Thus, the method name 'encodeHtml' is more intuitive than 'encode'.