### PR TITLE
Add source code link in about & move settings to the left

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/SettingsFragment.java
@@ -24,6 +24,7 @@ import android.widget.TextView;
 import com.gh4a.Gh4Application;
 import com.gh4a.R;
 import com.gh4a.activities.IssueListActivity;
+import com.gh4a.activities.RepositoryActivity;
 import com.gh4a.worker.NotificationsWorker;
 import com.gh4a.widget.IntegerListPreference;
 
@@ -181,6 +182,8 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
             } else {
                 newIssueButton.setVisibility(View.GONE);
             }
+
+            findViewById(R.id.btn_gh4a).setOnClickListener(this);
         }
 
         @Override
@@ -200,6 +203,11 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
                 context.startActivity(chooserIntent);
             } else if (id == R.id.btn_by_gh4a) {
                 Intent intent = IssueListActivity.makeIntent(context,
+                        context.getString(R.string.my_username),
+                        context.getString(R.string.my_repo));
+                context.startActivity(intent);
+            } else if (id == R.id.btn_gh4a) {
+                Intent intent = RepositoryActivity.makeIntent(context,
                         context.getString(R.string.my_username),
                         context.getString(R.string.my_repo));
                 context.startActivity(intent);

--- a/app/src/main/res/layout/about_dialog.xml
+++ b/app/src/main/res/layout/about_dialog.xml
@@ -45,4 +45,11 @@
         android:layout_height="wrap_content"
         android:text="@string/feedback_by_gh4a"
         android:textAppearance="?android:attr/textAppearanceMedium" />
+
+    <Button
+        android:id="@+id/btn_gh4a"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/source_code"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="my_web">http://slapperwan.github.com/gh4a</string>
     <string name="my_username">slapperwan</string>
     <string name="my_repo">gh4a</string>
+    <string name="source_code">Source Code</string>
     <string name="feedback_text">If you have any issues or suggestions, please contact me.  Any kind of feedback is greatly appreciated.</string>
     <string name="feedback_by_email">By Email</string>
     <string name="feedback_by_gh4a">By OctoDroid</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <com.gh4a.widget.IntegerListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@integer/default_theme"
         android:entries="@array/theme_items"
         android:entryValues="@array/theme_values"
@@ -10,6 +12,7 @@
         android:title="@string/theme" />
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="newsfeed"
         android:entries="@array/start_page_items"
         android:entryValues="@array/start_page_values"
@@ -18,6 +21,7 @@
         android:title="@string/start_page" />
 
     <com.gh4a.widget.IntegerListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="2"
         android:entries="@array/text_size_items"
         android:entryValues="@array/text_size_values"
@@ -26,6 +30,7 @@
         android:title="@string/menu_text_size" />
 
     <com.gh4a.widget.IntegerListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="1"
         android:entries="@array/load_gif_mode_items"
         android:entryValues="@array/load_gif_mode_values"
@@ -34,11 +39,13 @@
         android:title="@string/menu_gif_load_mode" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="false"
         android:key="notifications"
         android:title="@string/notifications" />
 
     <com.gh4a.widget.IntegerListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="15"
         android:dependency="notifications"
         android:entries="@array/notification_interval_items"
@@ -48,10 +55,12 @@
         android:title="@string/notification_interval" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="about"
         android:title="@string/about" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="open_source_components"
         android:title="@string/open_source_components" />
 


### PR DESCRIPTION
First of all thank you for your great app.
As the title says, this adds a link to the source code in the about dialog and removes the space between the left side and the settings.
![gh4a](https://user-images.githubusercontent.com/36813904/91663689-fbb57f00-ead9-11ea-96fd-cb9268293fb7.png)

Personally, I like a direct link to the source code more, than first being redirected to the issues and then going back to the source code.