### PR TITLE
Hide explore section if logged in

### DIFF
--- a/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
+++ b/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
@@ -127,6 +127,8 @@ public class HomeActivity extends BaseFragmentPagerActivity implements
         loadUserInfo(false);
         loadNotificationIndicator(false);
         mFactory.onStartLoadingData();
+
+        updateDrawerMode(false);
     }
 
     @Nullable
@@ -511,7 +513,7 @@ public class HomeActivity extends BaseFragmentPagerActivity implements
     private void updateDrawerMode(boolean accountMode) {
         mLeftDrawerMenu.setGroupVisible(R.id.my_items, !accountMode);
         mLeftDrawerMenu.setGroupVisible(R.id.navigation, !accountMode);
-        mLeftDrawerMenu.setGroupVisible(R.id.explore, !accountMode);
+        mLeftDrawerMenu.setGroupVisible(R.id.explore, false);
         mLeftDrawerMenu.setGroupVisible(R.id.settings, !accountMode);
         mLeftDrawerMenu.setGroupVisible(R.id.account, accountMode);
         mLeftDrawerMenu.setGroupVisible(R.id.other_accounts, accountMode);


### PR DESCRIPTION
Personally, I do not use the explore section and it makes the navigation drawer longer, than it would be needed.