### PR TITLE
Opt-out from WebView usage statistics collection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -183,5 +183,6 @@
             </intent-filter>
         </receiver>
         <meta-data android:name="com.crashlytics.ApiKey" android:value="684bb8e255484484ea06ed1e229adb4ca4e8bf6b"/>
+        <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
     </application>
 </manifest>


### PR DESCRIPTION
This PR adds to the manifest the needed `meta-data` tag to opt this app out from WebView usage statistics collection.

Fixes #1061