### PR TITLE
Fix size of private repo/gist icon in list

### DIFF
--- a/app/src/main/res/drawable-night/private_small.xml
+++ b/app/src/main/res/drawable-night/private_small.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="16dp"
+    android:height="16dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/app/src/main/res/drawable/private_small.xml
+++ b/app/src/main/res/drawable/private_small.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="16dp"
+    android:height="16dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path


### PR DESCRIPTION
It arguably looked wrong.
Before:

![private_before](https://user-images.githubusercontent.com/30041551/132096077-e184b631-0c3b-423a-b6d5-410ca08f58bb.png)

After:

![private_after](https://user-images.githubusercontent.com/30041551/132096085-6358fb79-3aec-4980-837d-cd6dcbe5fc73.png)
