### PR TITLE
Slightly improve file list appearance

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/FileAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/FileAdapter.java
@@ -65,6 +65,11 @@ public class FileAdapter extends RootAdapter<Content, FileAdapter.ViewHolder> {
         }
     }
 
+    @Override
+    public boolean hasDividers() {
+        return false;
+    }
+
     private int getIconId(ContentType type, String fileName) {
         if (mSubModuleNames != null && mSubModuleNames.contains(fileName)) {
             return R.drawable.submodule;

--- a/app/src/main/java/com/gh4a/adapter/RootAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/RootAdapter.java
@@ -272,6 +272,10 @@ public abstract class RootAdapter<T, VH extends RecyclerView.ViewHolder>
         return mFilter;
     }
 
+    public boolean hasDividers() {
+        return true;
+    }
+
     public boolean isCardStyle() {
         return false;
     }

--- a/app/src/main/java/com/gh4a/fragment/ListDataBaseFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ListDataBaseFragment.java
@@ -37,7 +37,7 @@ public abstract class ListDataBaseFragment<T> extends LoadingListFragmentBase {
 
     @Override
     protected boolean hasDividers() {
-        return !mAdapter.isCardStyle();
+        return mAdapter.hasDividers() && !mAdapter.isCardStyle();
     }
 
     protected void onAddData(RootAdapter<T, ?> adapter, List<T> data) {

--- a/app/src/main/java/com/gh4a/fragment/PagedDataBaseFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PagedDataBaseFragment.java
@@ -92,7 +92,7 @@ public abstract class PagedDataBaseFragment<T> extends LoadingListFragmentBase i
 
     @Override
     protected boolean hasDividers() {
-        return !mAdapter.isCardStyle();
+        return mAdapter.hasDividers() && !mAdapter.isCardStyle();
     }
 
     @Override

--- a/app/src/main/res/layout/row_file_manager.xml
+++ b/app/src/main/res/layout/row_file_manager.xml
@@ -25,7 +25,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textAppearance="@style/TextAppearance.ItemTitle"
         android:textColor="?android:attr/textColorPrimary"
         tools:text="filename.txt" />
 

--- a/app/src/main/res/layout/row_file_manager.xml
+++ b/app/src/main/res/layout/row_file_manager.xml
@@ -33,7 +33,7 @@
         android:id="@+id/tv_size"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
+        android:layout_gravity="center"
         android:layout_marginLeft="4dp"
         android:textAppearance="@style/TextAppearance.VerySmall"
         tools:text="2.5 KB" />


### PR DESCRIPTION
The repository file list was the only part of the UI which looked still a bit "old" IMHO, so I've made some small improvements to make it a bit sleeker:
- removed dividers between elements
- aligned file size with file name
- used condensed text for file/directory name

I'm not fully sure on the last one. It definitely helps with long file names but I'm not sure if it fits well.
Here's a comparison between condensed and normal text. I'll let you judge :smiley: 

![filelist_1](https://user-images.githubusercontent.com/30041551/132099022-00a497b0-3e7c-4519-b8e8-745585498d5a.png)

![filelist_2](https://user-images.githubusercontent.com/30041551/132099028-40fa82e8-bd55-4b2b-93c5-87eb3894d38c.png)
