### PR TITLE
Improve PRs/issues loading performance

### DIFF
--- a/app/src/main/java/com/gh4a/ServiceFactory.java
+++ b/app/src/main/java/com/gh4a/ServiceFactory.java
@@ -7,7 +7,6 @@ import com.gh4a.utils.Optional;
 import com.meisolsson.githubsdk.core.GitHubPaginationInterceptor;
 import com.meisolsson.githubsdk.core.ServiceGenerator;
 import com.meisolsson.githubsdk.core.StringResponseConverterFactory;
-import com.meisolsson.githubsdk.service.checks.ChecksService;
 
 import java.io.File;
 import java.util.HashMap;
@@ -36,9 +35,6 @@ import retrofit2.http.Path;
 public class ServiceFactory {
     private static final String DEFAULT_HEADER_ACCEPT =
             "application/vnd.github.squirrel-girl-preview," // reactions API preview
-            + "application/vnd.github.v3.full+json";
-    private static final String CHECKS_API_HEADER_ACCEPT =
-            "application/vnd.github.antiope-preview," // checks API preview
             + "application/vnd.github.v3.full+json";
 
     private final static HttpLoggingInterceptor LOGGING_INTERCEPTOR = new HttpLoggingInterceptor()
@@ -173,8 +169,6 @@ public class ServiceFactory {
                         final String header;
                         if (acceptHeader != null) {
                             header = acceptHeader;
-                        } else if (serviceClass == ChecksService.class) {
-                            header = CHECKS_API_HEADER_ACCEPT;
                         } else {
                             header = DEFAULT_HEADER_ACCEPT;
                         }

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -55,7 +55,7 @@ import com.gh4a.ServiceFactory;
 import com.gh4a.fragment.CommitCompareFragment;
 import com.gh4a.fragment.ConfirmationDialogFragment;
 import com.gh4a.fragment.PullRequestFilesFragment;
-import com.gh4a.fragment.PullRequestFragment;
+import com.gh4a.fragment.PullRequestConversationFragment;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.RxUtils;
@@ -118,7 +118,7 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
     private Issue mIssue;
     private PullRequest mPullRequest;
-    private PullRequestFragment mPullRequestFragment;
+    private PullRequestConversationFragment mConversationFragment;
     private IssueStateTrackingFloatingActionButton mEditFab;
     private Review mPendingReview;
     private boolean mPendingReviewLoaded;
@@ -129,8 +129,8 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
     private final ActivityResultLauncher<Intent> mCreateReviewLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(),
             new ActivityResultHelpers.ActivityResultSuccessCallback(() -> {
-                if (mPullRequestFragment != null) {
-                    mPullRequestFragment.reloadEvents(false);
+                if (mConversationFragment != null) {
+                    mConversationFragment.reloadEvents(false);
                 }
                 loadPendingReview(true);
             })
@@ -295,16 +295,16 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
     @Override
     protected Fragment makeFragment(int position) {
-        if (position == 1) {
+        if (position == PAGE_COMMITS) {
             PullRequestMarker base = mPullRequest.base();
             PullRequestMarker head = mPullRequest.head();
             return CommitCompareFragment.newInstance(mRepoOwner, mRepoName, mPullRequestNumber,
                     base.label(), base.sha(), head.label(), head.sha());
-        } else if (position == 2) {
+        } else if (position == PAGE_FILES) {
             return PullRequestFilesFragment.newInstance(mRepoOwner, mRepoName,
                     mPullRequestNumber, mPullRequest.head().sha());
         } else {
-            Fragment f = PullRequestFragment.newInstance(mPullRequest,
+            Fragment f = PullRequestConversationFragment.newInstance(mPullRequest,
                     mIssue, mIsCollaborator, mInitialComment);
             mInitialComment = null;
             return f;
@@ -313,15 +313,15 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
     @Override
     protected void onFragmentInstantiated(Fragment f, int position) {
-        if (position == 0) {
-            mPullRequestFragment = (PullRequestFragment) f;
+        if (position == PAGE_CONVERSATION) {
+            mConversationFragment = (PullRequestConversationFragment) f;
         }
     }
 
     @Override
     protected void onFragmentDestroyed(Fragment f) {
-        if (f == mPullRequestFragment) {
-            mPullRequestFragment = null;
+        if (f == mConversationFragment) {
+            mConversationFragment = null;
         }
     }
 
@@ -337,8 +337,8 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
     @Override
     public void onCommentsUpdated() {
-        if (mPullRequestFragment != null) {
-            mPullRequestFragment.reloadEvents(true);
+        if (mConversationFragment != null) {
+            mConversationFragment.reloadEvents(true);
         }
     }
 
@@ -433,8 +433,8 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
     }
 
     private void handlePullRequestUpdate() {
-        if (mPullRequestFragment != null) {
-            mPullRequestFragment.updateState(mPullRequest);
+        if (mConversationFragment != null) {
+            mConversationFragment.updateState(mPullRequest);
         }
         if (mIssue != null) {
             Issue.Builder builder = mIssue.toBuilder().state(mPullRequest.state());

--- a/app/src/main/java/com/gh4a/fragment/IssueFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragment.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 
 import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
 import retrofit2.Response;
 
 public class IssueFragment extends IssueFragmentBase {
@@ -77,13 +78,15 @@ public class IssueFragment extends IssueFragmentBase {
         final IssueCommentService commentService =
                 ServiceFactory.get(IssueCommentService.class, bypassCache);
 
-        Single<List<TimelineItem>> commentSingle = ApiHelpers.PageIterator
+        Single<List<TimelineItem.TimelineComment>> commentSingle = ApiHelpers.PageIterator
                 .toSingle(page -> commentService.getIssueComments(mRepoOwner, mRepoName, issueNumber, page))
-                .compose(RxUtils.mapList(TimelineItem.TimelineComment::new));
-        Single<List<TimelineItem>> eventSingle = ApiHelpers.PageIterator
+                .compose(RxUtils.mapList(TimelineItem.TimelineComment::new))
+                .subscribeOn(Schedulers.io());
+        Single<List<TimelineItem.TimelineEvent>> eventSingle = ApiHelpers.PageIterator
                 .toSingle(page -> eventService.getIssueEvents(mRepoOwner, mRepoName, issueNumber, page))
                 .compose(RxUtils.filter(event -> INTERESTING_EVENTS.contains(event.event())))
-                .compose((RxUtils.mapList(TimelineItem.TimelineEvent::new)));
+                .compose((RxUtils.mapList(TimelineItem.TimelineEvent::new)))
+                .subscribeOn(Schedulers.io());
 
         return Single.zip(commentSingle, eventSingle, (comments, events) -> {
             ArrayList<TimelineItem> result = new ArrayList<>();

--- a/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
@@ -80,7 +80,7 @@ import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 import retrofit2.Response;
 
-public class PullRequestFragment extends IssueFragmentBase {
+public class PullRequestConversationFragment extends IssueFragmentBase {
     private static final int ID_LOADER_STATUS = 1;
     private static final int ID_LOADER_HEAD_REF = 2;
 
@@ -88,9 +88,9 @@ public class PullRequestFragment extends IssueFragmentBase {
     private GitReference mHeadReference;
     private boolean mHasLoadedHeadReference;
 
-    public static PullRequestFragment newInstance(PullRequest pr, Issue issue,
+    public static PullRequestConversationFragment newInstance(PullRequest pr, Issue issue,
             boolean isCollaborator, IntentUtils.InitialCommentMarker initialComment) {
-        PullRequestFragment f = new PullRequestFragment();
+        PullRequestConversationFragment f = new PullRequestConversationFragment();
 
         Repository repo = pr.base().repo();
         Bundle args = buildArgs(repo.owner().login(), repo.name(),

--- a/app/src/main/java/com/gh4a/fragment/PullRequestFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestFragment.java
@@ -314,10 +314,10 @@ public class PullRequestFragment extends IssueFragmentBase {
                 });
 
         return Single.zip(
-                issueCommentItemSingle.subscribeOn(Schedulers.newThread()),
-                eventItemSingle.subscribeOn(Schedulers.newThread()),
-                reviewTimelineSingle.subscribeOn(Schedulers.newThread()),
-                commitCommentWithoutReviewSingle.subscribeOn(Schedulers.newThread()),
+                issueCommentItemSingle.subscribeOn(Schedulers.io()),
+                eventItemSingle.subscribeOn(Schedulers.io()),
+                reviewTimelineSingle.subscribeOn(Schedulers.io()),
+                commitCommentWithoutReviewSingle.subscribeOn(Schedulers.io()),
                 (comments, events, reviewItems, commentsWithoutReview) -> {
             ArrayList<TimelineItem> result = new ArrayList<>();
             result.addAll(comments);

--- a/app/src/main/java/com/gh4a/fragment/PullRequestFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestFragment.java
@@ -77,6 +77,7 @@ import java.util.Set;
 
 import io.reactivex.Observable;
 import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
 import retrofit2.Response;
 
 public class PullRequestFragment extends IssueFragmentBase {
@@ -313,10 +314,10 @@ public class PullRequestFragment extends IssueFragmentBase {
                 });
 
         return Single.zip(
-                issueCommentItemSingle,
-                eventItemSingle,
-                reviewTimelineSingle,
-                commitCommentWithoutReviewSingle,
+                issueCommentItemSingle.subscribeOn(Schedulers.newThread()),
+                eventItemSingle.subscribeOn(Schedulers.newThread()),
+                reviewTimelineSingle.subscribeOn(Schedulers.newThread()),
+                commitCommentWithoutReviewSingle.subscribeOn(Schedulers.newThread()),
                 (comments, events, reviewItems, commentsWithoutReview) -> {
             ArrayList<TimelineItem> result = new ArrayList<>();
             result.addAll(comments);

--- a/app/src/main/java/com/gh4a/utils/RxUtils.java
+++ b/app/src/main/java/com/gh4a/utils/RxUtils.java
@@ -86,7 +86,7 @@ public class RxUtils {
     }
 
     public static <T> Single<T> doInBackground(Single<T> upstream) {
-        return upstream.subscribeOn(Schedulers.newThread())
+        return upstream.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread());
     }
 


### PR DESCRIPTION
While I was investigating why loading a PRs with lots of comments was extremely slow, I opened up the Android Studio network profiler and saw this:
![pr_before](https://user-images.githubusercontent.com/30041551/132731352-1405224d-1a45-4853-b010-55ba1e57fea9.png)

What was happening in thread RxNewThreadScheduler-23 was that these API calls used to load the PR conversation:

https://github.com/slapperwan/gh4a/blob/dfdf3e1d46a4c9c3fcfa5dac3d3df5bec1350d3b/app/src/main/java/com/gh4a/fragment/PullRequestFragment.java#L315-L320
were all being executed sequentially!
To execute them in parallel, I only needed to explicitly subscribe each of those `Single`s on a background thread (63d4032).
After this change, this is what I saw in the profiler:
![pr-after](https://user-images.githubusercontent.com/30041551/132732601-9443f6e2-d11a-4c4f-8a33-0f199753f620.png)
Much better. The conversation of that specific PR (PowerShell/PowerShell#9900) now takes half the time to load (from 20 to 10 secs).

I noticed that also issues had the same performance problem (albeit much less serious), so I fixed it also for them (ff17c68).

There are some other misc small changes in this PR:
- all Singles are now subscribed on `Schedulers.io()` rather than on `newThread()` (0aef6f6). This avoids spawning a thread for literally every asynchronous action in the app, which is unnecessarily costly.
`io()` uses a shared thread pool that grows as needed, so we get the benefits of `newThread` but reusing previously allocated threads whenever possible.
- I've removed preview headers for checks API, since it [became an official part of the API last year](https://developer.github.com/changes/2020-10-01-graduate-antiope-preview/).
- I've renamed the PullRequestFragment to PullRequestConversationFragment, to improve clarity and symmetry with PullRequestFilesFragment.