### PR TITLE
Remove leftover Crashlytics API key

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -195,7 +195,6 @@
                 <action android:name="android.intent.action.DOWNLOAD_NOTIFICATION_CLICKED" />
             </intent-filter>
         </receiver>
-        <meta-data android:name="com.crashlytics.ApiKey" android:value="684bb8e255484484ea06ed1e229adb4ca4e8bf6b"/>
         <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
     </application>
 </manifest>


### PR DESCRIPTION
I've noticed just now that Crashlytics was removed in a previous version, this seems to be the last leftover remained.