### PR TITLE
Avoid an unnecessary API call to load formatted Release body

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
         exclude group: 'xpp3', module: 'xpp3'
     }
     implementation 'com.github.maniac103:rxloader:master-SNAPSHOT'
-    implementation 'com.github.maniac103:githubsdk:0.7.0.2'
+    implementation 'com.github.maniac103:githubsdk:0.7.0.3'
     implementation 'com.larswerkman:HoloColorPicker:1.5@aar'
     implementation 'com.caverock:androidsvg-aar:1.4'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.21'

--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -71,7 +71,6 @@ public class ReleaseInfoActivity extends BaseActivity implements
     }
 
     private static final int ID_LOADER_RELEASE = 0;
-    private static final int ID_LOADER_BODY = 1;
 
     private String mRepoOwner;
     private String mRepoName;
@@ -184,7 +183,6 @@ public class ReleaseInfoActivity extends BaseActivity implements
             name = mRelease.tagName();
         }
         getSupportActionBar().setTitle(name);
-        loadBody();
         fillData();
     }
 
@@ -212,6 +210,13 @@ public class ReleaseInfoActivity extends BaseActivity implements
         tag.setText(getString(R.string.release_tag, mRelease.tagName()));
         tag.setOnClickListener(this);
 
+        TextView body = findViewById(R.id.tv_release_notes);
+        if (!TextUtils.isEmpty(mRelease.bodyHtml())) {
+            mImageGetter.bind(body, mRelease.bodyHtml(), mRelease.id());
+        } else {
+            body.setText(R.string.release_no_releasenotes);
+        }
+
         if (mRelease.assets() != null && !mRelease.assets().isEmpty()) {
             RecyclerView downloadsList = findViewById(R.id.download_list);
             ReleaseAssetAdapter adapter = new ReleaseAssetAdapter(this);
@@ -223,19 +228,6 @@ public class ReleaseInfoActivity extends BaseActivity implements
         } else {
             findViewById(R.id.downloads).setVisibility(View.GONE);
         }
-    }
-
-    private void fillNotes(Optional<String> bodyHtmlOpt) {
-        TextView body = findViewById(R.id.tv_release_notes);
-
-        if (bodyHtmlOpt.isPresent()) {
-            mImageGetter.bind(body, bodyHtmlOpt.get(), mRelease.id());
-        } else {
-            body.setText(R.string.release_no_releasenotes);
-        }
-
-        body.setVisibility(View.VISIBLE);
-        findViewById(R.id.pb_releasenotes).setVisibility(View.GONE);
     }
 
     @Override
@@ -273,25 +265,5 @@ public class ReleaseInfoActivity extends BaseActivity implements
                     handleReleaseReady();
                     setContentShown(true);
                 }, this::handleLoadFailure);
-    }
-
-    private void loadBody() {
-        final Single<Optional<String>> htmlSingle;
-        if (TextUtils.isEmpty(mRelease.body())) {
-            htmlSingle = Single.just(Optional.absent());
-        } else {
-            MarkdownService service = ServiceFactory.get(MarkdownService.class, false);
-            RequestMarkdown request = RequestMarkdown.builder()
-                    .context(mRepoOwner + "/" + mRepoName)
-                    .mode("gfm")
-                    .text(mRelease.body())
-                    .build();
-            htmlSingle = service.renderMarkdown(request)
-                    .map(ApiHelpers::throwOnFailure)
-                    .map(Optional::of);
-        }
-        mBodySubscription = htmlSingle
-                .compose(makeLoaderSingle(ID_LOADER_BODY, false))
-                .subscribe(this::fillNotes, this::handleLoadFailure);
     }
 }

--- a/app/src/main/java/com/gh4a/widget/StyleableTextView.java
+++ b/app/src/main/java/com/gh4a/widget/StyleableTextView.java
@@ -11,6 +11,7 @@ import androidx.appcompat.widget.AppCompatTextView;
 
 import android.text.Spannable;
 import android.text.method.LinkMovementMethod;
+import android.text.method.MovementMethod;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.widget.TextView;
@@ -140,8 +141,9 @@ public class StyleableTextView extends AppCompatTextView {
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         if (isTextSelectable() && isEnabled()) {
-            setEnabled(false);
-            setEnabled(true);
+            MovementMethod method = getMovementMethod();
+            setMovementMethod(null);
+            setMovementMethod(method);
         }
     }
 

--- a/app/src/main/res/layout/release.xml
+++ b/app/src/main/res/layout/release.xml
@@ -82,10 +82,6 @@
                     android:layout_height="wrap_content"
                     android:text="@string/release_notes" />
 
-                <ProgressBar
-                    android:id="@+id/pb_releasenotes"
-                    style="@style/LoadingProgress" />
-
                 <com.gh4a.widget.StyleableTextView
                     android:id="@+id/tv_release_notes"
                     android:layout_width="match_parent"
@@ -94,10 +90,8 @@
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
                     android:textIsSelectable="true"
-                    android:visibility="gone"
                     app:needsLinkHandling="true"
-                    tools:text="Release notes text"
-                    tools:visibility="visible" />
+                    tools:text="Release notes text" />
 
             </LinearLayout>
 


### PR DESCRIPTION
In this PR I tried to use the newly added Release's bodyHtml field to avoid calling the Markdown API to format the Release body.

However, it seems that HttpImageGetter doesn't behave properly. Here's what I see as soon as I open a release:

<img src="https://user-images.githubusercontent.com/30041551/132812554-aac31928-dd69-4201-a8d8-5e4d43686020.png" width="400px"/>

The TextView has a gray background (instead of white) and the view is already scrolled down to the release body.

Am I doing anything wrong?