### PR TITLE
Improve search suggestions ergonomics - round 1

### DIFF
--- a/app/src/main/res/layout/row_suggestion.xml
+++ b/app/src/main/res/layout/row_suggestion.xml
@@ -8,5 +8,7 @@
     android:gravity="center_vertical"
     android:minHeight="?attr/listPreferredItemHeightSmall"
     android:padding="8dp"
-    android:textAppearance="?attr/textAppearanceSearchResultTitle"
+    android:textAppearance="?android:attr/textAppearanceMedium"
+    android:textColor="?android:textColorPrimary"
+    android:ellipsize="middle"
     tools:text="some suggestion" />


### PR DESCRIPTION
This PR makes a couple of small changes to make the search suggestion experience more comfortable:
- start the search directly when a suggestion is clicked
- make suggestion text a little bit smaller and ellipsize text in the middle when it's too long. This greatly improves the UX when searching code.

Below you can see the same example before and after this change:

![search_before](https://user-images.githubusercontent.com/30041551/132986891-0e9d80cc-c190-41fd-acb0-2d027e8cd652.png)

![search_after](https://user-images.githubusercontent.com/30041551/132986896-da525216-10eb-491c-9252-2a35a5899e68.png)

