### PR TITLE
Minor releases list improvements and fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,12 +54,14 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference:1.1.1'

--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -49,6 +49,8 @@ import com.meisolsson.githubsdk.model.request.RequestMarkdown;
 import com.meisolsson.githubsdk.service.misc.MarkdownService;
 import com.meisolsson.githubsdk.service.repositories.RepositoryReleaseService;
 
+import java.util.Date;
+
 import io.reactivex.Single;
 import io.reactivex.disposables.Disposable;
 
@@ -194,9 +196,10 @@ public class ReleaseInfoActivity extends BaseActivity implements
         gravatar.setOnClickListener(this);
 
         StyleableTextView details = findViewById(R.id.tv_releaseinfo);
+        Date releaseDateToShow = mRelease.publishedAt() != null ? mRelease.publishedAt() : mRelease.createdAt();
         String detailsText = getString(R.string.release_details,
                 ApiHelpers.getUserLogin(this, mRelease.author()),
-                StringUtils.formatRelativeTime(this, mRelease.createdAt(), true));
+                StringUtils.formatRelativeTime(this, releaseDateToShow, true));
         StringUtils.applyBoldTagsAndSetText(details, detailsText);
 
         TextView releaseType = findViewById(R.id.tv_releasetype);

--- a/app/src/main/java/com/gh4a/adapter/ReleaseAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/ReleaseAdapter.java
@@ -12,6 +12,8 @@ import com.gh4a.R;
 import com.gh4a.utils.StringUtils;
 import com.meisolsson.githubsdk.model.Release;
 
+import java.util.Date;
+
 public class ReleaseAdapter extends RootAdapter<Release, ReleaseAdapter.ViewHolder> {
     public ReleaseAdapter(Context context) {
         super(context);
@@ -31,8 +33,20 @@ public class ReleaseAdapter extends RootAdapter<Release, ReleaseAdapter.ViewHold
         }
         holder.tvTitle.setText(name);
         holder.tvType.setText(formatReleaseType(release));
-        holder.tvCreatedAt.setText(mContext.getString(R.string.download_created,
-                StringUtils.formatRelativeTime(mContext, release.createdAt(), true)));
+        holder.tvCreatedAt.setText(formatReleaseDate(release));
+    }
+
+    private String formatReleaseDate(Release release) {
+        Date dateToShow;
+        int dateStringResId;
+        if (release.publishedAt() != null) {
+            dateToShow = release.publishedAt();
+            dateStringResId = R.string.released_at;
+        } else {
+            dateToShow = release.createdAt();
+            dateStringResId = R.string.download_created;
+        }
+        return mContext.getString(dateStringResId, StringUtils.formatRelativeTime(mContext, dateToShow, true));
     }
 
     private String formatReleaseType(Release release) {

--- a/app/src/main/java/com/gh4a/fragment/ReleaseListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ReleaseListFragment.java
@@ -13,13 +13,22 @@ import com.meisolsson.githubsdk.model.Page;
 import com.meisolsson.githubsdk.model.Release;
 import com.meisolsson.githubsdk.service.repositories.RepositoryReleaseService;
 
+import java.util.Collections;
+import java.util.Comparator;
+
 import io.reactivex.Single;
 import retrofit2.Response;
+
+import static java.util.Comparator.reverseOrder;
+import static java.util.Comparator.nullsFirst;
 
 public class ReleaseListFragment extends PagedDataBaseFragment<Release> implements
         RootAdapter.OnItemClickListener<Release> {
     private String mUserLogin;
     private String mRepoName;
+
+    private static final Comparator<Release> MOST_RECENT_RELEASES_AND_DRAFTS_FIRST =
+            Comparator.comparing(Release::publishedAt, nullsFirst(reverseOrder()));
 
     public static ReleaseListFragment newInstance(String owner, String repo) {
         ReleaseListFragment f = new ReleaseListFragment();
@@ -39,9 +48,16 @@ public class ReleaseListFragment extends PagedDataBaseFragment<Release> implemen
 
     @Override
     protected Single<Response<Page<Release>>> loadPage(int page, boolean bypassCache) {
-        final RepositoryReleaseService service =
-                ServiceFactory.get(RepositoryReleaseService.class, bypassCache);
-        return service.getReleases(mUserLogin, mRepoName, page);
+        final RepositoryReleaseService service = ServiceFactory.get(RepositoryReleaseService.class, bypassCache);
+        return service.getReleases(mUserLogin, mRepoName, page)
+                // Sometimes the API returns releases in a slightly wrong order (see TeamNewPipe/NewPipe repo
+                // for an example), so we need to fix the sorting locally
+                .map(response -> {
+                    if (response.body() != null) {
+                        Collections.sort(response.body().items(), MOST_RECENT_RELEASES_AND_DRAFTS_FIRST);
+                    }
+                    return response;
+                });
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,6 +341,7 @@
 
     <!-- Release -->
     <string name="release_title">Release</string>
+    <string name="released_at">Released %1$s</string>
     <string name="release_details">Released by [b]%1$s[/b] %2$s</string>
     <string name="release_tag">On tag %1$s</string>
     <string name="release_notes">Release notes</string>


### PR DESCRIPTION
This PR includes a couple of improvements to the release UI:
- display the actual release date for published (non-draft) releases (`published_at` field) instead of the creation date (`created_at` field) in order to match the GitHub UI behavior, both in the release list and in the release details activity
- adds a workaround for the releases API returning entries in the wrong order in some cases (e.g. TeamNewPipe/NewPipe repo), as you can see in the following screenshots before and after this PR:

![releases_before](https://user-images.githubusercontent.com/30041551/133313806-73d7f577-7ec2-47d3-a309-09dd022f740c.png)
![releases_new](https://user-images.githubusercontent.com/30041551/133313819-7d2a5e33-319b-4237-b163-7e583f5a31ea.png)

In order to fix the sorting, I've set up [Java 8 API desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) in order to leverage the neat `Comparator.comparing` API.