### PR TITLE
Fix poor green text/icon contrast on dark theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,8 +12,7 @@
         <item name="cardViewTheme">@style/CardView.DayNight</item>
         <item name="inlineButtonStyle">@style/Widget.MaterialComponents.Button.TextButton</item>
 
-        <item name="android:textColorLink">@color/accent</item>
-
+        <item name="colorAccent">@color/accent</item>
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary_dark</item>
         <item name="colorOnPrimary">@android:color/white</item>


### PR DESCRIPTION
This PR fixes the app theme so that the accent color is applied consistently to both text links and headers/icons.
This greatly improves legibility of green text and green icons' contrast when using the dark theme.

Fixes #1079

### Before

![dark_before_1](https://user-images.githubusercontent.com/30041551/133604009-aca63096-7220-4dc1-a1c0-37773b974ea3.png)
![dark_before_2](https://user-images.githubusercontent.com/30041551/133604010-e99f15cc-6f46-4c01-8475-39cf42abf2dd.png)

### After

![dark_after_1](https://user-images.githubusercontent.com/30041551/133604025-8b31ee3c-8cd8-40a2-a772-8180a915de60.png)
![dark_after_2](https://user-images.githubusercontent.com/30041551/133604030-b588a294-c1d1-419d-a12e-8c24ed550aae.png)
