### PR TITLE
Show dates for commits older than 1 week in commit list

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/CommitAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CommitAdapter.java
@@ -83,7 +83,7 @@ public class CommitAdapter extends RootAdapter<Commit, CommitAdapter.ViewHolder>
 
         holder.tvExtra.setText(ApiHelpers.getAuthorName(mContext, commit));
         holder.tvTimestamp.setText(
-                StringUtils.formatRelativeTime(mContext, commit.commit().author().date(), false));
+                StringUtils.formatRelativeTime(mContext, commit.commit().author().date(), true));
     }
 
     @Override


### PR DESCRIPTION
~~This PR gets rid of PrettyTime to format relative dates and instead uses the built-in Android `DateUtils` class, so that the actual date is displayed when it is more than one week in the past.~~
~~Another difference is that `DateUtils` displays _"Yesterday"_ instead of _"1 day ago"_ (doesn't it sound a bit weird?).~~

~~Another small tweak I made was to change the commit list to display the actual commit dates instead of the authoring dates.~~
~~In this way some commits don't feel "out of place", as you can see the in the screenshots below comparing that list before and after this PR (the user can still see the authoring date in the commit details activity).~~

![dates_before](https://user-images.githubusercontent.com/30041551/133898420-1c8981b4-e643-4f49-adf5-73114e182324.png)
![dates_after](https://user-images.githubusercontent.com/30041551/133898422-8a5deee1-7bfa-45a4-a54f-11e0e12012ca.png)


