### PR TITLE
Improve links behavior

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,9 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="http" />
         </intent>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/com/gh4a/resolver/BrowseFilter.java
+++ b/app/src/main/java/com/gh4a/resolver/BrowseFilter.java
@@ -49,8 +49,7 @@ public class BrowseFilter extends AppCompatActivity {
         }
 
         result.loadTask.setIntentFlags(flags);
+        result.loadTask.setCompletionCallback(this::finish);
         result.loadTask.execute();
-
-        // Avoid finish() for now
     }
 }

--- a/app/src/main/java/com/gh4a/resolver/UrlLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/UrlLoadTask.java
@@ -21,6 +21,7 @@ public abstract class UrlLoadTask extends AsyncTask<Void, Void, Optional<Intent>
     protected final FragmentActivity mActivity;
     private ProgressDialogFragment mProgressDialog;
     private int mIntentFlags;
+    private Runnable completionCallback;
 
     public UrlLoadTask(FragmentActivity activity) {
         super();
@@ -29,6 +30,13 @@ public abstract class UrlLoadTask extends AsyncTask<Void, Void, Optional<Intent>
 
     public void setIntentFlags(int flags) {
         mIntentFlags = flags;
+    }
+
+    /**
+     * Must be called BEFORE executing the task, otherwise the callback might not get executed.
+     */
+    public void setCompletionCallback(Runnable callback) {
+        completionCallback = callback;
     }
 
     @Override
@@ -63,7 +71,10 @@ public abstract class UrlLoadTask extends AsyncTask<Void, Void, Optional<Intent>
         if (mProgressDialog != null && mProgressDialog.isAdded()) {
             mProgressDialog.dismissAllowingStateLoss();
         }
-        mActivity.finish();
+
+        if (completionCallback != null) {
+            completionCallback.run();
+        }
     }
 
     protected abstract Single<Optional<Intent>> getSingle();

--- a/app/src/main/java/com/gh4a/utils/HtmlUtils.java
+++ b/app/src/main/java/com/gh4a/utils/HtmlUtils.java
@@ -45,10 +45,10 @@ import android.text.style.StyleSpan;
 import android.text.style.SubscriptSpan;
 import android.text.style.SuperscriptSpan;
 import android.text.style.TypefaceSpan;
-import android.text.style.URLSpan;
 import android.text.style.UnderlineSpan;
 
 import com.gh4a.R;
+import com.gh4a.widget.LinkSpan;
 
 import org.ccil.cowan.tagsoup.HTMLSchema;
 import org.ccil.cowan.tagsoup.Parser;
@@ -783,7 +783,7 @@ public class HtmlUtils {
             Href h = getLast(text, Href.class);
             if (h != null) {
                 if (h.mHref != null) {
-                    setSpanFromMark(text, h, new URLSpan((h.mHref)));
+                    setSpanFromMark(text, h, new LinkSpan(h.mHref));
                 }
             }
         }

--- a/app/src/main/java/com/gh4a/utils/IntentUtils.java
+++ b/app/src/main/java/com/gh4a/utils/IntentUtils.java
@@ -101,10 +101,9 @@ public class IntentUtils {
                     .setDefaultColorSchemeParams(colorParams)
                     .build();
             i.intent.setPackage(pkg);
-            i.intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             i.launchUrl(activity, uri);
         } else {
-            launchBrowser(activity, uri, Intent.FLAG_ACTIVITY_NEW_TASK);
+            launchBrowser(activity, uri);
         }
     }
 

--- a/app/src/main/java/com/gh4a/widget/LinkSpan.java
+++ b/app/src/main/java/com/gh4a/widget/LinkSpan.java
@@ -1,0 +1,48 @@
+package com.gh4a.widget;
+
+import android.net.Uri;
+import android.text.style.ClickableSpan;
+import android.view.View;
+
+import com.gh4a.resolver.LinkParser;
+import com.gh4a.utils.IntentUtils;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+
+public class LinkSpan extends ClickableSpan {
+    private final String mUrl;
+
+    public LinkSpan(String url) {
+        mUrl = url;
+    }
+
+    @Override
+    public void onClick(@NonNull View widget) {
+        Uri clickedUri = Uri.parse(mUrl);
+        FragmentActivity activity = (FragmentActivity) widget.getContext();
+        LinkParser.ParseResult result = LinkParser.parseUri(activity, clickedUri, null);
+        if (result != null) {
+            launchActivity(result, activity);
+        } else {
+            openWebPage(clickedUri, activity);
+        }
+    }
+
+    private void launchActivity(LinkParser.ParseResult result, FragmentActivity activity) {
+        if (result.intent != null) {
+            activity.startActivity(result.intent);
+        } else if (result.loadTask != null) {
+            result.loadTask.execute();
+        }
+    }
+
+    private void openWebPage(Uri clickedUri, FragmentActivity activity) {
+        String hostname = clickedUri.getHost();
+        if (hostname.endsWith("github.com") || hostname.endsWith("githubusercontent.com")) {
+            IntentUtils.openInCustomTabOrBrowser(activity, clickedUri);
+        } else {
+            IntentUtils.launchBrowser(activity, clickedUri);
+        }
+    }
+}


### PR DESCRIPTION
This PR improves the behavior of links in comments, releases etc. in several ways:
- directly start the corresponding OctoDroid activity when possible, instead of asking the system to open the URL (which is the `URLSpan` behavior).
This avoids the need to set OctoDroid as the default handler for GitHub links, in order to prevent the Android "Open with..." sheet from showing up every time.
- when the clicked link is a **GitHub link** that can't be handled by OctoDroid, open it in a custom tab. In my opinion this helps reducing the perceived "switch of context" when viewing comment images.
An alternative solution could be to open all links in custom tabs by default and add an option to toggle this behavior. I'm not sure on which of the two solutions is best.
- open custom tabs in the same task as the application. I think this is one of the most useful benefits given by custom tabs (in this context, at least).

I've also added a missing `<queries>` intent filter needed to be able to detect which browser support custom tabs on Android 11+.

Implementation note: the refactoring in d2dd3e8 was done in order to be able to execute the `loadTask` in `LinkSpan`, without closing the activity in which the link was clicked.