### PR TITLE
Add bio to user/organization profile screen

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/UserFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/UserFragment.java
@@ -205,6 +205,7 @@ public class UserFragment extends LoadingFragmentBase implements
         fillTextView(R.id.tv_website, mUser.blog());
         fillTextView(R.id.tv_company, mUser.company());
         fillTextView(R.id.tv_location, mUser.location());
+        fillTextView(R.id.tv_bio, mUser.bio());
     }
 
     private static int orZero(Integer count) {

--- a/app/src/main/res/layout/user.xml
+++ b/app/src/main/res/layout/user.xml
@@ -98,6 +98,18 @@
                         tools:text="Location" />
                 </RelativeLayout>
 
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/tv_bio"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/overview_item_spacing"
+                    android:paddingLeft="@dimen/content_padding"
+                    android:paddingRight="@dimen/content_padding"
+                    android:autoLink="web"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    app:needsLinkHandling="true"
+                    tools:text="Bio of the user" />
+
                 <com.gh4a.widget.OverviewRow
                     android:id="@+id/type_row"
                     android:layout_width="match_parent"


### PR DESCRIPTION
A simple addition that makes the profile screen more complete.

You can see below how it appears for both users and organizations:

![user](https://user-images.githubusercontent.com/30041551/135447250-34c010af-9dba-4b65-8f82-5c1a591172c5.png)

![org](https://user-images.githubusercontent.com/30041551/135447278-809d7e70-65f3-482a-bbb1-33d5c8517950.png)