### PR TITLE
Parallelize some more PR and review loading requests

### DIFF
--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -80,6 +80,7 @@ import com.meisolsson.githubsdk.service.pull_request.PullRequestService;
 import java.util.Locale;
 
 import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
 
 public class PullRequestActivity extends BaseFragmentPagerActivity implements
         View.OnClickListener, ConfirmationDialogFragment.Callback,
@@ -497,11 +498,13 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
         IssueService issueService = ServiceFactory.get(IssueService.class, force);
 
         Single<PullRequest> prSingle = prService.getPullRequest(mRepoOwner, mRepoName, mPullRequestNumber)
-                .map(ApiHelpers::throwOnFailure);
+                .map(ApiHelpers::throwOnFailure)
+                .subscribeOn(Schedulers.io());
         Single<Issue> issueSingle = issueService.getIssue(mRepoOwner, mRepoName, mPullRequestNumber)
-                .map(ApiHelpers::throwOnFailure);
-        Single<Boolean> isCollaboratorSingle =
-                SingleFactory.isAppUserRepoCollaborator(mRepoOwner, mRepoName, force);
+                .map(ApiHelpers::throwOnFailure)
+                .subscribeOn(Schedulers.io());
+        Single<Boolean> isCollaboratorSingle = SingleFactory.isAppUserRepoCollaborator(mRepoOwner, mRepoName, force)
+                .subscribeOn(Schedulers.io());
 
         Single.zip(issueSingle, prSingle, isCollaboratorSingle, Triplet::create)
                 .compose(makeLoaderSingle(0, force))

--- a/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
 import retrofit2.Response;
 
 public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implements
@@ -204,7 +205,11 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
                             .map(Optional::of);
                 });
 
-        return Single.zip(reviewItemSingle, reviewCommentsSingle, filesSingle, commentsSingle,
+        return Single.zip(
+                reviewItemSingle.subscribeOn(Schedulers.io()),
+                reviewCommentsSingle.subscribeOn(Schedulers.io()),
+                filesSingle.subscribeOn(Schedulers.io()),
+                commentsSingle.subscribeOn(Schedulers.io()),
                 (reviewItem, reviewComments, filesOpt, commentsOpt) -> {
             if (!reviewComments.isEmpty()) {
                 HashMap<String, GitHubFile> filesByName = new HashMap<>();


### PR DESCRIPTION
I've noticed that a couple more places have the same loading performance issue that was fixed in #1107, due to missing explicit parallelization of requests.

With these changes, opening a PR and the details screen of a PR review are both ~0,5 secs faster.