### PR TITLE
Allow changing commit title when merging a PR

### DIFF
--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -45,7 +45,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -570,10 +569,10 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
     public static class MergeDialogFragment extends DialogFragment {
 
-        private TextInputLayout detailsField;
-        private TextInputLayout titleField;
-        private Spinner mergeMethodSelector;
-        private PullRequest pr;
+        private TextInputLayout mDetailsField;
+        private TextInputLayout mTitleField;
+        private Spinner mMergeMethodSelector;
+        private PullRequest mPr;
 
         public static MergeDialogFragment newInstance(PullRequest pr) {
             MergeDialogFragment f = new MergeDialogFragment();
@@ -587,27 +586,27 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
         @Override
         public Dialog onCreateDialog(Bundle savedInstanceState) {
             LayoutInflater inflater = LayoutInflater.from(getContext());
-            pr = getArguments().getParcelable("pr");
+            mPr = getArguments().getParcelable("pr");
 
             View view = inflater.inflate(R.layout.pull_merge_message_dialog, null);
-            detailsField = view.findViewById(R.id.details_field);
-            titleField = view.findViewById(R.id.title_field);
+            mDetailsField = view.findViewById(R.id.details_field);
+            mTitleField = view.findViewById(R.id.title_field);
             // This is needed to make the text field single-line but with line wrapping.
             // Setting these properties in the XML does not produce the wanted effect.
-            titleField.getEditText().setHorizontallyScrolling(false);
-            titleField.getEditText().setMaxLines(3);
+            mTitleField.getEditText().setHorizontallyScrolling(false);
+            mTitleField.getEditText().setMaxLines(3);
 
-            mergeMethodSelector = view.findViewById(R.id.merge_method);
+            mMergeMethodSelector = view.findViewById(R.id.merge_method);
             setupMergeMethodSpinner();
 
             final PullRequestActivity activity = (PullRequestActivity) getContext();
             return new AlertDialog.Builder(activity)
-                    .setTitle(getString(R.string.pull_message_dialog_title, pr.number()))
+                    .setTitle(getString(R.string.pull_message_dialog_title, mPr.number()))
                     .setView(view)
                     .setPositiveButton(R.string.pull_request_merge, (dialog, which) -> {
-                        String commitTitle = titleField.getEditText().getText().toString();
-                        String commitDetails = detailsField.getEditText().getText().toString();
-                        MergeMethodDesc selectedMethod = (MergeMethodDesc) mergeMethodSelector.getSelectedItem();
+                        String commitTitle = mTitleField.getEditText().getText().toString();
+                        String commitDetails = mDetailsField.getEditText().getText().toString();
+                        MergeMethodDesc selectedMethod = (MergeMethodDesc) mMergeMethodSelector.getSelectedItem();
 
                         activity.mergePullRequest(commitTitle, commitDetails, selectedMethod.action);
                     })
@@ -624,8 +623,8 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
             adapter.add(new MergeMethodDesc(
                     getString(R.string.pull_merge_method_rebase), MergeRequest.Method.Rebase));
 
-            mergeMethodSelector.setAdapter(adapter);
-            mergeMethodSelector.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            mMergeMethodSelector.setAdapter(adapter);
+            mMergeMethodSelector.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override
                 public void onItemSelected(AdapterView<?> adapter, View view, int position, long id) {
                     MergeMethodDesc selectedItem = (MergeMethodDesc) adapter.getItemAtPosition(position);
@@ -641,21 +640,22 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
         private void setCommitTitleHint(MergeRequest.Method mergeMethod) {
             switch (mergeMethod) {
                 case Merge:
-                    String username = ApiHelpers.getUserLogin(getContext(), pr.head().user());
-                    titleField.setPlaceholderText("Merge pull request #" + pr.number() + " from " + username + "/" + pr.head().ref());
+                    String username = ApiHelpers.getUserLogin(getContext(), mPr.head().user());
+                    mTitleField.setPlaceholderText(
+                            "Merge pull request #" + mPr.number() + " from " + username + "/" + mPr.head().ref());
                     break;
                 case Squash:
-                    titleField.setPlaceholderText(pr.title() + " (#" + pr.number() + ")");
+                    mTitleField.setPlaceholderText(mPr.title() + " (#" + mPr.number() + ")");
                     break;
             }
         }
 
         private void toggleFieldsVisibility(MergeRequest.Method mergeMethod) {
             int fieldsVisibility = mergeMethod == MergeRequest.Method.Rebase ? View.GONE : View.VISIBLE;
-            titleField.setVisibility(fieldsVisibility);
-            detailsField.setVisibility(fieldsVisibility);
+            mTitleField.setVisibility(fieldsVisibility);
+            mDetailsField.setVisibility(fieldsVisibility);
             if (fieldsVisibility == View.GONE) {
-                UiUtils.hideImeForView(titleField);
+                UiUtils.hideImeForView(mTitleField);
             }
         }
     }

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -626,8 +626,8 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
             mMergeMethodSelector.setAdapter(adapter);
             mMergeMethodSelector.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override
-                public void onItemSelected(AdapterView<?> adapter, View view, int position, long id) {
-                    MergeMethodDesc selectedItem = (MergeMethodDesc) adapter.getItemAtPosition(position);
+                public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                    MergeMethodDesc selectedItem = (MergeMethodDesc) parent.getItemAtPosition(position);
                     toggleFieldsVisibility(selectedItem.action);
                     setCommitTitleHint(selectedItem.action);
                 }

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -65,6 +65,7 @@ import com.gh4a.utils.Triplet;
 import com.gh4a.widget.BottomSheetCompatibleScrollingViewBehavior;
 import com.gh4a.widget.IssueStateTrackingFloatingActionButton;
 
+import com.google.android.material.textfield.TextInputLayout;
 import com.meisolsson.githubsdk.model.Issue;
 import com.meisolsson.githubsdk.model.IssueState;
 import com.meisolsson.githubsdk.model.PullRequest;
@@ -569,10 +570,8 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
     public static class MergeDialogFragment extends DialogFragment {
 
-        private View detailsLabel;
-        private EditText detailsField;
-        private View titleLabel;
-        private EditText titleField;
+        private TextInputLayout detailsField;
+        private TextInputLayout titleField;
         private Spinner mergeMethodSelector;
         private PullRequest pr;
 
@@ -591,14 +590,12 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
             pr = getArguments().getParcelable("pr");
 
             View view = inflater.inflate(R.layout.pull_merge_message_dialog, null);
-            detailsLabel = view.findViewById(R.id.details_label);
-            detailsField = view.findViewById(R.id.et_commit_message);
-            titleLabel = view.findViewById(R.id.title_label);
-            titleField = view.findViewById(R.id.et_commit_title);
+            detailsField = view.findViewById(R.id.details_field);
+            titleField = view.findViewById(R.id.title_field);
             // This is needed to make the text field single-line but with line wrapping.
             // Setting these properties in the XML does not produce the wanted effect.
-            titleField.setHorizontallyScrolling(false);
-            titleField.setMaxLines(3);
+            titleField.getEditText().setHorizontallyScrolling(false);
+            titleField.getEditText().setMaxLines(3);
 
             mergeMethodSelector = view.findViewById(R.id.merge_method);
             setupMergeMethodSpinner();
@@ -608,8 +605,8 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
                     .setTitle(getString(R.string.pull_message_dialog_title, pr.number()))
                     .setView(view)
                     .setPositiveButton(R.string.pull_request_merge, (dialog, which) -> {
-                        String commitTitle = titleField.getText() == null ? null : titleField.getText().toString();
-                        String commitDetails = detailsField.getText() == null ? null : detailsField.getText().toString();
+                        String commitTitle = titleField.getEditText().getText().toString();
+                        String commitDetails = detailsField.getEditText().getText().toString();
                         MergeMethodDesc selectedMethod = (MergeMethodDesc) mergeMethodSelector.getSelectedItem();
 
                         activity.mergePullRequest(commitTitle, commitDetails, selectedMethod.action);
@@ -645,10 +642,10 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
             switch (mergeMethod) {
                 case Merge:
                     String username = ApiHelpers.getUserLogin(getContext(), pr.head().user());
-                    titleField.setHint("Merge pull request #" + pr.number() + " from " + username + "/" + pr.head().ref());
+                    titleField.setPlaceholderText("Merge pull request #" + pr.number() + " from " + username + "/" + pr.head().ref());
                     break;
                 case Squash:
-                    titleField.setHint(pr.title() + " (#" + pr.number() + ")");
+                    titleField.setPlaceholderText(pr.title() + " (#" + pr.number() + ")");
                     break;
             }
         }
@@ -656,9 +653,7 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
         private void toggleFieldsVisibility(MergeRequest.Method mergeMethod) {
             int fieldsVisibility = mergeMethod == MergeRequest.Method.Rebase ? View.GONE : View.VISIBLE;
             titleField.setVisibility(fieldsVisibility);
-            titleLabel.setVisibility(fieldsVisibility);
             detailsField.setVisibility(fieldsVisibility);
-            detailsLabel.setVisibility(fieldsVisibility);
             if (fieldsVisibility == View.GONE) {
                 UiUtils.hideImeForView(titleField);
             }

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -30,6 +30,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import com.gh4a.utils.ActivityResultHelpers;
+import com.gh4a.utils.UiUtils;
 import com.google.android.material.appbar.AppBarLayout;
 
 import androidx.appcompat.view.ContextThemeWrapper;
@@ -658,6 +659,9 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
             titleLabel.setVisibility(fieldsVisibility);
             detailsField.setVisibility(fieldsVisibility);
             detailsLabel.setVisibility(fieldsVisibility);
+            if (fieldsVisibility == View.GONE) {
+                UiUtils.hideImeForView(titleField);
+            }
         }
     }
 

--- a/app/src/main/res/layout/pull_merge_message_dialog.xml
+++ b/app/src/main/res/layout/pull_merge_message_dialog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,6 +14,8 @@
         <com.gh4a.widget.StyleableTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
             android:text="@string/pull_merge_method" />
 
         <Spinner
@@ -20,39 +23,41 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <com.gh4a.widget.StyleableTextView
-            android:id="@+id/title_label"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/title_field"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:labelFor="@+id/et_commit_title"
-            android:text="@string/pull_merge_title_description"
-            android:textAppearance="?android:attr/textAppearanceSmall" />
+            app:expandedHintEnabled="false"
+            android:hint="@string/pull_merge_title_description">
 
-        <EditText
-            android:id="@+id/et_commit_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:cursorVisible="true"
-            android:imeOptions="actionNext"
-            android:inputType="textCapSentences" />
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionNext"
+                android:layout_marginStart="-8dp"
+                android:background="@android:color/transparent"
+                android:inputType="textCapSentences" />
 
-        <com.gh4a.widget.StyleableTextView
-            android:id="@+id/details_label"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:labelFor="@+id/et_commit_message"
-            android:text="@string/pull_merge_message_description"
-            android:textAppearance="?android:attr/textAppearanceSmall" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/et_commit_message"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/details_field"
+            android:layout_marginTop="16dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:cursorVisible="true"
-            android:inputType="textMultiLine|textCapSentences"
-            android:maxLines="5" />
+            android:hint="@string/pull_merge_message_description"
+            app:expandedHintEnabled="false"
+            app:placeholderText="@string/pull_merge_message_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="-8dp"
+                android:inputType="textMultiLine|textCapSentences"
+                android:background="@android:color/transparent"
+                android:maxLines="5" />
+
+        </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 </ScrollView>
 

--- a/app/src/main/res/layout/pull_merge_message_dialog.xml
+++ b/app/src/main/res/layout/pull_merge_message_dialog.xml
@@ -17,10 +17,28 @@
         android:layout_height="wrap_content" />
 
     <com.gh4a.widget.StyleableTextView
-        android:id="@+id/notice"
+        android:id="@+id/title_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:labelFor="@+id/et_commit_title"
+        android:text="@string/pull_merge_title_description"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+    <EditText
+        android:id="@+id/et_commit_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:cursorVisible="true"
+        android:imeOptions="flagNoFullscreen|actionNext"
+        android:inputType="textCapSentences" />
+
+    <com.gh4a.widget.StyleableTextView
+        android:id="@+id/details_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:labelFor="@+id/et_commit_message"
         android:text="@string/pull_merge_message_description"
         android:textAppearance="?android:attr/textAppearanceSmall" />
 
@@ -29,7 +47,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:cursorVisible="true"
-        android:imeOptions="flagNoFullscreen|actionNext"
+        android:imeOptions="flagNoFullscreen"
         android:inputType="textMultiLine|textCapSentences"
         android:maxLines="5" />
 

--- a/app/src/main/res/layout/pull_merge_message_dialog.xml
+++ b/app/src/main/res/layout/pull_merge_message_dialog.xml
@@ -1,55 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp">
+    android:layout_height="wrap_content">
 
-    <com.gh4a.widget.StyleableTextView
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/pull_merge_method" />
+        android:orientation="vertical"
+        android:padding="16dp">
 
-    <Spinner
-        android:id="@+id/merge_method"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        <com.gh4a.widget.StyleableTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/pull_merge_method" />
 
-    <com.gh4a.widget.StyleableTextView
-        android:id="@+id/title_label"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:labelFor="@+id/et_commit_title"
-        android:text="@string/pull_merge_title_description"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        <Spinner
+            android:id="@+id/merge_method"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
-    <EditText
-        android:id="@+id/et_commit_title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:cursorVisible="true"
-        android:imeOptions="flagNoFullscreen|actionNext"
-        android:inputType="textCapSentences" />
+        <com.gh4a.widget.StyleableTextView
+            android:id="@+id/title_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:labelFor="@+id/et_commit_title"
+            android:text="@string/pull_merge_title_description"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
-    <com.gh4a.widget.StyleableTextView
-        android:id="@+id/details_label"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:labelFor="@+id/et_commit_message"
-        android:text="@string/pull_merge_message_description"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        <EditText
+            android:id="@+id/et_commit_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:cursorVisible="true"
+            android:imeOptions="actionNext"
+            android:inputType="textCapSentences" />
 
-    <EditText
-        android:id="@+id/et_commit_message"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:cursorVisible="true"
-        android:imeOptions="flagNoFullscreen"
-        android:inputType="textMultiLine|textCapSentences"
-        android:maxLines="5" />
+        <com.gh4a.widget.StyleableTextView
+            android:id="@+id/details_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:labelFor="@+id/et_commit_message"
+            android:text="@string/pull_merge_message_description"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
-</LinearLayout>
+        <EditText
+            android:id="@+id/et_commit_message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:cursorVisible="true"
+            android:inputType="textMultiLine|textCapSentences"
+            android:maxLines="5" />
+    </LinearLayout>
+</ScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -440,6 +440,7 @@
     <string name="pull_request_merged">Merged</string>
     <string name="pull_error_merge">Merging pull request #%1$d failed.</string>
     <string name="pull_message_dialog_title">Merge pull request #%1$d</string>
+    <string name="pull_merge_title_description">Merge commit title</string>
     <string name="pull_merge_message_description">If you want to add additional details to the merge commit message, please enter them below.</string>
     <string name="pull_merge_status_behind">This branch is out-of-date with the base branch</string>
     <string name="pull_merge_status_blocked">Merging is blocked</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,7 +441,8 @@
     <string name="pull_error_merge">Merging pull request #%1$d failed.</string>
     <string name="pull_message_dialog_title">Merge pull request #%1$d</string>
     <string name="pull_merge_title_description">Merge commit title</string>
-    <string name="pull_merge_message_description">If you want to add additional details to the merge commit message, please enter them below.</string>
+    <string name="pull_merge_message_description">Merge commit details</string>
+    <string name="pull_merge_message_hint">If you want to add more details to the merge commit, enter them here.</string>
     <string name="pull_merge_status_behind">This branch is out-of-date with the base branch</string>
     <string name="pull_merge_status_blocked">Merging is blocked</string>
     <string name="pull_merge_status_clean">All checks have passed</string>


### PR DESCRIPTION
This PR adds the ability to customize the merge commit title, which previously was always generated by GitHub.
When the user doesn't enter a title, GitHub still provides its auto-generated title. To make this clear to the user, I have added a hint to the title EditText containing the title that GitHub will generate if the user doesn't type in anything. Here's an example:

![merge-pr](https://user-images.githubusercontent.com/30041551/137588675-84daf319-f2fd-475f-8642-e837b492879d.png)

While implementing this, I've done some refactoring to the MergeDialogFragment otherwise things would have become a bit too messy :smiley: 

