### PR TITLE
Make issue/PR body visible while the rest of the conversation is still loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation 'com.caverock:androidsvg-aar:1.4'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.21'
     implementation 'org.ocpsoft.prettytime:prettytime:4.0.6.Final'
-    implementation 'com.github.castorflex.smoothprogressbar:library:1.1.0'
+    implementation 'com.github.castorflex.smoothprogressbar:library:1.3.0'
     implementation 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
     implementation 'com.github.pluscubed:recycler-fast-scroll:3de76812553a77bfd25d3aea0a0af4d96516c3e3@aar'
     implementation('com.vdurmont:emoji-java:5.1.1') {

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -193,6 +193,8 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
 
         mListHeaderView = inflater.inflate(R.layout.issue_comment_list_header, view, false);
         mAdapter.setHeaderView(mListHeaderView);
+        View loadingView = inflater.inflate(R.layout.list_loading_view, view, false);
+        showLoadingIndicator(loadingView);
     }
 
     @Override
@@ -325,6 +327,16 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         }
 
         updateMentionUsers();
+        removeLoadingIndicator(adapter);
+    }
+
+    private void showLoadingIndicator(View loadingView) {
+        loadingView.setVisibility(View.VISIBLE);
+        mAdapter.setFooterView(loadingView, null);
+    }
+
+    private void removeLoadingIndicator(RootAdapter<TimelineItem, ?> adapter) {
+        adapter.setFooterView(null, null);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -37,6 +37,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.gh4a.BaseActivity;
 import com.gh4a.Gh4Application;
 import com.gh4a.R;
 import com.gh4a.ServiceFactory;
@@ -160,7 +161,16 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        getBaseActivity().addAppBarOffsetListener(mBottomSheet);
+        // We make the content container visible so that the issue/PR can be read while the rest
+        // of the conversation is still loading
+        view.findViewById(R.id.content_container).setVisibility(View.VISIBLE);
+
+        BaseActivity activity = getBaseActivity();
+        activity.addAppBarOffsetListener(mBottomSheet);
+        mBottomSheet.post(() -> {
+            // Fix an issue where the bottom sheet is initially located outside of the visible screen area
+            mBottomSheet.resetPeekHeight(activity.getAppBarTotalScrollRange());
+        });
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -161,9 +161,10 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        // We make the content container visible so that the issue/PR can be read while the rest
-        // of the conversation is still loading
-        view.findViewById(R.id.content_container).setVisibility(View.VISIBLE);
+        // We want to make the user able to read the issue/PR while the rest of the conversation is still loading
+        if (mInitialComment == null) {
+            view.findViewById(R.id.content_container).setVisibility(View.VISIBLE);
+        }
 
         BaseActivity activity = getBaseActivity();
         activity.addAppBarOffsetListener(mBottomSheet);

--- a/app/src/main/java/com/gh4a/fragment/LoadingFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/LoadingFragmentBase.java
@@ -67,7 +67,6 @@ public abstract class LoadingFragmentBase extends Fragment implements
         super.onDestroyView();
         mContentContainer = null;
         mProgress = null;
-        mProgress = null;
     }
 
     @Override
@@ -129,7 +128,10 @@ public abstract class LoadingFragmentBase extends Fragment implements
         View in = mContentShown ? mContentContainer : mProgress;
         if (isResumed()) {
             out.startAnimation(AnimationUtils.loadAnimation(getActivity(), android.R.anim.fade_out));
-            in.startAnimation(AnimationUtils.loadAnimation(getActivity(), android.R.anim.fade_in));
+            // Prevent UI "flashes" by not unnecessarily animating an element when it's already visible
+            if (in.getVisibility() != View.VISIBLE) {
+                in.startAnimation(AnimationUtils.loadAnimation(getActivity(), android.R.anim.fade_in));
+            }
         } else {
             in.clearAnimation();
             out.clearAnimation();

--- a/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
@@ -168,10 +168,6 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
 
     @Override
     protected void bindSpecialViews(View headerView) {
-        if (!mHasLoadedHeadReference) {
-            return;
-        }
-
         PullRequestBranchInfoView branchContainer = headerView.findViewById(R.id.branch_container);
         branchContainer.bind(mPullRequest.head(), mPullRequest.base(), mHeadReference);
         branchContainer.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
@@ -168,6 +168,9 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
 
     @Override
     protected void bindSpecialViews(View headerView) {
+        CommitStatusBox commitStatusBox = mListHeaderView.findViewById(R.id.commit_status_box);
+        commitStatusBox.setVisibility(View.VISIBLE);
+
         PullRequestBranchInfoView branchContainer = headerView.findViewById(R.id.branch_container);
         branchContainer.bind(mPullRequest.head(), mPullRequest.base(), mHeadReference);
         branchContainer.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
@@ -168,9 +168,6 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
 
     @Override
     protected void bindSpecialViews(View headerView) {
-        CommitStatusBox commitStatusBox = mListHeaderView.findViewById(R.id.commit_status_box);
-        commitStatusBox.setVisibility(View.VISIBLE);
-
         PullRequestBranchInfoView branchContainer = headerView.findViewById(R.id.branch_container);
         branchContainer.bind(mPullRequest.head(), mPullRequest.base(), mHeadReference);
         branchContainer.setVisibility(View.VISIBLE);
@@ -461,6 +458,10 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
         if (mPullRequest.state() != IssueState.Open) {
             return;
         }
+
+        // At this point the status box will display a loading placeholder
+        CommitStatusBox commitStatusBox = mListHeaderView.findViewById(R.id.commit_status_box);
+        commitStatusBox.setVisibility(View.VISIBLE);
 
         RepositoryStatusService repoService = ServiceFactory.get(RepositoryStatusService.class, force);
         String sha = mPullRequest.head().sha();

--- a/app/src/main/java/com/gh4a/widget/CommitStatusBox.java
+++ b/app/src/main/java/com/gh4a/widget/CommitStatusBox.java
@@ -9,6 +9,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.gh4a.R;
@@ -21,6 +22,7 @@ import java.util.List;
 
 public class CommitStatusBox extends LinearLayoutCompat implements View.OnClickListener {
     private final ImageView mStatusIcon;
+    private final ProgressBar mLoadingIndicator;
     private final TextView mStatusLabel;
     private final ViewGroup mStatusContainer;
     private final LayoutInflater mInflater;
@@ -45,13 +47,12 @@ public class CommitStatusBox extends LinearLayoutCompat implements View.OnClickL
         mInflater.inflate(R.layout.commit_status_box, this, true);
 
         mStatusIcon = findViewById(R.id.iv_merge_status_icon);
+        mLoadingIndicator = findViewById(R.id.status_progress);
         mStatusLabel = findViewById(R.id.merge_status_label);
         mStatusContainer = findViewById(R.id.merge_commit_status_container);
         mSummaryTextView = findViewById(R.id.merge_commit_summary);
         mDropDownIcon = findViewById(R.id.drop_down_icon);
-
         mHeader = findViewById(R.id.commit_status_header);
-        mHeader.setOnClickListener(this);
     }
 
     public void fillStatus(List<StatusWrapper> statuses, PullRequest.MergeableState mergableState) {
@@ -95,9 +96,9 @@ public class CommitStatusBox extends LinearLayoutCompat implements View.OnClickL
                 break;
         }
 
-        setVisibility(View.VISIBLE);
-
+        mLoadingIndicator.setVisibility(GONE);
         mStatusIcon.setImageResource(statusIconDrawableResId);
+        mStatusIcon.setVisibility(VISIBLE);
         mStatusLabel.setText(statusLabelResId);
 
         mStatusContainer.removeAllViews();
@@ -110,7 +111,7 @@ public class CommitStatusBox extends LinearLayoutCompat implements View.OnClickL
             return;
         }
 
-        mHeader.setClickable(true);
+        mHeader.setOnClickListener(this);
         mDropDownIcon.setVisibility(View.VISIBLE);
         mStatusContainer.setVisibility(View.VISIBLE);
 

--- a/app/src/main/java/com/gh4a/widget/CommitStatusBox.java
+++ b/app/src/main/java/com/gh4a/widget/CommitStatusBox.java
@@ -159,7 +159,7 @@ public class CommitStatusBox extends LinearLayoutCompat implements View.OnClickL
         }
 
         setSummaryText(failingCount, pendingCount, successCount);
-        setStatusesExpanded(failingCount + pendingCount > 0);
+        setStatusesExpanded(false);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/widget/OverviewRow.java
+++ b/app/src/main/java/com/gh4a/widget/OverviewRow.java
@@ -48,7 +48,7 @@ public class OverviewRow extends LinearLayoutCompat implements View.OnClickListe
         mIcon = findViewById(R.id.icon);
         mLabel = findViewById(R.id.label);
         mRedirectNotice = findViewById(R.id.forward_notice);
-        mProgress = findViewById(R.id.progress);
+        mProgress = findViewById(R.id.progress_indicator);
 
         final TypedArray a = getContext().obtainStyledAttributes(
                 attrs, R.styleable.OverviewRow, defStyle, 0);

--- a/app/src/main/res/layout/commit_status_box.xml
+++ b/app/src/main/res/layout/commit_status_box.xml
@@ -13,6 +13,15 @@
         android:layout_height="wrap_content"
         android:background="?selectableItemBackground">
 
+        <ProgressBar
+            android:id="@+id/status_progress"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_marginLeft="@dimen/content_padding"
+            android:layout_marginRight="10dp"
+            android:layout_marginTop="@dimen/content_padding"
+            android:indeterminate="true" />
+
         <ImageView
             android:id="@+id/iv_merge_status_icon"
             android:layout_width="30dp"
@@ -21,6 +30,7 @@
             android:layout_marginLeft="@dimen/content_padding"
             android:layout_marginRight="10dp"
             android:layout_marginTop="@dimen/content_padding"
+            android:visibility="invisible"
             tools:src="@drawable/pull_request_merge_ok" />
 
         <com.gh4a.widget.StyleableTextView
@@ -30,8 +40,8 @@
             android:layout_marginTop="@dimen/content_padding"
             android:layout_toLeftOf="@+id/drop_down_icon"
             android:layout_toRightOf="@id/iv_merge_status_icon"
-            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-            tools:text="All checks have passed" />
+            android:text="@string/pull_merge_status_loading"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
         <com.gh4a.widget.StyleableTextView
             android:id="@+id/merge_commit_summary"
@@ -56,7 +66,9 @@
             android:layout_marginRight="@dimen/content_padding"
             android:layout_marginTop="@dimen/content_padding"
             android:scaleType="center"
-            android:src="@drawable/drop_up_arrow" />
+            android:visibility="gone"
+            android:src="@drawable/drop_up_arrow"
+            tools:visibility="visible"/>
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/loading_fragment.xml
+++ b/app/src/main/res/layout/loading_fragment.xml
@@ -5,6 +5,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <FrameLayout
+        android:id="@+id/content_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
     <fr.castorflex.android.smoothprogressbar.SmoothProgressBar
         android:id="@+id/progress"
         android:layout_width="match_parent"
@@ -17,10 +22,5 @@
         app:spb_progressiveStop_speed="3.4"
         app:spb_sections_count="6"
         app:spb_speed="1.0" />
-
-    <FrameLayout
-        android:id="@+id/content_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/overview_row.xml
+++ b/app/src/main/res/layout/overview_row.xml
@@ -15,7 +15,7 @@
         tools:src="@drawable/icon_watch" />
 
     <ProgressBar
-        android:id="@+id/progress"
+        android:id="@+id/progress_indicator"
         style="@style/Widget.AppCompat.ProgressBar"
         android:layout_width="24dp"
         android:layout_height="24dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,6 +445,7 @@
     <string name="pull_merge_title_description">Merge commit title</string>
     <string name="pull_merge_message_description">Merge commit details</string>
     <string name="pull_merge_message_hint">If you want to add more details to the merge commit, enter them here.</string>
+    <string name="pull_merge_status_loading">Loading pull request status…</string>
     <string name="pull_merge_status_behind">This branch is out-of-date with the base branch</string>
     <string name="pull_merge_status_blocked">Merging is blocked</string>
     <string name="pull_merge_status_clean">All checks have passed</string>


### PR DESCRIPTION
This PR mitigates the sometimes very slow loading of issue/PR conversations (due to GH REST API limitations we all know) by showing the issue/PR body as soon as possible, instead of waiting for the rest of the conversation to load.
This can be best demonstrated by the screencast here: https://streamable.com/aj4p28.

This way, the user can start reading the content of the issue/PR without waiting, drastically reducing the perception of the loading times.
The only thing I'm not too sure about is whether we should keep the editor bottom sheet hidden while loading is in progress. There is technically nothing that can prevent us not to show it, but at the same time it doesn't make much sense to use it before the conversation is loaded.

**Note:** I've tried to workaround some issues with the editor bottom sheet that are also present in the current version of the app. Some glitches are still present when rotating the screen, but I haven't had enough time to understand how bottom sheet positioning/resizing works in order to do a proper fix and I'm not sure whether I want to. :slightly_smiling_face:

**A sidenote:** I personally think that we shouldn't expand automatically the list of check runs when there are some failed checks. As you can see in the screencast above, for repositories that have something like 20+ checks (_PowerShell/PowerShell_ and _dotnet/runtime_ are great examples) it becomes a bit annoying having to scroll down the list to reach the first comment (yes, you could collapse it but often just happens to go brainlessly straight to the conversation :sweat_smile:).