### PR TITLE
Allow direct installation of downloaded APKs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,11 +8,11 @@
     <!-- see http://stackoverflow.com/questions/32070670/preferencefragmentcompat-requires-preferencetheme-to-be-set -->
     <uses-sdk tools:overrideLibrary="android.support.v14.preference" />
 
-    <uses-permission
-        android:name="android.permission.INTERNET" />
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/com/gh4a/activities/FileViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/FileViewerActivity.java
@@ -37,11 +37,11 @@ import com.gh4a.ApiRequestException;
 import com.gh4a.R;
 import com.gh4a.ServiceFactory;
 import com.gh4a.utils.ApiHelpers;
+import com.gh4a.utils.DownloadUtils;
 import com.gh4a.utils.FileUtils;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.Optional;
 import com.gh4a.utils.StringUtils;
-import com.gh4a.utils.UiUtils;
 import com.meisolsson.githubsdk.model.ClientErrorResponse;
 import com.meisolsson.githubsdk.model.Content;
 import com.meisolsson.githubsdk.model.TextMatch;
@@ -235,7 +235,7 @@ public class FileViewerActivity extends WebViewerActivity
                 IntentUtils.launchBrowser(this, url);
                 return true;
             case R.id.download:
-                UiUtils.enqueueDownloadWithPermissionCheck(this, buildRawFileUrl(),
+                DownloadUtils.enqueueDownloadWithPermissionCheck(this, buildRawFileUrl(),
                         FileUtils.getMimeTypeFor(mPath), FileUtils.getFileName(mPath), null);
                 return true;
             case R.id.share:

--- a/app/src/main/java/com/gh4a/activities/GistViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/GistViewerActivity.java
@@ -27,10 +27,10 @@ import android.view.MenuItem;
 import com.gh4a.R;
 import com.gh4a.ServiceFactory;
 import com.gh4a.utils.ApiHelpers;
+import com.gh4a.utils.DownloadUtils;
 import com.gh4a.utils.FileUtils;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.StringUtils;
-import com.gh4a.utils.UiUtils;
 import com.meisolsson.githubsdk.model.GistFile;
 import com.meisolsson.githubsdk.service.gists.GistService;
 
@@ -121,7 +121,7 @@ public class GistViewerActivity extends WebViewerActivity {
                 IntentUtils.launchBrowser(this, Uri.parse(mGistFile.rawUrl()));
                 return true;
             case R.id.download:
-                UiUtils.enqueueDownloadWithPermissionCheck(this, mGistFile.rawUrl(),
+                DownloadUtils.enqueueDownloadWithPermissionCheck(this, mGistFile.rawUrl(),
                         mGistFile.type(), mGistFile.filename(), null);
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -36,22 +36,19 @@ import com.gh4a.adapter.ReleaseAssetAdapter;
 import com.gh4a.adapter.RootAdapter;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.AvatarHandler;
+import com.gh4a.utils.DownloadUtils;
 import com.gh4a.utils.HttpImageGetter;
 import com.gh4a.utils.IntentUtils;
-import com.gh4a.utils.Optional;
 import com.gh4a.utils.StringUtils;
 import com.gh4a.utils.UiUtils;
 import com.gh4a.widget.StyleableTextView;
 import com.gh4a.widget.SwipeRefreshLayout;
 import com.meisolsson.githubsdk.model.Release;
 import com.meisolsson.githubsdk.model.ReleaseAsset;
-import com.meisolsson.githubsdk.model.request.RequestMarkdown;
-import com.meisolsson.githubsdk.service.misc.MarkdownService;
 import com.meisolsson.githubsdk.service.repositories.RepositoryReleaseService;
 
 import java.util.Date;
 
-import io.reactivex.Single;
 import io.reactivex.disposables.Disposable;
 
 public class ReleaseInfoActivity extends BaseActivity implements
@@ -235,7 +232,7 @@ public class ReleaseInfoActivity extends BaseActivity implements
 
     @Override
     public void onItemClick(ReleaseAsset item) {
-        UiUtils.enqueueDownloadWithPermissionCheck(this, item);
+        DownloadUtils.enqueueDownloadWithPermissionCheck(this, item);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
@@ -31,9 +31,9 @@ import com.gh4a.fragment.ContentListContainerFragment;
 import com.gh4a.fragment.RepositoryEventListFragment;
 import com.gh4a.fragment.RepositoryFragment;
 import com.gh4a.utils.ApiHelpers;
+import com.gh4a.utils.DownloadUtils;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.RxUtils;
-import com.gh4a.utils.UiUtils;
 import com.meisolsson.githubsdk.model.Branch;
 import com.meisolsson.githubsdk.model.Commit;
 import com.meisolsson.githubsdk.model.Repository;
@@ -316,7 +316,7 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
                         .appendPath("zipball")
                         .appendPath(getCurrentRef())
                         .toString();
-                UiUtils.enqueueDownloadWithPermissionCheck(this, zipUrl, "application/zip",
+                DownloadUtils.enqueueDownloadWithPermissionCheck(this, zipUrl, "application/zip",
                         mRepoName + "-" + getCurrentRef() + ".zip", null);
                 return true;
             }

--- a/app/src/main/java/com/gh4a/fragment/ContentListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ContentListFragment.java
@@ -35,11 +35,11 @@ import com.gh4a.activities.CommitHistoryActivity;
 import com.gh4a.adapter.FileAdapter;
 import com.gh4a.adapter.RootAdapter;
 import com.gh4a.utils.ApiHelpers;
+import com.gh4a.utils.DownloadUtils;
 import com.gh4a.utils.FileUtils;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.RxUtils;
 import com.gh4a.utils.StringUtils;
-import com.gh4a.utils.UiUtils;
 import com.gh4a.widget.ContextMenuAwareRecyclerView;
 import com.meisolsson.githubsdk.model.Commit;
 import com.meisolsson.githubsdk.model.Content;
@@ -190,7 +190,7 @@ public class ContentListFragment extends ListDataBaseFragment<Content> implement
             case R.id.download:
                 String url = IntentUtils.createRawFileUrl(mRepository.owner().login(),
                         mRepository.name(), mRef, contents.path());
-                UiUtils.enqueueDownloadWithPermissionCheck(getBaseActivity(),
+                DownloadUtils.enqueueDownloadWithPermissionCheck(getBaseActivity(),
                         url, FileUtils.getMimeTypeFor(contents.name()),
                         contents.name(), null);
                 return true;

--- a/app/src/main/java/com/gh4a/fragment/EventListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/EventListFragment.java
@@ -46,10 +46,10 @@ import com.gh4a.adapter.RootAdapter;
 import com.gh4a.resolver.CommitCommentLoadTask;
 import com.gh4a.resolver.PullRequestReviewCommentLoadTask;
 import com.gh4a.utils.ApiHelpers;
+import com.gh4a.utils.DownloadUtils;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.Optional;
 import com.gh4a.utils.RxUtils;
-import com.gh4a.utils.UiUtils;
 import com.gh4a.widget.ContextMenuAwareRecyclerView;
 import com.meisolsson.githubsdk.model.Download;
 import com.meisolsson.githubsdk.model.GitHubEvent;
@@ -171,7 +171,7 @@ public abstract class EventListFragment extends PagedDataBaseFragment<GitHubEven
             case DownloadEvent: {
                 DownloadPayload payload = (DownloadPayload) event.payload();
                 Download download = payload.download();
-                UiUtils.enqueueDownloadWithPermissionCheck((BaseActivity) getActivity(), download);
+                DownloadUtils.enqueueDownloadWithPermissionCheck((BaseActivity) getActivity(), download);
                 break;
             }
 
@@ -481,11 +481,11 @@ public abstract class EventListFragment extends PagedDataBaseFragment<GitHubEven
             if (event.type() == GitHubEventType.ReleaseEvent) {
                 ReleasePayload payload = (ReleasePayload) event.payload();
                 ReleaseAsset asset = payload.release().assets().get(id - MENU_DOWNLOAD_START);
-                UiUtils.enqueueDownloadWithPermissionCheck((BaseActivity) getActivity(), asset);
+                DownloadUtils.enqueueDownloadWithPermissionCheck((BaseActivity) getActivity(), asset);
             } else if (event.type() == GitHubEventType.DownloadEvent) {
                 DownloadPayload payload = (DownloadPayload) event.payload();
                 Download download = payload.download();
-                UiUtils.enqueueDownloadWithPermissionCheck((BaseActivity) getActivity(), download);
+                DownloadUtils.enqueueDownloadWithPermissionCheck((BaseActivity) getActivity(), download);
                 }
             return true;
         }

--- a/app/src/main/java/com/gh4a/utils/DownloadUtils.java
+++ b/app/src/main/java/com/gh4a/utils/DownloadUtils.java
@@ -1,0 +1,167 @@
+package com.gh4a.utils;
+
+import android.Manifest;
+import android.app.DownloadManager;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.Uri;
+import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
+
+import com.gh4a.BaseActivity;
+import com.gh4a.Gh4Application;
+import com.gh4a.R;
+import com.gh4a.ServiceFactory;
+import com.meisolsson.githubsdk.model.Download;
+import com.meisolsson.githubsdk.model.ReleaseAsset;
+
+import java.io.IOException;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.app.ActivityCompat;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class DownloadUtils {
+    public static void enqueueDownloadWithPermissionCheck(final BaseActivity activity,
+            final Download download) {
+        enqueueDownloadWithPermissionCheck(activity, download.htmlUrl(), download.contentType(),
+                download.name(), download.description());
+    }
+
+    public static void enqueueDownloadWithPermissionCheck(final BaseActivity activity,
+            final ReleaseAsset asset) {
+        final ActivityCompat.OnRequestPermissionsResultCallback cb =
+                (requestCode, permissions, grantResults) -> {
+                    if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                        enqueueDownload(activity, asset);
+                    }
+                };
+        activity.requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, cb,
+                R.string.download_permission_rationale);
+    }
+
+    public static void enqueueDownloadWithPermissionCheck(final BaseActivity activity,
+            final String url, final String mimeType, final String fileName, final String description) {
+        final ActivityCompat.OnRequestPermissionsResultCallback cb =
+                (requestCode, permissions, grantResults) -> {
+                    if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                        enqueueDownload(activity, url, fileName, description, mimeType, null, false);
+                    }
+                };
+        activity.requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, cb,
+                R.string.download_permission_rationale);
+    }
+
+    private static void enqueueDownload(Context context, Uri uri, String fileName,
+            String description, String mimeType, String mediaType,
+            boolean wifiOnly, boolean addAuthHeader) {
+        final DownloadManager dm = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+        DownloadManager.Request request = new DownloadManager.Request(uri)
+                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+                .setDescription(description)
+                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                .setAllowedOverRoaming(false);
+
+        if (mediaType != null) {
+            request.addRequestHeader("Accept", mediaType);
+        }
+        final String token = Gh4Application.get().getAuthToken();
+        if (addAuthHeader && token != null) {
+            request.addRequestHeader("Authorization", "Token " + token);
+        }
+        if (mimeType != null) {
+            request.setMimeType(mimeType);
+        }
+        if (wifiOnly) {
+            request.setAllowedOverMetered(false);
+        }
+
+        dm.enqueue(request);
+    }
+
+    private static void enqueueDownload(final Context context, final ReleaseAsset asset) {
+        // Ugly workaround for #972 (see #976 for analysis), suggested by GH support:
+        // "First, you make an API call to the endpoint for fetching an asset and you pass in the
+        //  token via the Authorization header. You make this call using an HTTP library (not via
+        //  the Android Download Manager) and you disable automatic following of redirects when you
+        //  make that call (in case that's enabled by default). The result of that call will be a
+        //  redirect response with a Location header.
+        //  Second, you use the Android Download Manager to download the asset from the URL that's
+        //  provided in the Location header from the response of the first step. You would not
+        //  provide an Authorization header here since the required authorization is already a
+        //  part of the URL."
+        final OkHttpClient client = ServiceFactory.getHttpClientBuilder()
+                .followRedirects(false)
+                .build();
+        final Request.Builder requestBuilder = new Request.Builder()
+                .url(asset.url())
+                .header("Accept", "application/octet-stream");
+        final String token = Gh4Application.get().getAuthToken();
+        if (token != null) {
+            requestBuilder.addHeader("Authorization", "Token " + token);
+        }
+
+        final Handler handler = new Handler(Looper.getMainLooper());
+
+        client.newCall(requestBuilder.build()).enqueue(new Callback() {
+            private void completeDownload(final String url) {
+                handler.post(() -> {
+                    enqueueDownload(context, url, asset.name(), asset.label(), asset.contentType(),
+                            "application/octet-stream", false);
+                });
+            }
+            @Override
+            public void onFailure(Call call, IOException e) {
+                completeDownload(asset.url());
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) {
+                completeDownload(response.isRedirect()
+                        ? response.header("Location")
+                        : call.request().url().toString());
+            }
+        });
+    }
+
+    private static void enqueueDownload(final Context context, String url, final String fileName,
+            final String description, final String mimeType,
+            final String mediaType, final boolean addAuthHeader) {
+        if (url == null) {
+            return;
+        }
+
+        final Uri uri = Uri.parse(url);
+        if (!downloadNeedsWarning(context)) {
+            enqueueDownload(context, uri, fileName, description, mimeType, mediaType, false, addAuthHeader);
+            return;
+        }
+
+        DialogInterface.OnClickListener buttonListener = (dialog, which) -> {
+            boolean wifiOnly = which == DialogInterface.BUTTON_NEUTRAL;
+            enqueueDownload(context, uri, fileName, description, mimeType, mediaType, wifiOnly, addAuthHeader);
+        };
+
+        new AlertDialog.Builder(context)
+                .setTitle(R.string.download_mobile_warning_title)
+                .setMessage(R.string.download_mobile_warning_message)
+                .setPositiveButton(R.string.download_now_button, buttonListener)
+                .setNeutralButton(R.string.download_wifi_button, buttonListener)
+                .setNegativeButton(R.string.cancel, null)
+                .show();
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public static boolean downloadNeedsWarning(Context context) {
+        ConnectivityManager cm =
+                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        return cm.isActiveNetworkMetered();
+    }
+}

--- a/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
+++ b/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
@@ -512,7 +512,7 @@ public class HttpImageGetter {
         int mode = prefs.getInt(SettingsFragment.KEY_GIF_LOADING, 1);
         switch (mode) {
             case 1: // load via Wifi
-                return !UiUtils.downloadNeedsWarning(mContext);
+                return !DownloadUtils.downloadNeedsWarning(mContext);
             case 2: // always load
                 return true;
             default:

--- a/app/src/main/java/com/gh4a/utils/UiUtils.java
+++ b/app/src/main/java/com/gh4a/utils/UiUtils.java
@@ -1,29 +1,11 @@
 package com.gh4a.utils;
 
-import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Dialog;
-import android.app.DownloadManager;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.pm.PackageManager;
 import android.content.res.TypedArray;
 import android.graphics.Color;
-import android.net.ConnectivityManager;
-import android.net.Uri;
 import android.os.Build;
-import android.os.Environment;
-import androidx.annotation.AttrRes;
-import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-import androidx.appcompat.app.AlertDialog;
-import androidx.recyclerview.widget.RecyclerView;
-
-import android.os.Handler;
-import android.os.Looper;
 import android.text.Editable;
 import android.text.SpannableStringBuilder;
 import android.text.TextWatcher;
@@ -40,26 +22,22 @@ import android.widget.EditText;
 import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
 
-import com.gh4a.BaseActivity;
-import com.gh4a.Gh4Application;
 import com.gh4a.R;
-import com.gh4a.ServiceFactory;
 import com.gh4a.widget.IssueLabelSpan;
-import com.meisolsson.githubsdk.model.Download;
 import com.meisolsson.githubsdk.model.Label;
-import com.meisolsson.githubsdk.model.ReleaseAsset;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import androidx.annotation.AttrRes;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class UiUtils {
     public static void hideImeForView(View view) {
@@ -222,142 +200,6 @@ public class UiUtils {
         int color = a.getColor(0, 0);
         a.recycle();
         return color;
-    }
-
-    private static void enqueueDownload(Context context, Uri uri, String fileName,
-            String description, String mimeType, String mediaType,
-            boolean wifiOnly, boolean addAuthHeader) {
-        final DownloadManager dm = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-        DownloadManager.Request request = new DownloadManager.Request(uri)
-                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
-                .setDescription(description)
-                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                .setAllowedOverRoaming(false);
-
-        if (mediaType != null) {
-            request.addRequestHeader("Accept", mediaType);
-        }
-        final String token = Gh4Application.get().getAuthToken();
-        if (addAuthHeader && token != null) {
-            request.addRequestHeader("Authorization", "Token " + token);
-        }
-        if (mimeType != null) {
-            request.setMimeType(mimeType);
-        }
-        if (wifiOnly) {
-            request.setAllowedOverMetered(false);
-        }
-
-        dm.enqueue(request);
-    }
-
-    public static void enqueueDownloadWithPermissionCheck(final BaseActivity activity,
-            final Download download) {
-        enqueueDownloadWithPermissionCheck(activity, download.htmlUrl(), download.contentType(),
-                download.name(), download.description());
-    }
-
-    public static void enqueueDownloadWithPermissionCheck(final BaseActivity activity,
-            final ReleaseAsset asset) {
-        final ActivityCompat.OnRequestPermissionsResultCallback cb =
-                (requestCode, permissions, grantResults) -> {
-                    if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                        enqueueDownload(activity, asset);
-                    }
-                };
-        activity.requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, cb,
-                R.string.download_permission_rationale);
-    }
-
-    public static void enqueueDownloadWithPermissionCheck(final BaseActivity activity,
-            final String url, final String mimeType, final String fileName, final String description) {
-        final ActivityCompat.OnRequestPermissionsResultCallback cb =
-                (requestCode, permissions, grantResults) -> {
-                    if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                        enqueueDownload(activity, url, fileName, description, mimeType, null, false);
-                    }
-                };
-        activity.requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, cb,
-                R.string.download_permission_rationale);
-    }
-
-    private static void enqueueDownload(final Context context, final ReleaseAsset asset) {
-        // Ugly workaround for #972 (see #976 for analysis), suggested by GH support:
-        // "First, you make an API call to the endpoint for fetching an asset and you pass in the
-        //  token via the Authorization header. You make this call using an HTTP library (not via
-        //  the Android Download Manager) and you disable automatic following of redirects when you
-        //  make that call (in case that's enabled by default). The result of that call will be a
-        //  redirect response with a Location header.
-        //  Second, you use the Android Download Manager to download the asset from the URL that's
-        //  provided in the Location header from the response of the first step. You would not
-        //  provide an Authorization header here since the required authorization is already a
-        //  part of the URL."
-        final OkHttpClient client = ServiceFactory.getHttpClientBuilder()
-                .followRedirects(false)
-                .build();
-        final Request.Builder requestBuilder = new Request.Builder()
-                .url(asset.url())
-                .header("Accept", "application/octet-stream");
-        final String token = Gh4Application.get().getAuthToken();
-        if (token != null) {
-            requestBuilder.addHeader("Authorization", "Token " + token);
-        }
-
-        final Handler handler = new Handler(Looper.getMainLooper());
-
-        client.newCall(requestBuilder.build()).enqueue(new Callback() {
-            private void completeDownload(final String url) {
-                handler.post(() -> {
-                    enqueueDownload(context, url, asset.name(), asset.label(), asset.contentType(),
-                            "application/octet-stream", false);
-                });
-            }
-            @Override
-            public void onFailure(Call call, IOException e) {
-                completeDownload(asset.url());
-            }
-
-            @Override
-            public void onResponse(Call call, Response response) {
-                completeDownload(response.isRedirect()
-                        ? response.header("Location")
-                        : call.request().url().toString());
-            }
-        });
-    }
-
-    private static void enqueueDownload(final Context context, String url, final String fileName,
-            final String description, final String mimeType,
-            final String mediaType, final boolean addAuthHeader) {
-        if (url == null) {
-            return;
-        }
-
-        final Uri uri = Uri.parse(url);
-        if (!downloadNeedsWarning(context)) {
-            enqueueDownload(context, uri, fileName, description, mimeType, mediaType, false, addAuthHeader);
-            return;
-        }
-
-        DialogInterface.OnClickListener buttonListener = (dialog, which) -> {
-            boolean wifiOnly = which == DialogInterface.BUTTON_NEUTRAL;
-            enqueueDownload(context, uri, fileName, description, mimeType, mediaType, wifiOnly, addAuthHeader);
-        };
-
-        new AlertDialog.Builder(context)
-                .setTitle(R.string.download_mobile_warning_title)
-                .setMessage(R.string.download_mobile_warning_message)
-                .setPositiveButton(R.string.download_now_button, buttonListener)
-                .setNeutralButton(R.string.download_wifi_button, buttonListener)
-                .setNegativeButton(R.string.cancel, null)
-                .show();
-    }
-
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public static boolean downloadNeedsWarning(Context context) {
-        ConnectivityManager cm =
-                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        return cm.isActiveNetworkMetered();
     }
 
     public static abstract class EmptinessWatchingTextWatcher implements TextWatcher {


### PR DESCRIPTION
This PR adds a required permission to the manifest so that downloaded APKs can be installed directly by tapping on the download notification on Android 6+.

I've also extracted download-related methods that were in `UiUtils` in a separate `DownloadUtils` class (I felt they were out of place while looking at the code) ~~and renamed the receiver responsibile for intercepting clicks on pending download notifications~~.

Fixes #1067