### PR TITLE
Fix right drawer becoming interactable in wrong activities after fast scrolling

### DIFF
--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -553,6 +553,10 @@ public abstract class BaseActivity extends AppCompatActivity implements
         return false;
     }
 
+    public boolean hasRightDrawer() {
+        return getRightNavigationDrawerMenuResources() != null;
+    }
+
     public void setRightDrawerLockedClosed(boolean locked) {
         mDrawerLayout.setDrawerLockMode(
                 locked ? DrawerLayout.LOCK_MODE_LOCKED_CLOSED : DrawerLayout.LOCK_MODE_UNLOCKED,

--- a/app/src/main/java/com/gh4a/fragment/LoadingListFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/LoadingListFragmentBase.java
@@ -59,20 +59,25 @@ public abstract class LoadingListFragmentBase extends LoadingFragmentBase implem
         mFastScroller = view.findViewById(R.id.fast_scroller);
         mFastScroller.attachRecyclerView(mRecyclerView);
         mFastScroller.setVisibility(View.VISIBLE);
-        mFastScroller.setOnHandleTouchListener((v, event) -> {
-            switch (event.getActionMasked()) {
-                case MotionEvent.ACTION_DOWN:
-                    getBaseActivity().setRightDrawerLockedClosed(true);
-                    break;
 
-                case MotionEvent.ACTION_UP:
-                case MotionEvent.ACTION_CANCEL:
-                    getBaseActivity().setRightDrawerLockedClosed(false);
-                    break;
-            }
+        BaseActivity activity = getBaseActivity();
+        if (activity.hasRightDrawer()) {
+            // Prevent the right drawer from being accidentally opened while fast scrolling
+            mFastScroller.setOnHandleTouchListener((v, event) -> {
+                switch (event.getActionMasked()) {
+                    case MotionEvent.ACTION_DOWN:
+                        activity.setRightDrawerLockedClosed(true);
+                        break;
 
-            return false;
-        });
+                    case MotionEvent.ACTION_UP:
+                    case MotionEvent.ACTION_CANCEL:
+                        activity.setRightDrawerLockedClosed(false);
+                        break;
+                }
+
+                return false;
+            });
+        }
 
         return view;
     }


### PR DESCRIPTION
This PR fixes a small issue I found with the right drawer, which you can see [in this video](https://streamable.com/mouvkw).
Long story short, the workaround used to prevent the right drawer from appearing while fast scrolling unlocked the drawer in activities that have no right drawer too.
The fix was to avoid executing the workaround when the activity is not supposed to have a right drawer.