### PR TITLE
Fixes for link handling regressions

### DIFF
--- a/app/src/main/java/com/gh4a/resolver/CommitCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitCommentLoadTask.java
@@ -2,6 +2,8 @@ package com.gh4a.resolver;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
@@ -33,9 +35,9 @@ public class CommitCommentLoadTask extends UrlLoadTask {
     @VisibleForTesting
     protected final IntentUtils.InitialCommentMarker mMarker;
 
-    public CommitCommentLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            String commitSha, IntentUtils.InitialCommentMarker marker) {
-        super(activity);
+    public CommitCommentLoadTask(FragmentActivity activity, Uri urlToResolve, String repoOwner,
+            String repoName, String commitSha, IntentUtils.InitialCommentMarker marker) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mCommitSha = commitSha;

--- a/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
@@ -24,9 +26,9 @@ public class CommitDiffLoadTask extends DiffLoadTask<GitComment> {
     @VisibleForTesting
     protected final String mSha;
 
-    public CommitDiffLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            DiffHighlightId diffId, String sha) {
-        super(activity, repoOwner, repoName, diffId);
+    public CommitDiffLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, DiffHighlightId diffId, String sha) {
+        super(activity, urlToResolve, repoOwner, repoName, diffId);
         mSha = sha;
     }
 

--- a/app/src/main/java/com/gh4a/resolver/DiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/DiffLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 
@@ -21,9 +23,9 @@ public abstract class DiffLoadTask<C extends PositionalCommentBase> extends UrlL
     protected final String mRepoName;
     protected final DiffHighlightId mDiffId;
 
-    public DiffLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            DiffHighlightId diffId) {
-        super(activity);
+    public DiffLoadTask(FragmentActivity activity, Uri urlToResolve, String repoOwner,
+            String repoName, DiffHighlightId diffId) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mDiffId = diffId;

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -59,6 +59,10 @@ public class LinkParser {
             return parseNewBlogLink(activity, parts);
         }
 
+        if (!"github.com".equals(uri.getHost())) {
+            return null;
+        }
+
         if (parts.isEmpty()) {
             return null;
         }

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -99,10 +99,10 @@ public class LinkParser {
 
         switch (action) {
             case "releases":
-                return parseReleaseLink(activity, parts, user, repo, id);
+                return parseReleaseLink(activity, uri, parts, user, repo, id);
             case "tree":
             case "commits":
-                return parseCommitsLink(activity, parts, user, repo, action);
+                return parseCommitsLink(activity, uri, parts, user, repo, action);
             case "issues":
                 return parseIssuesLink(activity, uri, user, repo, id, initialCommentFallback);
             case "pulls":
@@ -168,13 +168,13 @@ public class LinkParser {
         if (tab != null) {
             switch (tab) {
                 case "repositories":
-                    return new ParseResult(new UserReposLoadTask(activity, user, false));
+                    return new ParseResult(new UserReposLoadTask(activity, uri, user, false));
                 case "stars":
-                    return new ParseResult(new UserReposLoadTask(activity, user, true));
+                    return new ParseResult(new UserReposLoadTask(activity, uri, user, true));
                 case "followers":
-                    return new ParseResult(new UserFollowersLoadTask(activity, user, true));
+                    return new ParseResult(new UserFollowersLoadTask(activity, uri, user, true));
                 case "following":
-                    return new ParseResult(new UserFollowersLoadTask(activity, user, false));
+                    return new ParseResult(new UserFollowersLoadTask(activity, uri, user, false));
                 default:
                     return new ParseResult(UserActivity.makeIntent(activity, user));
             }
@@ -198,17 +198,17 @@ public class LinkParser {
     }
 
     @NonNull
-    private static ParseResult parseReleaseLink(FragmentActivity activity, List<String> parts,
-            String user, String repo, String id) {
+    private static ParseResult parseReleaseLink(FragmentActivity activity, Uri uri,
+            List<String> parts, String user, String repo, String id) {
         if ("tag".equals(id)) {
             final String release = parts.size() >= 5 ? parts.get(4) : null;
             if (release != null) {
-                return new ParseResult(new ReleaseLoadTask(activity, user, repo, release));
+                return new ParseResult(new ReleaseLoadTask(activity, uri, user, repo, release));
             }
         } else if (!TextUtils.isEmpty(id)) {
             try {
                 long numericId = Long.parseLong(id);
-                return new ParseResult(new ReleaseLoadTask(activity, user, repo, numericId));
+                return new ParseResult(new ReleaseLoadTask(activity, uri, user, repo, numericId));
             } catch (NumberFormatException e) {
                 // fall through to release list
             }
@@ -217,8 +217,8 @@ public class LinkParser {
     }
 
     @NonNull
-    private static ParseResult parseCommitsLink(FragmentActivity activity, List<String> parts,
-            String user, String repo, String action) {
+    private static ParseResult parseCommitsLink(FragmentActivity activity, Uri uri,
+            List<String> parts, String user, String repo, String action) {
         int page = "tree".equals(action)
                 ? RepositoryActivity.PAGE_FILES
                 : RepositoryActivity.PAGE_COMMITS;
@@ -230,7 +230,7 @@ public class LinkParser {
             refStart = 5;
         }
         String refAndPath = TextUtils.join("/", parts.subList(refStart, parts.size()));
-        return new ParseResult(new RefPathDisambiguationTask(activity, user, repo, refAndPath,
+        return new ParseResult(new RefPathDisambiguationTask(activity, uri, user, repo, refAndPath,
                 page));
     }
 
@@ -277,7 +277,7 @@ public class LinkParser {
                 extractDiffId(uri.getFragment(), "diff-", true);
 
         if (diffId != null) {
-            return new ParseResult(new PullRequestDiffLoadTask(activity, user, repo, diffId,
+            return new ParseResult(new PullRequestDiffLoadTask(activity, uri, user, repo, diffId,
                     pullRequestNumber));
         }
 
@@ -287,7 +287,7 @@ public class LinkParser {
         IntentUtils.InitialCommentMarker initialDiffComment =
                 generateInitialCommentMarkerWithoutFallback(uri.getFragment(), "r");
         if (initialDiffComment != null) {
-            return new ParseResult(new PullRequestDiffCommentLoadTask(activity, user, repo,
+            return new ParseResult(new PullRequestDiffCommentLoadTask(activity, uri, user, repo,
                     pullRequestNumber, initialDiffComment, page));
         }
 
@@ -295,7 +295,7 @@ public class LinkParser {
                 generateInitialCommentMarkerWithoutFallback(uri.getFragment(),
                         "pullrequestreview-");
         if (reviewMarker != null) {
-            return new ParseResult(new PullRequestReviewLoadTask(activity, user, repo,
+            return new ParseResult(new PullRequestReviewLoadTask(activity, uri, user, repo,
                     pullRequestNumber, reviewMarker));
         }
 
@@ -303,14 +303,14 @@ public class LinkParser {
                 generateInitialCommentMarkerWithoutFallback(uri.getFragment(),
                         "discussion_r");
         if (reviewCommentMarker != null) {
-            return new ParseResult(new PullRequestReviewCommentLoadTask(activity, user, repo,
+            return new ParseResult(new PullRequestReviewCommentLoadTask(activity, uri, user, repo,
                     pullRequestNumber, reviewCommentMarker));
         }
 
         DiffHighlightId reviewDiffHunkId =
                 extractDiffId(uri.getFragment(), "discussion-diff-", false);
         if (reviewDiffHunkId != null) {
-            return new ParseResult(new PullRequestReviewDiffLoadTask(activity, user, repo,
+            return new ParseResult(new PullRequestReviewDiffLoadTask(activity, uri, user, repo,
                     reviewDiffHunkId, pullRequestNumber));
         }
 
@@ -343,13 +343,13 @@ public class LinkParser {
         DiffHighlightId diffId =
                 extractDiffId(uri.getFragment(), "diff-", true);
         if (diffId != null) {
-            return new ParseResult(new CommitDiffLoadTask(activity, user, repo, diffId, id));
+            return new ParseResult(new CommitDiffLoadTask(activity, uri, user, repo, diffId, id));
         }
 
         IntentUtils.InitialCommentMarker initialComment = generateInitialCommentMarker(
                 uri.getFragment(), "commitcomment-", initialCommentFallback);
         if (initialComment != null) {
-            return new ParseResult(new CommitCommentLoadTask(activity, user, repo, id, initialComment));
+            return new ParseResult(new CommitCommentLoadTask(activity, uri, user, repo, id, initialComment));
         }
         return new ParseResult(CommitActivity.makeIntent(activity, user, repo, id, null));
     }
@@ -361,7 +361,7 @@ public class LinkParser {
             return null;
         }
         String refAndPath = TextUtils.join("/", parts.subList(3, parts.size()));
-        return new ParseResult(new RefPathDisambiguationTask(activity, user, repo, refAndPath,
+        return new ParseResult(new RefPathDisambiguationTask(activity, uri, user, repo, refAndPath,
                 uri.getFragment()));
     }
 

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffCommentLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 import androidx.core.util.Pair;
@@ -35,10 +37,10 @@ public class PullRequestDiffCommentLoadTask extends UrlLoadTask {
     @VisibleForTesting
     protected final int mPage;
 
-    public PullRequestDiffCommentLoadTask(FragmentActivity activity, String repoOwner,
-            String repoName, int pullRequestNumber, IntentUtils.InitialCommentMarker marker,
-            int page) {
-        super(activity);
+    public PullRequestDiffCommentLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, int pullRequestNumber,
+            IntentUtils.InitialCommentMarker marker, int page) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mPullRequestNumber = pullRequestNumber;

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
@@ -23,9 +25,9 @@ public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
     @VisibleForTesting
     protected final int mPullRequestNumber;
 
-    public PullRequestDiffLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            DiffHighlightId diffId, int pullRequestNumber) {
-        super(activity, repoOwner, repoName, diffId);
+    public PullRequestDiffLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, DiffHighlightId diffId, int pullRequestNumber) {
+        super(activity, urlToResolve, repoOwner, repoName, diffId);
         mPullRequestNumber = pullRequestNumber;
     }
 

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewCommentLoadTask.java
@@ -2,6 +2,8 @@ package com.gh4a.resolver;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
@@ -32,9 +34,9 @@ public class PullRequestReviewCommentLoadTask extends UrlLoadTask {
     @VisibleForTesting
     protected final IntentUtils.InitialCommentMarker mMarker;
 
-    public PullRequestReviewCommentLoadTask(FragmentActivity activity, String repoOwner,
-            String repoName, int pullRequestNumber, IntentUtils.InitialCommentMarker marker) {
-        super(activity);
+    public PullRequestReviewCommentLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, int pullRequestNumber, IntentUtils.InitialCommentMarker marker) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mPullRequestNumber = pullRequestNumber;

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewDiffLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
@@ -9,7 +11,6 @@ import com.gh4a.activities.ReviewActivity;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.Optional;
-import com.gh4a.utils.RxUtils;
 import com.meisolsson.githubsdk.service.pull_request.PullRequestReviewCommentService;
 import com.meisolsson.githubsdk.service.pull_request.PullRequestReviewService;
 
@@ -25,9 +26,9 @@ public class PullRequestReviewDiffLoadTask extends UrlLoadTask {
     @VisibleForTesting
     protected final int mPullRequestNumber;
 
-    public PullRequestReviewDiffLoadTask(FragmentActivity activity, String repoOwner,
-            String repoName, DiffHighlightId diffId, int pullRequestNumber) {
-        super(activity);
+    public PullRequestReviewDiffLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, DiffHighlightId diffId, int pullRequestNumber) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mDiffId = diffId;

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
@@ -23,9 +25,9 @@ public class PullRequestReviewLoadTask extends UrlLoadTask {
     @VisibleForTesting
     protected final IntentUtils.InitialCommentMarker mMarker;
 
-    public PullRequestReviewLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            int pullRequestNumber, IntentUtils.InitialCommentMarker marker) {
-        super(activity);
+    public PullRequestReviewLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, int pullRequestNumber, IntentUtils.InitialCommentMarker marker) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mPullRequestNumber = pullRequestNumber;

--- a/app/src/main/java/com/gh4a/resolver/RefPathDisambiguationTask.java
+++ b/app/src/main/java/com/gh4a/resolver/RefPathDisambiguationTask.java
@@ -3,6 +3,8 @@ package com.gh4a.resolver;
 import android.content.Intent;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
+
+import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Pair;
 
@@ -37,9 +39,9 @@ public class RefPathDisambiguationTask extends UrlLoadTask {
     @VisibleForTesting
     protected final boolean mGoToFileViewer;
 
-    public RefPathDisambiguationTask(FragmentActivity activity, String repoOwner,
-            String repoName, String refAndPath, int initialPage) {
-        super(activity);
+    public RefPathDisambiguationTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, String refAndPath, int initialPage) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mRefAndPath = refAndPath;
@@ -48,9 +50,9 @@ public class RefPathDisambiguationTask extends UrlLoadTask {
         mGoToFileViewer = false;
     }
 
-    public RefPathDisambiguationTask(FragmentActivity activity, String repoOwner,
-            String repoName, String refAndPath, String fragment) {
-        super(activity);
+    public RefPathDisambiguationTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, String refAndPath, String fragment) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mRefAndPath = refAndPath;

--- a/app/src/main/java/com/gh4a/resolver/ReleaseLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/ReleaseLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
@@ -27,17 +29,18 @@ public class ReleaseLoadTask extends UrlLoadTask {
     @VisibleForTesting
     protected final long mId;
 
-    public ReleaseLoadTask(FragmentActivity activity, String repoOwner, String repoName,
-            String tagName) {
-        super(activity);
+    public ReleaseLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, String tagName) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mTagName = tagName;
         mId = -1;
     }
 
-    public ReleaseLoadTask(FragmentActivity activity, String repoOwner, String repoName, long id) {
-        super(activity);
+    public ReleaseLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String repoOwner, String repoName, long id) {
+        super(activity, urlToResolve);
         mRepoOwner = repoOwner;
         mRepoName = repoName;
         mId = id;

--- a/app/src/main/java/com/gh4a/resolver/UrlLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/UrlLoadTask.java
@@ -2,6 +2,7 @@ package com.gh4a.resolver;
 
 import android.app.Dialog;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
@@ -20,12 +21,14 @@ import io.reactivex.Single;
 public abstract class UrlLoadTask extends AsyncTask<Void, Void, Optional<Intent>> {
     protected final FragmentActivity mActivity;
     private ProgressDialogFragment mProgressDialog;
+    private final Uri mUrlToResolve;
     private int mIntentFlags;
-    private Runnable completionCallback;
+    private Runnable mCompletionCallback;
 
-    public UrlLoadTask(FragmentActivity activity) {
+    public UrlLoadTask(FragmentActivity activity, Uri urlToResolve) {
         super();
         mActivity = activity;
+        mUrlToResolve = urlToResolve;
     }
 
     public void setIntentFlags(int flags) {
@@ -36,7 +39,7 @@ public abstract class UrlLoadTask extends AsyncTask<Void, Void, Optional<Intent>
      * Must be called BEFORE executing the task, otherwise the callback might not get executed.
      */
     public void setCompletionCallback(Runnable callback) {
-        completionCallback = callback;
+        mCompletionCallback = callback;
     }
 
     @Override
@@ -65,15 +68,15 @@ public abstract class UrlLoadTask extends AsyncTask<Void, Void, Optional<Intent>
         if (result.isPresent()) {
             mActivity.startActivity(result.get().setFlags(mIntentFlags));
         } else {
-            IntentUtils.launchBrowser(mActivity, mActivity.getIntent().getData(), mIntentFlags);
+            IntentUtils.launchBrowser(mActivity, mUrlToResolve, mIntentFlags);
         }
 
         if (mProgressDialog != null && mProgressDialog.isAdded()) {
             mProgressDialog.dismissAllowingStateLoss();
         }
 
-        if (completionCallback != null) {
-            completionCallback.run();
+        if (mCompletionCallback != null) {
+            mCompletionCallback.run();
         }
     }
 

--- a/app/src/main/java/com/gh4a/resolver/UserFollowersLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/UserFollowersLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
@@ -13,9 +15,9 @@ public class UserFollowersLoadTask extends UserLoadTask {
     @VisibleForTesting
     protected final boolean mShowFollowers;
 
-    public UserFollowersLoadTask(FragmentActivity activity, String userLogin,
-            boolean showFollowers) {
-        super(activity, userLogin);
+    public UserFollowersLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String userLogin, boolean showFollowers) {
+        super(activity, urlToResolve, userLogin);
         mShowFollowers = showFollowers;
     }
 

--- a/app/src/main/java/com/gh4a/resolver/UserLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/UserLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
@@ -16,8 +18,8 @@ public abstract class UserLoadTask extends UrlLoadTask {
     @VisibleForTesting
     protected final String mUserLogin;
 
-    public UserLoadTask(FragmentActivity activity, String userLogin) {
-        super(activity);
+    public UserLoadTask(FragmentActivity activity, Uri urlToResolve, String userLogin) {
+        super(activity, urlToResolve);
         this.mUserLogin = userLogin;
     }
 

--- a/app/src/main/java/com/gh4a/resolver/UserReposLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/UserReposLoadTask.java
@@ -1,6 +1,8 @@
 package com.gh4a.resolver;
 
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
@@ -13,8 +15,9 @@ public class UserReposLoadTask extends UserLoadTask {
     @VisibleForTesting
     protected final boolean mShowStars;
 
-    public UserReposLoadTask(FragmentActivity activity, String userLogin, boolean showStars) {
-        super(activity, userLogin);
+    public UserReposLoadTask(FragmentActivity activity, Uri urlToResolve,
+            String userLogin, boolean showStars) {
+        super(activity, urlToResolve, userLogin);
         mShowStars = showStars;
     }
 

--- a/app/src/main/java/com/gh4a/widget/LinkSpan.java
+++ b/app/src/main/java/com/gh4a/widget/LinkSpan.java
@@ -39,6 +39,11 @@ public class LinkSpan extends ClickableSpan {
 
     private void openWebPage(Uri clickedUri, FragmentActivity activity) {
         String hostname = clickedUri.getHost();
+        if (hostname == null) {
+            // The user clicked on a relative or partial URL, there's nothing we can do
+            return;
+        }
+
         if (hostname.endsWith("github.com") || hostname.endsWith("githubusercontent.com")) {
             IntentUtils.openInCustomTabOrBrowser(activity, clickedUri);
         } else {

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -740,11 +740,6 @@ public class LinkParserTest {
     }
 
     @Test
-    public void compareLink__redirectsToCompareView() {
-
-    }
-
-    @Test
     public void compareLink_withoutRefs__opensBrowser() {
         LinkParser.ParseResult result =
                 (parseLink("https://github.com/slapperwan/gh4a/compare/v4.2.0...v4.2.1"));
@@ -766,6 +761,11 @@ public class LinkParserTest {
     @Test
     public void unknownRepositoryLink__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/unknown"));
+    }
+
+    @Test
+    public void nonGitHubDotComLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://user-images.githubusercontent.com/30041551/an_image.png"));
     }
 
     private LinkParser.ParseResult parseLink(String uriString) {

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -2,9 +2,7 @@ package com.gh4a.resolver;
 
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.fragment.app.FragmentActivity;
 
-import com.gh4a.BuildConfig;
 import com.gh4a.activities.BlogListActivity;
 import com.gh4a.activities.CommitActivity;
 import com.gh4a.activities.CompareActivity;
@@ -26,18 +24,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import androidx.fragment.app.FragmentActivity;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
-@SuppressWarnings("ConstantConditions")
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class)
 public class LinkParserTest {
     private FragmentActivity mActivity;
 
@@ -61,7 +58,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void linkToGist_withUserInPath__opensGistActivity() throws Exception {
+    public void linkToGist_withUserInPath__opensGistActivity() {
         LinkParser.ParseResult result = parseLink("https://gist.github.com/user/gistId");
         assertRedirectsTo(result, GistActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -87,24 +84,24 @@ public class LinkParserTest {
     }
 
     @Test
-    public void exploreLink__opensTrendingActivity() throws Exception {
+    public void exploreLink__opensTrendingActivity() {
         assertRedirectsTo(parseLink("https://github.com/explore"), TrendingActivity.class);
     }
 
     @Test
-    public void blogLink__opensBlogListActivity() throws Exception {
+    public void blogLink__opensBlogListActivity() {
         assertRedirectsTo(parseLink("https://github.com/blog"), BlogListActivity.class);
         assertRedirectsTo(parseLink("https://blog.github.com"), BlogListActivity.class);
     }
 
     @Test
-    public void blogLink_withBlogInPath__opensBrowser() throws Exception {
+    public void blogLink_withBlogInPath__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/blog/blog-title"));
         assertRedirectsToBrowser(parseLink("https://blog.github.com/blog-title"));
     }
 
     @Test
-    public void organizationLink__opensUserActivity() throws Exception {
+    public void organizationLink__opensUserActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/orgs/android");
         assertRedirectsTo(result, UserActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -113,13 +110,12 @@ public class LinkParserTest {
     }
 
     @Test
-    public void organizationLink_withoutName__opensBrowser() throws Exception {
+    public void organizationLink_withoutName__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/orgs"));
     }
 
     @Test
-    public void organisationLink_leadingToMembers__opensOrganizationMemberListActivity()
-            throws Exception {
+    public void organisationLink_leadingToMembers__opensOrganizationMemberListActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/orgs/android/people");
         assertRedirectsTo(result, OrganizationMemberListActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -128,7 +124,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void userLink__opensUserActivity() throws Exception {
+    public void userLink__opensUserActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan");
         assertRedirectsTo(result, UserActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -137,7 +133,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void userLink_withRepositoriesTab__loadsUserRepos() throws Exception {
+    public void userLink_withRepositoriesTab__loadsUserRepos() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=repositories");
         UserReposLoadTask loadTask = assertThatLoadTaskIs(result.loadTask, UserReposLoadTask.class);
         assertThat("Loading starred repos is set to true", loadTask.mShowStars, is(false));
@@ -145,7 +141,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void userLink_withStarsTab__loadsUserStarredRepos() throws Exception {
+    public void userLink_withStarsTab__loadsUserStarredRepos() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=stars");
         UserReposLoadTask loadTask = assertThatLoadTaskIs(result.loadTask, UserReposLoadTask.class);
         assertThat("Loading starred repos is set to false", loadTask.mShowStars, is(true));
@@ -153,7 +149,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void userLink_withFollowersTab__loadsUserFollowers() throws Exception {
+    public void userLink_withFollowersTab__loadsUserFollowers() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=followers");
         UserFollowersLoadTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, UserFollowersLoadTask.class);
@@ -162,7 +158,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void userLink_withFollowingTab__loadsUserFollows() throws Exception {
+    public void userLink_withFollowingTab__loadsUserFollows() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=following");
         UserFollowersLoadTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, UserFollowersLoadTask.class);
@@ -171,7 +167,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void userLink_withUnknownTab__opensUserActivity() throws Exception {
+    public void userLink_withUnknownTab__opensUserActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan?tab=unknown");
         assertRedirectsTo(result, UserActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -180,7 +176,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void repositoryLink__opensRepositoryActivity() throws Exception {
+    public void repositoryLink__opensRepositoryActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a");
         assertRedirectsTo(result, RepositoryActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -194,7 +190,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void releasesLink__opensReleaseListActivity() throws Exception {
+    public void releasesLink__opensReleaseListActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/releases");
         assertRedirectsTo(result, ReleaseListActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -204,7 +200,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void releaseLink_withoutTagId__opensReleaseListActivity() throws Exception {
+    public void releaseLink_withoutTagId__opensReleaseListActivity() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/releases/tag");
         assertRedirectsTo(result, ReleaseListActivity.class);
@@ -215,7 +211,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void releaseLink_withTagId__loadsRelease() throws Exception {
+    public void releaseLink_withTagId__loadsRelease() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/releases/tag/tagName");
         ReleaseLoadTask loadTask = assertThatLoadTaskIs(result.loadTask, ReleaseLoadTask.class);
@@ -225,7 +221,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void issuesLink__opensIssueListActivity() throws Exception {
+    public void issuesLink__opensIssueListActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/issues");
         assertRedirectsTo(result, IssueListActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -236,7 +232,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void newIssueLink__opensIssueEditActivity() throws Exception {
+    public void newIssueLink__opensIssueEditActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/issues/new");
         assertRedirectsTo(result, IssueEditActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -247,7 +243,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void issueLink__opensIssueActivity() throws Exception {
+    public void issueLink__opensIssueActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/issues/42");
         assertRedirectsTo(result, IssueActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -259,14 +255,14 @@ public class LinkParserTest {
     }
 
     @Test
-    public void issueLink_withIncorrectNumber__opensBrowser() throws Exception {
+    public void issueLink_withIncorrectNumber__opensBrowser() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/issues/34no");
         assertRedirectsToBrowser(result);
     }
 
     @Test
     public void issueLink_withCommentMarker__opensIssueActivity_andHasCommentMarker()
-            throws Exception {
+            {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/issues/42#issuecomment-1234");
         assertRedirectsTo(result, IssueActivity.class);
@@ -281,7 +277,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void issueLink_withIncorrectCommentMarker_opensIssueActivity() throws Exception {
+    public void issueLink_withIncorrectCommentMarker_opensIssueActivity() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/issues/42#issuecomment-A3");
         assertRedirectsTo(result, IssueActivity.class);
@@ -294,7 +290,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestsLink__opensIssueListActivity() throws Exception {
+    public void pullRequestsLink__opensIssueListActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/pulls");
         assertRedirectsTo(result, IssueListActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -306,7 +302,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void wikiLink__opensWikiListActivity() throws Exception {
+    public void wikiLink__opensWikiListActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/wiki");
         assertRedirectsTo(result, WikiListActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -317,19 +313,19 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withoutId__opensBrowser() throws Exception {
+    public void pullRequestLink_withoutId__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull"));
     }
 
     @Test
-    public void pullRequestLink_withInvalidId__opensBrowser() throws Exception {
+    public void pullRequestLink_withInvalidId__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull/-1"));
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull/fwbi"));
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull/0"));
     }
 
     @Test
-    public void pullRequestLink__opensPullRequestActivity() throws Exception {
+    public void pullRequestLink__opensPullRequestActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/pull/12");
         assertRedirectsTo(result, PullRequestActivity.class);
         Bundle extras = result.intent.getExtras();
@@ -343,8 +339,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withCommentMarker__opensPullRequestActivity_andHasCommentMarker()
-            throws Exception {
+    public void pullRequestLink_withCommentMarker__opensPullRequestActivity_andHasCommentMarker() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/14#issuecomment-7546");
         assertRedirectsTo(result, PullRequestActivity.class);
@@ -360,7 +355,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withCommitsPage__opensPullRequestCommits() throws Exception {
+    public void pullRequestLink_withCommitsPage__opensPullRequestCommits() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/23/commits");
         assertRedirectsTo(result, PullRequestActivity.class);
@@ -376,7 +371,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withFilesPage__opensPullRequestFiles() throws Exception {
+    public void pullRequestLink_withFilesPage__opensPullRequestFiles() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/23/files");
         assertRedirectsTo(result, PullRequestActivity.class);
@@ -392,7 +387,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withUnknownPage__opensPullRequest() throws Exception {
+    public void pullRequestLink_withUnknownPage__opensPullRequest() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/23/unknown");
         assertRedirectsTo(result, PullRequestActivity.class);
@@ -407,7 +402,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withDiffMarker__loadsDiff() throws Exception {
+    public void pullRequestLink_withDiffMarker__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
                         "#diff-38f43208e0c158ca7b78e175b8846bc6");
@@ -425,7 +420,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withDiffMarker_andLeftNumber__loadsDiff() throws Exception {
+    public void pullRequestLink_withDiffMarker_andLeftNumber__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
                         "#diff-38f43208e0c158ca7b78e175b8846bc6L24");
@@ -443,7 +438,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withDiffMarker_andLineRange__loadsDiff() throws Exception {
+    public void pullRequestLink_withDiffMarker_andLineRange__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
                         "#diff-38f43208e0c158ca7b78e175b8846bc6L24-L26");
@@ -479,7 +474,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withDiffMarker_andRightNumber__loadsDiff() throws Exception {
+    public void pullRequestLink_withDiffMarker_andRightNumber__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
                         "#diff-38f43208e0c158ca7b78e175b8846bc6R24");
@@ -497,7 +492,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withDiffMarker_andIncorrectHash__loadsDiff() throws Exception {
+    public void pullRequestLink_withDiffMarker_andIncorrectHash__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
                         "#diff-38f43208e0c158ca7b78e1");
@@ -514,7 +509,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestReviewLink__loadsReview() throws Exception {
+    public void pullRequestReviewLink__loadsReview() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665#pullrequestreview-59822171");
         PullRequestReviewLoadTask loadTask =
@@ -527,7 +522,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestReviewCommentLink__loadsReviewComment() throws Exception {
+    public void pullRequestReviewCommentLink__loadsReviewComment() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665#discussion_r136306029");
         PullRequestReviewCommentLoadTask loadTask =
@@ -540,7 +535,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestReviewDiffLink__loadsReviewDiff() throws Exception {
+    public void pullRequestReviewDiffLink__loadsReviewDiff() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/pull/665" +
                 "#discussion-diff-136304421R590");
         PullRequestReviewDiffLoadTask loadTask =
@@ -556,7 +551,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestDiffCommentLink__loadsReviewDiff() throws Exception {
+    public void pullRequestDiffCommentLink__loadsReviewDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files#r136306029");
         PullRequestDiffCommentLoadTask loadTask =
@@ -570,7 +565,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void commitLink__opensCommitActivity() throws Exception {
+    public void commitLink__opensCommitActivity() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/commit/commitSha");
         assertRedirectsTo(result, CommitActivity.class);
@@ -585,12 +580,12 @@ public class LinkParserTest {
     }
 
     @Test
-    public void commitLink_withoutCommitSha__opensBrowser() throws Exception {
+    public void commitLink_withoutCommitSha__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/commit"));
     }
 
     @Test
-    public void commitLink_withDiffMarker__loadsCommitDiff() throws Exception {
+    public void commitLink_withDiffMarker__loadsCommitDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/commit/" +
                         "57a054f85ade77ebb80eecd671aace770b312bf5" +
@@ -611,7 +606,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void commitLink_withCommentMarker__opensCommitActivity() throws Exception {
+    public void commitLink_withCommentMarker__opensCommitActivity() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/commit/commitSha#commitcomment-12");
         CommitCommentLoadTask loadTask =
@@ -625,13 +620,13 @@ public class LinkParserTest {
     }
 
     @Test
-    public void commitsLink__handlesRefAndPath_andRedirectsToCommitsPage() throws Exception {
+    public void commitsLink__handlesRefAndPath_andRedirectsToCommitsPage() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/commits");
         RefPathDisambiguationTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
         assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
         assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
-        assertThat("Ref and path is not empty", loadTask.mRefAndPath, isEmptyString());
+        assertThat("Ref and path is not empty", loadTask.mRefAndPath, is(equalTo("")));
         assertThat("Page does not lead to commits", loadTask.mInitialPage,
                 is(RepositoryActivity.PAGE_COMMITS));
         assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
@@ -639,8 +634,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void commitsLink_withBranch__handlesRefAndPath_andRedirectsToCommitsPage()
-            throws Exception {
+    public void commitsLink_withBranch__handlesRefAndPath_andRedirectsToCommitsPage() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/commits/master");
         RefPathDisambiguationTask loadTask =
@@ -655,8 +649,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void commitsLink_withRefsHeads__handlesRefAndPath_andRedirectsToCommitsPage()
-            throws Exception {
+    public void commitsLink_withRefsHeads__handlesRefAndPath_andRedirectsToCommitsPage() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/commits/refs/heads/master");
         RefPathDisambiguationTask loadTask =
@@ -671,13 +664,13 @@ public class LinkParserTest {
     }
 
     @Test
-    public void treeLink__handlesRefAndPath_andRedirectsToFilesPage() throws Exception {
+    public void treeLink__handlesRefAndPath_andRedirectsToFilesPage() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/tree");
         RefPathDisambiguationTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
         assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
         assertThat("Repo name is incorrect", loadTask.mRepoName, is("gh4a"));
-        assertThat("Ref and path is not empty", loadTask.mRefAndPath, isEmptyString());
+        assertThat("Ref and path is not empty", loadTask.mRefAndPath, is(equalTo("")));
         assertThat("Page does not lead to files", loadTask.mInitialPage,
                 is(RepositoryActivity.PAGE_FILES));
         assertThat("Fragment is set", loadTask.mFragment, is(nullValue()));
@@ -685,7 +678,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void treeLink_withBranch__handlesRefAndPath_andRedirectsToFilesPage() throws Exception {
+    public void treeLink_withBranch__handlesRefAndPath_andRedirectsToFilesPage() {
         LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/tree/master");
         RefPathDisambiguationTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, RefPathDisambiguationTask.class);
@@ -699,8 +692,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void treeLink_withRefsHeads__handlesRefAndPath_andRedirectsToFilesPage()
-            throws Exception {
+    public void treeLink_withRefsHeads__handlesRefAndPath_andRedirectsToFilesPage() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/tree/refs/heads/master");
         RefPathDisambiguationTask loadTask =
@@ -715,7 +707,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void blobLink__handlesRefAndPath_andRedirectsToFileViewer() throws Exception {
+    public void blobLink__handlesRefAndPath_andRedirectsToFileViewer() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/blob/master/README.md");
         RefPathDisambiguationTask loadTask =
@@ -729,8 +721,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void blobLink_withLineMarker__handlesRefAndPath_andRedirectsToFileViewer()
-            throws Exception {
+    public void blobLink_withLineMarker__handlesRefAndPath_andRedirectsToFileViewer() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/blob/master/build.gradle#L10");
         RefPathDisambiguationTask loadTask =
@@ -744,17 +735,17 @@ public class LinkParserTest {
     }
 
     @Test
-    public void blobLink_withoutBranchAndPath__opensBrowser() throws Exception {
+    public void blobLink_withoutBranchAndPath__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/blob"));
     }
 
     @Test
-    public void compareLink__redirectsToCompareView() throws Exception {
+    public void compareLink__redirectsToCompareView() {
 
     }
 
     @Test
-    public void compareLink_withoutRefs__opensBrowser() throws Exception {
+    public void compareLink_withoutRefs__opensBrowser() {
         LinkParser.ParseResult result =
                 (parseLink("https://github.com/slapperwan/gh4a/compare/v4.2.0...v4.2.1"));
         assertRedirectsTo(result, CompareActivity.class);
@@ -768,12 +759,12 @@ public class LinkParserTest {
     }
 
     @Test
-    public void compareLink_withIncompleteRefs__opensBrowser() throws Exception {
+    public void compareLink_withIncompleteRefs__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/compare/v4.2.0..."));
     }
 
     @Test
-    public void unknownRepositoryLink__opensBrowser() throws Exception {
+    public void unknownRepositoryLink__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/unknown"));
     }
 


### PR DESCRIPTION
This PR fixes a couple of regressions introduced by #1118:
- many non-GitHub links erroneously resolved to OctoDroid activities, because the LinkParser didn't take into account the possibility of receiving non-GitHub URLs
- tapping on links to relative URLs (such as anchor links in Readme) made the app crash due to an NPE
- when an URL couldn't be resolved to an OctoDroid activity, it wasn't opened in the browser as it should have been

Also, tests didn't compile until I fixed them. Ideally there should be a pipeline that builds the app and runs them, so that at least they have a chance to run from time to time :)