### PR TITLE
Make line numbers monospaced in review inline diffs

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/timeline/DiffViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/DiffViewHolder.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.Typeface;
 import android.net.Uri;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.widget.PopupMenu;
@@ -14,6 +15,7 @@ import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.style.ClickableSpan;
 import android.text.style.LineBackgroundSpan;
+import android.text.style.TypefaceSpan;
 import android.util.TypedValue;
 import android.view.Menu;
 import android.view.View;
@@ -156,7 +158,12 @@ class DiffViewHolder extends TimelineItemAdapter.TimelineItemViewHolder<Timeline
             DiffLineSpan span = new DiffLineSpan(backgroundColor, lineNumberBackgroundColor, mPadding, i == start,
                     i == lines.length - 1, lineNumberLength);
             builder.setSpan(span, spanStart, builder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+            // We want to make only the line numbers monospaced, and the rest of the line normal for compactness reasons
+            builder.setSpan(new TypefaceSpan("normal"),
+                    spanStart + lineNumberLength, builder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
+        mDiffHunkTextView.setTypeface(Typeface.MONOSPACE);
         mDiffHunkTextView.setText(builder);
         mDiffHunkTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX,
                 mInitialDiffTextSize * getDiffSizeMultiplier());

--- a/app/src/main/java/com/gh4a/adapter/timeline/DiffViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/DiffViewHolder.java
@@ -32,7 +32,7 @@ import com.meisolsson.githubsdk.model.ReviewComment;
 class DiffViewHolder extends TimelineItemAdapter.TimelineItemViewHolder<TimelineItem.Diff>
         implements View.OnClickListener {
     private static final float[] DIFF_SIZE_MULTIPLIERS = new float[] {
-            0.667F, 0.833F, 1F, 1.5F, 2F
+            0.8F, 0.9F, 1F, 1.25F, 1.5F
     };
 
     private final int mAddedLineBackgroundColor;

--- a/app/src/main/res/layout/commit_filename.xml
+++ b/app/src/main/res/layout/commit_filename.xml
@@ -31,7 +31,6 @@
         android:layout_alignParentLeft="true"
         android:layout_alignWithParentIfMissing="true"
         android:layout_toLeftOf="@id/comments"
-        android:typeface="monospace"
         tools:text="some/file/in/directories.txt" />
 
     <com.gh4a.widget.StyleableTextView


### PR DESCRIPTION
This small PR changes inline diff hunks in reviews to make line numbers use a monospaced font, so that the start of the line of code is now perfectly aligned, as you can see from the screenshots below.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/141441994-eb8444ae-8f21-44b2-8499-c7ad40f01eee.jpg"/>
</td><td><img src="https://user-images.githubusercontent.com/30041551/141442086-c5c5c181-6f97-43b8-bbc4-3f22634926d8.png" /></td></tr>
</table>

I didn't use monospace for all the code in the diff hunk for compactness reasons: when code is moderately indented (20+ spaces), you would always need to scroll right to be able to read the text.

While making this change, I've noticed that the diff was originally intended to have a monospace font, but there is a bug in `StyleableTextView` that causes the attribute `android:typeface` to be ignored. I've used `setTypeface` instead since it works as expected, given that I haven't managed to fix the bug.

I've also made some adjustments to the text size multipliers for inline diff hunks, since the "Smallest" option made them unreadable and the "Largest" ridiculously big.
I personally think that the code size option should not affect those inline diffs, since they aren't meant to be zoomed in and out... but I'll let you decide.