### PR TITLE
Fixed keeping stale scroll position when switching between fragments.

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/LoadingListFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/LoadingListFragmentBase.java
@@ -132,5 +132,11 @@ public abstract class LoadingListFragmentBase extends LoadingFragmentBase implem
         mFastScroller.setHandlePressedColor(getHighlightColor());
     }
 
+    protected void resetScroll() {
+        if (mLayoutManager != null) {
+            mLayoutManager.scrollToPositionWithOffset(0, 0);
+        }
+    }
+
     protected abstract int getEmptyTextResId();
 }

--- a/app/src/main/java/com/gh4a/fragment/PagedDataBaseFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PagedDataBaseFragment.java
@@ -117,6 +117,9 @@ public abstract class PagedDataBaseFragment<T> extends LoadingListFragmentBase i
                             if (response.code() == HttpURLConnection.HTTP_NO_CONTENT) {
                                 return Response.success(new ApiHelpers.DummyPage<T>());
                             }
+                            if (page == 1) {
+                                resetScroll();
+                            }
                             return response;
                         })
                         .map(ApiHelpers::throwOnFailure)


### PR DESCRIPTION
Hi.
When a user switches between accounts in the `News Feed`, a scroll position of their screen stays the same.
It's annoying enough when I have to manually move the scroll back to the original position after switching accounts.
So this small PR fixes that behavior.

It can be reproduced not only with multiple accounts/organizations, but also between `News Feed` and `Public Timeline`. 