### PR TITLE
URL resolution improvements

### DIFF
--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -34,9 +34,9 @@ import java.util.List;
 
 public class LinkParser {
     private static final List<String> RESERVED_NAMES = Arrays.asList(
-            "apps", "integrations", "login", "logout", "marketplace", "sessions", "settings",
-            "updates", "support", "contact", "about", "personal", "open-source",
-            "business", "site", "security", "features", "topics", "explore"
+            "about", "apps", "business", "contact", "explore", "features", "integrations", "login",
+            "logout", "marketplace", "open-source", "personal", "security", "sessions", "settings",
+            "site", "support", "updates", "topics"
     );
 
     private LinkParser() {

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import android.text.TextUtils;
 
+import com.gh4a.R;
 import com.gh4a.activities.BlogListActivity;
 import com.gh4a.activities.CommitActivity;
 import com.gh4a.activities.CompareActivity;
@@ -19,9 +20,11 @@ import com.gh4a.activities.PullRequestActivity;
 import com.gh4a.activities.ReleaseListActivity;
 import com.gh4a.activities.RepositoryActivity;
 import com.gh4a.activities.SearchActivity;
+import com.gh4a.activities.TimelineActivity;
 import com.gh4a.activities.TrendingActivity;
 import com.gh4a.activities.UserActivity;
 import com.gh4a.activities.WikiListActivity;
+import com.gh4a.activities.home.HomeActivity;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.StringUtils;
 
@@ -33,7 +36,7 @@ public class LinkParser {
     private static final List<String> RESERVED_NAMES = Arrays.asList(
             "apps", "integrations", "login", "logout", "marketplace", "sessions", "settings",
             "updates", "support", "contact", "about", "personal", "open-source",
-            "business", "site", "security", "features", "topics"
+            "business", "site", "security", "features", "topics", "explore"
     );
 
     private LinkParser() {
@@ -73,8 +76,23 @@ public class LinkParser {
         }
 
         switch (first) {
-            case "explore":
+            case "notifications":
+                return new ParseResult(HomeActivity.makeIntent(activity, R.id.notifications));
+            case "stars":
+                return new ParseResult(HomeActivity.makeIntent(activity, R.id.bookmarks));
+            case "issues":
+                return new ParseResult(HomeActivity.makeIntent(activity, R.id.my_issues));
+            case "pulls":
+                return new ParseResult(HomeActivity.makeIntent(activity, R.id.my_prs));
+            case "gists":
+                return new ParseResult(HomeActivity.makeIntent(activity, R.id.my_gists));
+            case "dashboard":
+                return new ParseResult(HomeActivity.makeIntent(activity, R.id.news_feed));
+            case "repositories":
+            case "trending":
                 return new ParseResult(new Intent(activity, TrendingActivity.class));
+            case "timeline":
+                return new ParseResult(new Intent(activity, TimelineActivity.class));
             case "blog":
                 return parseBlogLink(activity, parts);
             case "orgs":

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -34,9 +34,13 @@ import java.util.List;
 
 public class LinkParser {
     private static final List<String> RESERVED_NAMES = Arrays.asList(
-            "about", "apps", "business", "contact", "explore", "features", "integrations", "login",
-            "logout", "marketplace", "open-source", "personal", "security", "sessions", "settings",
-            "site", "support", "updates", "topics"
+            "about", "account", "advisories", "apps", "business", "careers", "codespaces",
+            "collections", "contact", "customer-stories", "discussions", "enterprise", "events",
+            "explore", "features", "git-guides", "guides", "home", "integrations", "join", "learn",
+            "login", "logout", "maintenance", "marketplace", "mobile", "new", "nonprofit", "open-source",
+            "organizations", "pages", "personal", "plans", "press", "pricing", "readme", "resources",
+            "security", "services", "sessions", "settings", "shop", "site", "site-map", "sponsors",
+            "status", "support", "team", "terms", "topics", "updates"
     );
 
     private LinkParser() {

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -74,15 +74,8 @@ public class LinkParserTest {
     }
 
     @Test
-    public void reservedPaths__openBrowser() {
-        String[] reservedPaths = {
-                "apps", "integrations", "login", "logout", "marketplace", "sessions", "settings",
-                "updates", "support", "contact", "about", "personal", "open-source", "business",
-                "site", "security", "features"
-        };
-        for (String reservedPath : reservedPaths) {
-            assertRedirectsToBrowser(parseLink("https://github.com/" + reservedPath));
-        }
+    public void linkToReservedPath__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/settings"));
     }
 
     @Test

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -14,9 +14,11 @@ import com.gh4a.activities.OrganizationMemberListActivity;
 import com.gh4a.activities.PullRequestActivity;
 import com.gh4a.activities.ReleaseListActivity;
 import com.gh4a.activities.RepositoryActivity;
+import com.gh4a.activities.TimelineActivity;
 import com.gh4a.activities.TrendingActivity;
 import com.gh4a.activities.UserActivity;
 import com.gh4a.activities.WikiListActivity;
+import com.gh4a.activities.home.HomeActivity;
 import com.gh4a.utils.IntentUtils;
 
 import org.junit.Before;
@@ -84,8 +86,66 @@ public class LinkParserTest {
     }
 
     @Test
-    public void exploreLink__opensTrendingActivity() {
-        assertRedirectsTo(parseLink("https://github.com/explore"), TrendingActivity.class);
+    public void timelineLink__opensTimelineActivity() {
+        assertRedirectsTo(parseLink("https://github.com/timeline"), TimelineActivity.class);
+    }
+
+    @Test
+    public void trendingLink__opensTrendingActivity() {
+        assertRedirectsTo(parseLink("https://github.com/trending"), TrendingActivity.class);
+    }
+
+    @Test
+    public void repositoriesLink__opensTrendingActivity() {
+        assertRedirectsTo(parseLink("https://github.com/repositories"), TrendingActivity.class);
+    }
+
+    @Test
+    public void starsLink__opensHomeActivity_onBookmarksAndStarsSection() {
+        LinkParser.ParseResult result = parseLink("https://github.com/stars");
+        assertRedirectsTo(result, HomeActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Redirected to wrong HomeActivity section", extras.getString("initial_page"), is("bookmarks"));
+    }
+
+    @Test
+    public void gistsLink__opensHomeActivity_onGistsSection() {
+        LinkParser.ParseResult result = parseLink("https://github.com/gists");
+        assertRedirectsTo(result, HomeActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Redirected to wrong HomeActivity section", extras.getString("initial_page"), is("gists"));
+    }
+
+    @Test
+    public void notificationsLink__opensHomeActivity_onNotificationsSection() {
+        LinkParser.ParseResult result = parseLink("https://github.com/notifications");
+        assertRedirectsTo(result, HomeActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Redirected to wrong HomeActivity section", extras.getString("initial_page"), is("notifications"));
+    }
+
+    @Test
+    public void issuesLink__opensHomeActivity_onMyIssuesSection() {
+        LinkParser.ParseResult result = parseLink("https://github.com/issues");
+        assertRedirectsTo(result, HomeActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Redirected to wrong HomeActivity section", extras.getString("initial_page"), is("issues"));
+    }
+
+    @Test
+    public void pullsLink__opensHomeActivity_onMyPullRequestsSection() {
+        LinkParser.ParseResult result = parseLink("https://github.com/pulls");
+        assertRedirectsTo(result, HomeActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Redirected to wrong HomeActivity section", extras.getString("initial_page"), is("prs"));
+    }
+
+    @Test
+    public void dashboardLink__opensHomeActivity_onNewsFeedSection() {
+        LinkParser.ParseResult result = parseLink("https://github.com/dashboard");
+        assertRedirectsTo(result, HomeActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Redirected to wrong HomeActivity section", extras.getString("initial_page"), is("newsfeed"));
     }
 
     @Test

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -69,7 +69,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void githubLink__opensMainActivity() {
+    public void githubDotComLink__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com"));
     }
 


### PR DESCRIPTION
This PR adds handling for special GitHub URL segments that the app previously treated mistakenly as GH users (such as /issues, /notifications, /timeline etc.).
The list of GitHub reserved names was also greatly expanded with page names of their website (all added pages have been manually checked).

I've also made a performance tweak to the RefPathDisambiguationTask, so that it doesn't unnecessarily try to resolve the ref to a branch/tag name when the ref is a SHA1. I don't think anyone sane would name a branch like `<full SHA1>/something` :sweat_smile: