### PR TITLE
Avoid pop-in when issue/PR conversation loads fast enough

### DIFF
--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -270,11 +270,6 @@ public abstract class BaseActivity extends AppCompatActivity implements
         mSwipeLayout.setChildScrollDelegate(delegate);
     }
 
-    protected void setEmptyText(CharSequence text) {
-        ensureContent();
-        mEmptyView.setText(text);
-    }
-
     protected void setContentShown(boolean shown) {
         mContentShown = shown;
         updateSwipeToRefreshState();

--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -65,8 +65,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewStub;
-import android.view.animation.Animation;
-import android.view.animation.AnimationUtils;
 import android.widget.TextView;
 
 import com.gh4a.activities.Github4AndroidActivity;
@@ -842,25 +840,9 @@ public abstract class BaseActivity extends AppCompatActivity implements
 
     private void updateViewVisibility(boolean animate) {
         ensureContent();
-        updateViewVisibility(mProgress, animate, !mContentShown);
-        updateViewVisibility(mEmptyView, animate, mContentEmpty && mContentShown);
-        updateViewVisibility(mContentContainer, animate, !mContentEmpty && mContentShown);
-    }
-
-    private void updateViewVisibility(View view, boolean animate, boolean show) {
-        int visibility = show ? View.VISIBLE : View.GONE;
-        if (view.getVisibility() == visibility) {
-            return;
-        }
-
-        if (animate) {
-            Animation anim = AnimationUtils.loadAnimation(view.getContext(),
-                    show ? android.R.anim.fade_in : android.R.anim.fade_out);
-            view.startAnimation(anim);
-        } else {
-            view.clearAnimation();
-        }
-        view.setVisibility(visibility);
+        UiUtils.updateViewVisibility(mProgress, animate, !mContentShown);
+        UiUtils.updateViewVisibility(mEmptyView, animate, mContentEmpty && mContentShown);
+        UiUtils.updateViewVisibility(mContentContainer, animate, !mContentEmpty && mContentShown);
     }
 
     private void ensureContent() {

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -161,9 +161,13 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        // We want to make the user able to read the issue/PR while the rest of the conversation is still loading
         if (mInitialComment == null) {
-            view.findViewById(R.id.content_container).setVisibility(View.VISIBLE);
+            // We want to make the user able to read the issue/PR while the rest of the conversation is still loading,
+            // but at the same time we want to avoid item pop-in when the conversation loads quickly
+            View contentContainer = view.findViewById(R.id.content_container);
+            contentContainer.postDelayed(
+                    () -> UiUtils.updateViewVisibility(contentContainer, isResumed(), true),
+                    800);
         }
 
         BaseActivity activity = getBaseActivity();

--- a/app/src/main/java/com/gh4a/fragment/LoadingFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/LoadingFragmentBase.java
@@ -126,21 +126,8 @@ public abstract class LoadingFragmentBase extends Fragment implements
     private void updateContentVisibility() {
         View out = mContentShown ? mProgress : mContentContainer;
         View in = mContentShown ? mContentContainer : mProgress;
-        if (isResumed()) {
-            // Only animate views if they aren't in target state already, otherwise we'll
-            // show (out) / hide (in) them for a short time
-            if (out.getVisibility() != View.GONE) {
-                out.startAnimation(AnimationUtils.loadAnimation(getActivity(), android.R.anim.fade_out));
-            }
-            if (in.getVisibility() != View.VISIBLE) {
-                in.startAnimation(AnimationUtils.loadAnimation(getActivity(), android.R.anim.fade_in));
-            }
-        } else {
-            in.clearAnimation();
-            out.clearAnimation();
-        }
-        out.setVisibility(View.GONE);
-        in.setVisibility(View.VISIBLE);
+        UiUtils.updateViewVisibility(out, isResumed(), false);
+        UiUtils.updateViewVisibility(in, isResumed(), true);
     }
 
     protected abstract View onCreateContentView(LayoutInflater inflater, ViewGroup parent);

--- a/app/src/main/java/com/gh4a/utils/UiUtils.java
+++ b/app/src/main/java/com/gh4a/utils/UiUtils.java
@@ -34,6 +34,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EdgeEffect;
 import android.widget.EditText;
@@ -90,6 +92,22 @@ public class UiUtils {
             return ContextCompat.getColor(context, R.color.label_fg_dark);
         }
         return ContextCompat.getColor(context, R.color.label_fg_light);
+    }
+
+    public static void updateViewVisibility(View view, boolean animate, boolean show) {
+        int visibility = show ? View.VISIBLE : View.GONE;
+        if (view.getVisibility() == visibility) {
+            return;
+        }
+
+        if (animate) {
+            Animation anim = AnimationUtils.loadAnimation(view.getContext(),
+                    show ? android.R.anim.fade_in : android.R.anim.fade_out);
+            view.startAnimation(anim);
+        } else {
+            view.clearAnimation();
+        }
+        view.setVisibility(visibility);
     }
 
     public static void trySetListOverscrollColor(RecyclerView view, int color) {


### PR DESCRIPTION
Small improvement on top of #1128.
This PR aims to avoid rapid pop-in of items when issue/PR conversations have none to few comments and therefore load very fast.
The issue/PR body will get displayed after 800ms if the entire conversation hasn't been loaded yet. For conversations that load faster than 800ms, the app will behave the same as it did before #1128 (show the content as soon as everything is loaded).