### PR TITLE
Fix a couple of wiki-related bugs

### DIFF
--- a/app/src/main/java/com/gh4a/model/Feed.java
+++ b/app/src/main/java/com/gh4a/model/Feed.java
@@ -16,7 +16,8 @@
 package com.gh4a.model;
 
 import android.net.Uri;
-import androidx.annotation.Nullable;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 import com.gh4a.utils.StringUtils;
 
@@ -28,8 +29,10 @@ import org.simpleframework.xml.core.Commit;
 
 import java.util.Date;
 
+import androidx.annotation.Nullable;
+
 @Root(name = "entry", strict = false)
-public class Feed {
+public class Feed implements Parcelable {
     @Element(name = "id")
     private String id;
 
@@ -157,4 +160,42 @@ public class Feed {
     public Date getUpdated() {
         return updated;
     }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(id);
+        dest.writeString(link);
+        dest.writeString(title);
+        dest.writeString(content);
+        dest.writeString(author);
+        dest.writeString(avatarUrl);
+        dest.writeInt(userId);
+        dest.writeString(preview);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<Feed> CREATOR = new Creator<Feed>() {
+        @Override
+        public Feed createFromParcel(Parcel in) {
+            Feed feed = new Feed();
+            feed.id = in.readString();
+            feed.link = in.readString();
+            feed.title = in.readString();
+            feed.content = in.readString();
+            feed.author = in.readString();
+            feed.avatarUrl = in.readString();
+            feed.userId = in.readInt();
+            feed.preview = in.readString();
+            return feed;
+        }
+
+        @Override
+        public Feed[] newArray(int size) {
+            return new Feed[size];
+        }
+    };
 }

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -130,10 +130,9 @@ public class LinkParser {
             case "pulls":
                 return new ParseResult(IssueListActivity.makeIntent(activity, user, repo, true));
             case "wiki":
-                return new ParseResult(WikiListActivity.makeIntent(activity, user, repo, null));
+                return parseWikiLink(activity, parts, user, repo);
             case "pull":
-                return parsePullRequestLink(activity, uri, parts, user,
-                        repo, id, initialCommentFallback);
+                return parsePullRequestLink(activity, uri, parts, user, repo, id, initialCommentFallback);
             case "commit":
                 return parseCommitLink(activity, uri, user, repo, id, initialCommentFallback);
             case "blob":
@@ -275,6 +274,16 @@ public class LinkParser {
         } catch (NumberFormatException e) {
             return null;
         }
+    }
+
+    @Nullable
+    private static ParseResult parseWikiLink(FragmentActivity activity, List<String> parts, String user, String repo) {
+        // In this case we can't open links to specific wiki pages in a WikiActivity,
+        // since there are no APIs to fetch the content of a single wiki page
+        if (parts.size() > 3) {
+            return null;
+        }
+        return new ParseResult(WikiListActivity.makeIntent(activity, user, repo, null));
     }
 
     @Nullable

--- a/app/src/main/java/com/gh4a/utils/IntentUtils.java
+++ b/app/src/main/java/com/gh4a/utils/IntentUtils.java
@@ -266,6 +266,19 @@ public class IntentUtils {
         return result;
     }
 
+    public static void putCompressedParcelableExtra(Intent intent, String key, Parcelable parcelable, int thresholdBytes) {
+        Parcel parcel = Parcel.obtain();
+        parcel.writeParcelable(parcelable, 0);
+        byte[] compressedData = compressDataIfNeeded(parcel.marshall(), thresholdBytes);
+        parcel.recycle();
+
+        if (compressedData != null) {
+            intent.putExtra(compressedDataKey(key), compressedData);
+        } else {
+            intent.putExtra(key, parcelable);
+        }
+    }
+
     public static void putParcelableToBundleCompressed(Bundle bundle,
             String key, Parcelable parcelable, int thresholdBytes) {
         Parcel parcel = Parcel.obtain();

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -366,6 +366,12 @@ public class LinkParserTest {
     }
 
     @Test
+    public void wikiLink_toSpecificPage__opensBrowser() {
+        LinkParser.ParseResult result = parseLink("https://github.com/slapperwan/gh4a/wiki/Information-hierarchy");
+        assertRedirectsToBrowser(result);
+    }
+
+    @Test
     public void pullRequestLink_withoutId__opensBrowser() {
         assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/pull"));
     }


### PR DESCRIPTION
This PR fixes two bugs related to repository wikis:
- links to specific wiki pages incorrectly resolved to the "Recent Wiki Updates" screen (#1127).
Those links now open the wiki page in a browser, since GH doesn't have an API for fetching a wiki page content in order to display it in a WikiActivity.
- app crashed when opening some very large wiki pages from the "Recent Wiki Updates" screen (e.g. https://github.com/ReactiveX/RxJava/wiki/What's-different-in-3.0) due to a TransactionTooLargeException (page content is passed via intent extras).
To fix this, I've made `Feed` implement `Parcelable` and passed it as a whole to the WikiActivity, compressing it as needed. At first I tried to compress/decompress just the `content` intent extra, but I didn't manage to: Android has no public APIs to construct strings from byte arrays (you'd need to use `StringFactory`, which a hidden SDK API).

Fixes #1127