### PR TITLE
Do not crash the app on Moshi's JsonDataExceptions

### DIFF
--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -33,12 +33,15 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.CallSuper;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.gh4a.activities.IssueEditActivity;
+import com.gh4a.utils.ActivityResultHelpers;
 import com.google.android.material.appbar.AppBarLayout;
 
 import androidx.appcompat.view.ContextThemeWrapper;
@@ -127,6 +130,14 @@ public abstract class BaseActivity extends AppCompatActivity implements
     private final int[] mProgressColors = new int[2];
     private Animator mHeaderTransition;
     private final Handler mHandler = new Handler();
+
+    private final ActivityResultLauncher<Intent> mIssueReportLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            new ActivityResultHelpers.ActivityResultSuccessCallback(() ->
+                    Snackbar.make(mCoordinatorLayout, R.string.issue_reported, Snackbar.LENGTH_LONG)
+                            .show()
+            )
+    );
 
     private RxLoader mRxLoader;
     private final CompositeDisposable mDisposeOnStop = new CompositeDisposable();
@@ -693,7 +704,7 @@ public abstract class BaseActivity extends AppCompatActivity implements
                 getString(R.string.my_username),
                 getString(R.string.my_repo),
                 issueTitle, issueBody);
-        startActivity(newIssueIntent);
+        mIssueReportLauncher.launch(newIssueIntent);
     }
 
     protected void onDrawerOpened(boolean right) {

--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -21,6 +21,7 @@ import android.animation.ArgbEvaluator;
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.assist.AssistContent;
 import android.content.Intent;
@@ -40,8 +41,8 @@ import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.gh4a.activities.IssueActivity;
 import com.gh4a.activities.IssueEditActivity;
-import com.gh4a.utils.ActivityResultHelpers;
 import com.google.android.material.appbar.AppBarLayout;
 
 import androidx.appcompat.view.ContextThemeWrapper;
@@ -81,6 +82,7 @@ import com.gh4a.utils.UiUtils;
 import com.gh4a.widget.SwipeRefreshLayout;
 import com.gh4a.widget.ToggleableAppBarLayoutBehavior;
 import com.meisolsson.githubsdk.model.ClientErrorResponse;
+import com.meisolsson.githubsdk.model.Issue;
 import com.philosophicalhacker.lib.RxLoader;
 import com.squareup.moshi.JsonDataException;
 
@@ -133,10 +135,17 @@ public abstract class BaseActivity extends AppCompatActivity implements
 
     private final ActivityResultLauncher<Intent> mIssueReportLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(),
-            new ActivityResultHelpers.ActivityResultSuccessCallback(() ->
+            result -> {
+                if (result.getResultCode() == Activity.RESULT_OK) {
                     Snackbar.make(mCoordinatorLayout, R.string.issue_reported, Snackbar.LENGTH_LONG)
-                            .show()
-            )
+                            .setAction(R.string.view, v -> {
+                                Issue createdIssue = result.getData().getParcelableExtra("issue");
+                                Intent intent = IssueActivity.makeIntent(this, createdIssue);
+                                startActivity(intent);
+                            })
+                            .show();
+                }
+            }
     );
 
     private RxLoader mRxLoader;

--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -38,6 +38,7 @@ import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.gh4a.activities.IssueEditActivity;
 import com.google.android.material.appbar.AppBarLayout;
 
 import androidx.appcompat.view.ContextThemeWrapper;
@@ -665,6 +666,12 @@ public abstract class BaseActivity extends AppCompatActivity implements
             } else if (e instanceof JsonDataException) {
                 messageView.setText(getString(R.string.load_failure_explanation_parsing));
                 retryButton.setVisibility(View.GONE);
+                View reportIssueButton = error.findViewById(R.id.report_button);
+                reportIssueButton.setVisibility(View.VISIBLE);
+                reportIssueButton.setOnClickListener(v -> {
+                    Intent newIssueIntent = IssueEditActivity.makeCreateIntent(this, getString(R.string.my_username), getString(R.string.my_repo));
+                    startActivity(newIssueIntent);
+                });
             } else {
                 messageView.setText(R.string.load_failure_explanation);
                 retryButton.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -668,10 +668,7 @@ public abstract class BaseActivity extends AppCompatActivity implements
                 retryButton.setVisibility(View.GONE);
                 View reportIssueButton = error.findViewById(R.id.report_button);
                 reportIssueButton.setVisibility(View.VISIBLE);
-                reportIssueButton.setOnClickListener(v -> {
-                    Intent newIssueIntent = IssueEditActivity.makeCreateIntent(this, getString(R.string.my_username), getString(R.string.my_repo));
-                    startActivity(newIssueIntent);
-                });
+                reportIssueButton.setOnClickListener(v -> launchIssueCreationForError(e));
             } else {
                 messageView.setText(R.string.load_failure_explanation);
                 retryButton.setVisibility(View.VISIBLE);
@@ -680,6 +677,23 @@ public abstract class BaseActivity extends AppCompatActivity implements
         } else {
             error.setVisibility(View.GONE);
         }
+    }
+
+    private void launchIssueCreationForError(Throwable e) {
+        String issueTitle = "";
+        String issueBody = new StringBuilder()
+                .append("<!-- Please describe here what you were doing when the error occurred -->\n\n")
+                .append("### Error stack trace\n")
+                .append("```\n")
+                .append(Log.getStackTraceString(e))
+                .append("\n```")
+                .toString();
+        Intent newIssueIntent = IssueEditActivity.makeCreateIntent(
+                this,
+                getString(R.string.my_username),
+                getString(R.string.my_repo),
+                issueTitle, issueBody);
+        startActivity(newIssueIntent);
     }
 
     protected void onDrawerOpened(boolean right) {

--- a/app/src/main/java/com/gh4a/activities/IssueActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueActivity.java
@@ -64,9 +64,15 @@ import java.util.Locale;
 
 public class IssueActivity extends BaseActivity implements
         View.OnClickListener, ConfirmationDialogFragment.Callback {
+    public static Intent makeIntent(Context context, Issue issue) {
+        String[] urlParts = issue.url().split("/");
+        return makeIntent(context, urlParts[4], urlParts[5], issue.number());
+    }
+
     public static Intent makeIntent(Context context, String login, String repoName, int number) {
         return makeIntent(context, login, repoName, number, null);
     }
+
     public static Intent makeIntent(Context context, String login, String repoName,
             int number, IntentUtils.InitialCommentMarker initialComment) {
         return new Intent(context, IssueActivity.class)

--- a/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
@@ -96,14 +96,14 @@ public class IssueEditActivity extends BasePagerActivity implements
     public static Intent makeCreateIntent(Context context, String repoOwner, String repoName) {
         // can't reuse makeEditIntent here, because even a null extra counts for hasExtra()
         return new Intent(context, IssueEditActivity.class)
-                .putExtra("owner", repoOwner)
-                .putExtra("repo", repoName);
+                .putExtra(EXTRA_KEY_OWNER, repoOwner)
+                .putExtra(EXTRA_KEY_REPO, repoName);
     }
 
     public static Intent makeCreateIntent(Context context, String repoOwner, String repoName, String title, String body) {
         return new Intent(context, IssueEditActivity.class)
-                .putExtra("owner", repoOwner)
-                .putExtra("repo", repoName)
+                .putExtra(EXTRA_KEY_OWNER, repoOwner)
+                .putExtra(EXTRA_KEY_REPO, repoName)
                 .putExtra(EXTRA_KEY_TITLE, title)
                 .putExtra(EXTRA_KEY_BODY, body);
     }
@@ -111,9 +111,9 @@ public class IssueEditActivity extends BasePagerActivity implements
     public static Intent makeEditIntent(Context context, String repoOwner,
             String repoName, Issue issue) {
         return new Intent(context, IssueEditActivity.class)
-                .putExtra("owner", repoOwner)
-                .putExtra("repo", repoName)
-                .putExtra("issue", issue);
+                .putExtra(EXTRA_KEY_OWNER, repoOwner)
+                .putExtra(EXTRA_KEY_REPO, repoName)
+                .putExtra(EXTRA_KEY_ISSUE, issue);
     }
 
     private interface OnAssigneesLoaded {
@@ -163,6 +163,9 @@ public class IssueEditActivity extends BasePagerActivity implements
 
     private static final String EXTRA_KEY_TITLE = "title";
     private static final String EXTRA_KEY_BODY = "body";
+    private static final String EXTRA_KEY_OWNER = "owner";
+    private static final String EXTRA_KEY_REPO = "repo";
+    private static final String EXTRA_KEY_ISSUE = "issue";
 
     private static final String STATE_KEY_ISSUE = "issue";
     private static final String STATE_KEY_ORIGINAL_ISSUE = "original_issue";
@@ -280,12 +283,12 @@ public class IssueEditActivity extends BasePagerActivity implements
     @Override
     protected void onInitExtras(Bundle extras) {
         super.onInitExtras(extras);
-        mRepoOwner = extras.getString("owner");
-        mRepoName = extras.getString("repo");
+        mRepoOwner = extras.getString(EXTRA_KEY_OWNER);
+        mRepoName = extras.getString(EXTRA_KEY_REPO);
         // If mEditIssue is != null here, it was restored from saved state
         if (mEditIssue == null) {
-            if (extras.containsKey("issue")) {
-                mEditIssue = extras.getParcelable("issue");
+            if (extras.containsKey(EXTRA_KEY_ISSUE)) {
+                mEditIssue = extras.getParcelable(EXTRA_KEY_ISSUE);
                 // Save only editable fields
                 mOriginalIssue = Issue.builder()
                         .title(mEditIssue.title())
@@ -330,7 +333,7 @@ public class IssueEditActivity extends BasePagerActivity implements
     }
 
     private boolean isEditingExistingIssue() {
-        return getIntent().hasExtra("issue");
+        return getIntent().hasExtra(EXTRA_KEY_ISSUE);
     }
 
     private boolean isContentGivenViaIntent() {

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -86,9 +86,15 @@ import io.reactivex.schedulers.Schedulers;
 public class PullRequestActivity extends BaseFragmentPagerActivity implements
         View.OnClickListener, ConfirmationDialogFragment.Callback,
         PullRequestFilesFragment.CommentUpdateListener {
+    public static Intent makeIntent(Context context, Issue issue) {
+        String[] urlParts = issue.url().split("/");
+        return makeIntent(context, urlParts[4], urlParts[5], issue.number());
+    }
+
     public static Intent makeIntent(Context context, String repoOwner, String repoName, int number) {
         return makeIntent(context, repoOwner, repoName, number, -1, null);
     }
+
     public static Intent makeIntent(Context context, String repoOwner, String repoName,
             int number, int initialPage, IntentUtils.InitialCommentMarker initialComment) {
         return new Intent(context, PullRequestActivity.class)

--- a/app/src/main/java/com/gh4a/fragment/IssueListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueListFragment.java
@@ -15,7 +15,6 @@
  */
 package com.gh4a.fragment;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -108,10 +107,9 @@ public class IssueListFragment extends PagedDataBaseFragment<Issue> {
 
     @Override
     public void onItemClick(Issue issue) {
-        String[] urlPart = issue.url().split("/");
         Intent intent = issue.pullRequest() != null
-                ? PullRequestActivity.makeIntent(getActivity(), urlPart[4], urlPart[5], issue.number())
-                : IssueActivity.makeIntent(getActivity(), urlPart[4], urlPart[5], issue.number());
+                ? PullRequestActivity.makeIntent(getActivity(), issue)
+                : IssueActivity.makeIntent(getActivity(), issue);
         mIssueLauncher.launch(intent);
     }
 

--- a/app/src/main/res/layout/error.xml
+++ b/app/src/main/res/layout/error.xml
@@ -2,7 +2,6 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/error"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -27,36 +26,22 @@
         android:textColor="?android:attr/textColorSecondary"
         android:textSize="16sp" />
 
-    <com.gh4a.widget.StyleableTextView
+    <Button
         android:id="@+id/retry_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:paddingBottom="8dp"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:paddingTop="8dp"
         android:text="@string/try_again"
-        android:textAllCaps="true"
-        android:textColor="?attr/colorAccent"
-        app:ghFont="medium" />
+        style="@style/Widget.MaterialComponents.Button.TextButton" />
 
-    <com.gh4a.widget.StyleableTextView
+    <Button
         android:id="@+id/report_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:paddingBottom="8dp"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:paddingTop="8dp"
         android:visibility="gone"
         android:text="@string/report_issue"
-        android:textAllCaps="true"
-        android:textColor="?attr/colorAccent"
-        app:ghFont="medium"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
         tools:visibility="visible" />
 
     <View

--- a/app/src/main/res/layout/error.xml
+++ b/app/src/main/res/layout/error.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/error"
     android:layout_width="match_parent"
@@ -40,6 +41,23 @@
         android:textAllCaps="true"
         android:textColor="?attr/colorAccent"
         app:ghFont="medium" />
+
+    <com.gh4a.widget.StyleableTextView
+        android:id="@+id/report_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:paddingBottom="8dp"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="8dp"
+        android:visibility="gone"
+        android:text="@string/report_issue"
+        android:textAllCaps="true"
+        android:textColor="?attr/colorAccent"
+        app:ghFont="medium"
+        tools:visibility="visible" />
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="credentials_otp_prompt">Please enter the two-factor confirmation code you got via SMS.</string>
     <string name="credentials_token">Access token</string>
     <string name="try_again">Try again</string>
+    <string name="report_issue">Report issue</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
     <string name="settings">Settings</string>
@@ -68,7 +69,7 @@
     <string name="pub_timeline">Public Timeline</string>
     <string name="load_failure_explanation">Loading the data from GitHub failed. Please verify you have a working network connection and try again.</string>
     <string name="load_failure_explanation_dmca">This repository was taken down for legal reasons.\nPlease see %1$s for details.</string>
-    <string name="load_failure_explanation_parsing">There was an error while parsing GitHub\'s response. See the logcat for details.</string>
+    <string name="load_failure_explanation_parsing">There was an error while parsing GitHub\'s response. You can use the button below to report this issue to the app developers.</string>
     <string name="load_failure_explanation_with_reason">Loading the data from GitHub failed. GitHub told us the following reason:\n%1$s</string>
     <string name="find_next">Find next</string>
     <string name="find_previous">Find previous</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,9 +66,10 @@
     <string name="draft">Draft</string>
     <string name="theme">Theme</string>
     <string name="pub_timeline">Public Timeline</string>
-    <string name="load_failure_explanation">Loading the data from Github failed. Please verify you have a working network connection and try again.</string>
+    <string name="load_failure_explanation">Loading the data from GitHub failed. Please verify you have a working network connection and try again.</string>
     <string name="load_failure_explanation_dmca">This repository was taken down for legal reasons.\nPlease see %1$s for details.</string>
-    <string name="load_failure_explanation_with_reason">Loading the data from Github failed. Github told us the following reason:\n%1$s</string>
+    <string name="load_failure_explanation_parsing">There was an error while parsing GitHub\'s response. See the logcat for details.</string>
+    <string name="load_failure_explanation_with_reason">Loading the data from GitHub failed. GitHub told us the following reason:\n%1$s</string>
     <string name="find_next">Find next</string>
     <string name="find_previous">Find previous</string>
     <string name="share">Share</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="load_failure_explanation_dmca">This repository was taken down for legal reasons.\nPlease see %1$s for details.</string>
     <string name="load_failure_explanation_parsing">There was an error while parsing GitHub\'s response. You can use the button below to report this issue to the app developers.</string>
     <string name="load_failure_explanation_with_reason">Loading the data from GitHub failed. GitHub told us the following reason:\n%1$s</string>
+    <string name="issue_reported">The issue has been reported. Thank you!</string>
     <string name="find_next">Find next</string>
     <string name="find_previous">Find previous</string>
     <string name="share">Share</string>


### PR DESCRIPTION
We will never get rid of them (as long as we use the current bindings library). GH can always add new enum values to enums that don't have a null fallback, or there may be enum bindings that are not exhaustive.
Now these errors have a specific error message, so that the user knows what's going on.

Also, I thought it would be a good idea to log all handled exceptions as errors in logcat to make them more prominent.