### PR TITLE
Update bindings and leverage new features

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,7 +83,7 @@ dependencies {
         exclude group: 'xpp3', module: 'xpp3'
     }
     implementation 'com.github.maniac103:rxloader:master-SNAPSHOT'
-    implementation 'com.github.maniac103:githubsdk:0.7.0.4'
+    implementation 'com.github.maniac103:githubsdk:0.7.0.5'
     implementation 'com.larswerkman:HoloColorPicker:1.5@aar'
     implementation 'com.caverock:androidsvg-aar:1.4'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.21'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,17 +73,17 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.5.0'
-    implementation 'com.squareup.retrofit2:converter-moshi:2.5.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.6.4'
+    implementation 'com.squareup.retrofit2:converter-moshi:2.6.4'
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.13'
-    implementation('com.squareup.retrofit2:converter-simplexml:2.5.0') {
+    implementation('com.squareup.retrofit2:converter-simplexml:2.6.4') {
         exclude group: 'stax', module: 'stax-api'
         exclude group: 'stax', module: 'stax'
         exclude group: 'xpp3', module: 'xpp3'
     }
     implementation 'com.github.maniac103:rxloader:master-SNAPSHOT'
-    implementation 'com.github.maniac103:githubsdk:0.7.0.5'
+    implementation 'com.github.maniac103:githubsdk:0.7.0.8'
     implementation 'com.larswerkman:HoloColorPicker:1.5@aar'
     implementation 'com.caverock:androidsvg-aar:1.4'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.21'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -30,32 +30,6 @@
 -keep class org.ocpsoft.prettytime.i18n.**
 
 #
-# JodaTimeAndroid rules copied from https://github.com/dlew/joda-time-android/blob/main/library/proguard-rules.txt
-#
-
-# All the resources are retrieved via reflection, so we need to make sure we keep them
--keep class net.danlew.android.joda.R$raw { *; }
-
-# These aren't necessary if including joda-convert, but
-# most people aren't, so it's helpful to include it.
--dontwarn org.joda.convert.FromString
--dontwarn org.joda.convert.ToString
-
-# Joda classes use the writeObject special method for Serializable, so
-# if it's stripped, we'll run into NotSerializableExceptions.
-# https://www.guardsquare.com/en/products/proguard/manual/examples#serializable
--keepnames class org.joda.** implements java.io.Serializable
--keepclassmembers class org.joda.** implements java.io.Serializable {
-    static final long serialVersionUID;
-    private static final java.io.ObjectStreamField[] serialPersistentFields;
-    !static !transient <fields>;
-    private void writeObject(java.io.ObjectOutputStream);
-    private void readObject(java.io.ObjectInputStream);
-    java.lang.Object writeReplace();
-    java.lang.Object readResolve();
-}
-
-#
 # Moshi rules copied from https://github.com/square/moshi/blob/moshi-parent-1.8.0/moshi/src/main/resources/META-INF/proguard/moshi.pro
 #
 

--- a/app/src/main/java/com/gh4a/Gh4Application.java
+++ b/app/src/main/java/com/gh4a/Gh4Application.java
@@ -28,8 +28,6 @@ import com.gh4a.worker.NotificationsWorker;
 import com.meisolsson.githubsdk.model.User;
 import com.tspoon.traceur.Traceur;
 
-import net.danlew.android.joda.JodaTimeAndroid;
-
 import org.ocpsoft.prettytime.PrettyTime;
 
 import java.util.HashSet;
@@ -123,7 +121,6 @@ public class Gh4Application extends MultiDexApplication implements
         }
 
         mPt = new PrettyTime();
-        JodaTimeAndroid.init(this);
         ServiceFactory.initClient(this);
 
         updateNotificationWorker(prefs);

--- a/app/src/main/java/com/gh4a/ServiceFactory.java
+++ b/app/src/main/java/com/gh4a/ServiceFactory.java
@@ -33,7 +33,9 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public class ServiceFactory {
-    private static final String DEFAULT_HEADER_ACCEPT = "application/vnd.github.v3.full+json";
+    private static final String DEFAULT_HEADER_ACCEPT = "application/vnd.github.v3+json," +
+            "application/vnd.github.v3.raw+json," +
+            "application/vnd.github.v3.html+json";
 
     private final static HttpLoggingInterceptor LOGGING_INTERCEPTOR = new HttpLoggingInterceptor()
             .setLevel(HttpLoggingInterceptor.Level.BASIC);

--- a/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
@@ -679,10 +679,9 @@ public class IssueEditActivity extends BasePagerActivity implements
     }
 
     private Single<IssueTemplate> parseTemplate(RepositoryContentService service, Content content) {
-        return service.getContents(mRepoOwner, mRepoName, content.path(), null)
+        return service.getContentsRaw(mRepoOwner, mRepoName, content.path(), null)
             .map(ApiHelpers::throwOnFailure)
-            .map(fileContent -> StringUtils.fromBase64(fileContent.content()))
-            .map(contentString -> new IssueTemplate(contentString))
+            .map(IssueTemplate::new)
             .compose(RxUtils::doInBackground);
     }
 

--- a/app/src/main/java/com/gh4a/fragment/CommitFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/CommitFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
+import android.text.style.StrikethroughSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -239,7 +240,14 @@ public class CommitFragment extends LoadingFragmentBase implements OnClickListen
 
             ViewGroup fileView = (ViewGroup) inflater.inflate(R.layout.commit_filename, parent, false);
             TextView fileNameView = fileView.findViewById(R.id.filename);
-            fileNameView.setText(file.filename());
+            if (file.previousFilename() != null) {
+                SpannableStringBuilder fileNames = new SpannableStringBuilder();
+                fileNames.append(file.previousFilename()).append('\n').append(file.filename());
+                fileNames.setSpan(new StrikethroughSpan(), 0, file.previousFilename().length(), 0);
+                fileNameView.setText(fileNames);
+            } else {
+                fileNameView.setText(file.filename());
+            }
 
             TextView statsView = fileView.findViewById(R.id.stats);
             if (file.patch() != null) {

--- a/app/src/main/java/com/gh4a/fragment/ContentListContainerFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ContentListContainerFragment.java
@@ -315,11 +315,10 @@ public class ContentListContainerFragment extends Fragment implements
         String repoOwner = mRepository.owner().login();
         String repoName = mRepository.name();
 
-        service.getContents(repoOwner, repoName, ".gitmodules", mSelectedRef)
+        service.getContentsRaw(repoOwner, repoName, ".gitmodules", mSelectedRef)
                 .map(ApiHelpers::throwOnFailure)
                 .map(Optional::of)
-                .compose(RxUtils.mapFailureToValue(HttpURLConnection.HTTP_NOT_FOUND, Optional.<Content>absent()))
-                .map(contentOpt -> contentOpt.map(content -> StringUtils.fromBase64(content.content())))
+                .compose(RxUtils.mapFailureToValue(HttpURLConnection.HTTP_NOT_FOUND, Optional.<String>absent()))
                 .map(this::parseModuleMap)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/gh4a/model/StatusWrapper.java
+++ b/app/src/main/java/com/gh4a/model/StatusWrapper.java
@@ -45,6 +45,7 @@ public class StatusWrapper {
         mTargetUrl = checkRun.detailsUrl();
 
         switch (checkRun.state()) {
+            case Waiting:
             case Requested:
             case Queued:
                 mState = State.Unknown;


### PR DESCRIPTION
This PR updates bindings to version 0.7.0.7 and includes the following improvements:
- JodaTime has been removed (debug builds of the app are almost 1MB smaller)
- the new `getContentsRaw` method has been used to retrieve text file contents in some cases (issue templates, gitmodules)
- `waiting` state for check runs is now handled (fixes #1169)
- commit details now display the previous filename for deleted files.
The best and simplest solution I came up with is the one you can see in the screenshots below (the previous filename is ruled-out).
![](https://user-images.githubusercontent.com/30041551/147275207-f2ce1743-3457-40c6-80c6-9ccc3eea647f.png)
![](https://user-images.githubusercontent.com/30041551/147275210-ec671309-538c-43e9-80a5-011faf42eb10.png)
I also tried to do something like "OLD FILENAME → NEW FILENAME", but the `→` symbol looks terrible in Roboto.
I'm open to any suggestions for improvement.

Last but not least, the default header for all API requests has been changed so that API responses don't include the `bodyText` field for issues and comments (which is never used by the bindings). The data savings aren't big, but summed up they can make a difference in the long run.

**Before:**
<img src="https://user-images.githubusercontent.com/30041551/147276375-5877745b-a486-4ab2-aec8-db5f68d59b76.png" />

**After (new headers):**
![comments_after](https://user-images.githubusercontent.com/30041551/147276450-309212ba-1dc6-4a4e-a095-e3616980a956.png)

I have done some quick tests and I have observed no regressions. AFAIK the other endpoints that change their behavior according to the Accept header are the ones used by the [`RepositoryContentService`](https://github.com/maniac103/GitHubSdk/blob/gh4a-rebase/library/src/main/java/com/meisolsson/githubsdk/service/repositories/RepositoryContentService.java), which continue to work as intended.