### PR TITLE
Add basic support for embedded videos in comments

### DIFF
--- a/app/src/main/java/com/gh4a/utils/HtmlUtils.java
+++ b/app/src/main/java/com/gh4a/utils/HtmlUtils.java
@@ -464,6 +464,8 @@ public class HtmlUtils {
                 startHeading(attributes, tag.charAt(1) - '1');
             } else if (tag.equalsIgnoreCase("img")) {
                 startImg(attributes, mImageGetter);
+            } else if (tag.equalsIgnoreCase("video")) {
+                appendVideoLink(attributes.getValue("src"));
             } else if (tag.equalsIgnoreCase("th")) {
                 start(new Bold());
             } else if (tag.equalsIgnoreCase("td")) {
@@ -582,6 +584,16 @@ public class HtmlUtils {
             for (int j = existingNewlines; j < minNewline; j++) {
                 mSpannableStringBuilder.append("\n");
             }
+        }
+
+        private void appendVideoLink(String videoUrl) {
+            mSpannableStringBuilder.append("\uD83C\uDFA5 "); // movie camera emoji
+            String videoLinkText = mContext.getString(R.string.view_video);
+            mSpannableStringBuilder.append(videoLinkText);
+            mSpannableStringBuilder.setSpan(new LinkSpan(videoUrl),
+                    mSpannableStringBuilder.length() - videoLinkText.length(),
+                    mSpannableStringBuilder.length(),
+                    Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         }
 
         private void startBlockElement(Attributes attributes) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="saving_comment">Saving comment\u2026</string>
     <string name="ellipse" translatable="false">\u2026</string>
     <string name="view_more">View more\u2026</string>
+    <string name="view_video">View video</string>
     <string name="pulls">Pulls</string>
     <string name="issue_milestone_hint">Milestone</string>
     <string name="issue_assignee_hint">Assignees</string>


### PR DESCRIPTION
This PR adds a small QoL life change to allow viewing embedded videos in comments in the app.
Before this PR, you had to open the comment in the GitHub website in order to see an embedded video, because the app displayed only the name of the video file.
Now, a "View video" link will appear near the video name, which opens the video in a custom tab, as you can see in the screenshot below:

<img src="https://user-images.githubusercontent.com/30041551/147474727-5d5afcd4-c7e6-403a-ab43-43ff4ce0d8a5.jpeg" width=450 />

I initially thought of making the video file name a clickable link, but it turned out to be too difficult since the `<video>` tag is after the name (which is a `<span>`) in the HTML.