### PR TITLE
Improve lists UI behaviour when there are long usernames

### DIFF
--- a/app/src/main/res/layout/row_commit.xml
+++ b/app/src/main/res/layout/row_commit.xml
@@ -46,34 +46,40 @@
 
     </LinearLayout>
 
-    <com.gh4a.widget.StyleableTextView
-        android:id="@+id/tv_extra"
+    <LinearLayout
+        android:id="@+id/username_and_date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
-        android:layout_toRightOf="@id/iv_gravatar"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?android:attr/textColorPrimary"
-        tools:text="Username" />
+        android:layout_toRightOf="@id/iv_gravatar">
 
-    <com.gh4a.widget.StyleableTextView
-        android:id="@+id/tv_timestamp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignBaseline="@id/tv_extra"
-        android:layout_alignWithParentIfMissing="true"
-        android:layout_marginLeft="16dp"
-        android:layout_toLeftOf="@id/info"
-        android:layout_toRightOf="@id/tv_extra"
-        android:textAppearance="@style/TextAppearance.VerySmall"
-        tools:text="yesterday" />
+        <com.gh4a.widget.StyleableTextView
+            android:id="@+id/tv_extra"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:maxLines="2"
+            android:ellipsize="end"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorPrimary"
+            tools:text="Username"
+            tools:ignore="InefficientWeight" />
+
+        <com.gh4a.widget.StyleableTextView
+            android:id="@+id/tv_timestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="16dp"
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="yesterday" />
+    </LinearLayout>
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignWithParentIfMissing="true"
-        android:layout_below="@id/tv_extra"
+        android:layout_below="@id/username_and_date"
         android:layout_toLeftOf="@id/info"
         android:layout_toRightOf="@id/iv_gravatar"
         android:ellipsize="end"

--- a/app/src/main/res/layout/row_event.xml
+++ b/app/src/main/res/layout/row_event.xml
@@ -29,30 +29,34 @@
                 android:background="?attr/selectableItemBackgroundBorderless"
                 tools:src="@drawable/default_avatar" />
 
-            <com.gh4a.widget.StyleableTextView
-                android:id="@+id/tv_actor"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:gravity="center_vertical"
                 android:layout_alignBottom="@id/iv_gravatar"
                 android:layout_alignTop="@id/iv_gravatar"
-                android:layout_toRightOf="@id/iv_gravatar"
-                android:gravity="center_vertical"
-                android:maxLines="1"
-                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-                app:ghFont="bold"
-                tools:text="username" />
+                android:layout_toRightOf="@id/iv_gravatar">
 
-            <com.gh4a.widget.StyleableTextView
-                android:id="@+id/tv_created_at"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignBaseline="@id/tv_actor"
-                android:layout_alignParentRight="true"
-                android:layout_toRightOf="@id/tv_actor"
-                android:gravity="right"
-                android:maxLines="1"
-                android:textAppearance="@style/TextAppearance.VerySmall"
-                tools:text="yesterday" />
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/tv_actor"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                    app:ghFont="bold"
+                    tools:text="username" />
+
+                <com.gh4a.widget.StyleableTextView
+                    android:id="@+id/tv_created_at"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="16dp"
+                    android:maxLines="1"
+                    android:textAppearance="@style/TextAppearance.VerySmall"
+                    tools:text="yesterday" />
+            </LinearLayout>
 
             <com.gh4a.widget.StyleableTextView
                 android:id="@+id/tv_title"

--- a/app/src/main/res/layout/row_issue.xml
+++ b/app/src/main/res/layout/row_issue.xml
@@ -61,30 +61,38 @@
         android:layout_gravity="bottom"
         android:layout_marginTop="8dp" />
 
-    <com.gh4a.widget.StyleableTextView
-        android:id="@+id/tv_creator"
+    <LinearLayout
+        android:id="@+id/username_and_date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/iv_gravatar"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?android:attr/textColorPrimary"
-        tools:text="IssueCreatorUsername" />
+        android:layout_toRightOf="@id/iv_gravatar">
 
-    <com.gh4a.widget.StyleableTextView
-        android:id="@+id/tv_timestamp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignBaseline="@id/tv_creator"
-        android:layout_marginLeft="16dp"
-        android:layout_toRightOf="@id/tv_creator"
-        android:textAppearance="@style/TextAppearance.VerySmall"
-        tools:text="yesterday" />
+        <com.gh4a.widget.StyleableTextView
+            android:id="@+id/tv_creator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:maxLines="2"
+            android:ellipsize="end"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorPrimary"
+            tools:text="IssueCreatorUsername"
+            tools:ignore="InefficientWeight" />
+
+        <com.gh4a.widget.StyleableTextView
+            android:id="@+id/tv_timestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="16dp"
+            android:textAppearance="@style/TextAppearance.VerySmall"
+            tools:text="yesterday" />
+    </LinearLayout>
 
     <com.gh4a.widget.StyleableTextView
         android:id="@+id/tv_desc"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/tv_creator"
+        android:layout_below="@id/username_and_date"
         android:layout_toLeftOf="@id/info"
         android:layout_toRightOf="@id/iv_gravatar"
         android:ellipsize="end"


### PR DESCRIPTION
This PR makes some lists look better (commits, issues and activity lists) when usernames are too long to fit in one line.
The layouts have been adjusted (using [this trick](https://stackoverflow.com/a/48199856)) to make sure that the timestamp of the item never gets shrunk/wrapped and the username gets ellipsized or wrapped if it's too long.
Here are some before/after comparisons:

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/148433961-e19fb4cd-133a-458b-a767-5d64bdcc2af5.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/148433992-e9534bfb-7d0f-4703-965c-8ec3e9d58374.png" /></td></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/148434041-2d904de6-bd2d-4ffc-831a-464efdd1a127.png"/>
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/148434073-3160ea75-0ce0-48bf-8b3d-c3c35b7d4649.png" /></td></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/148434165-059507a6-db41-4d5a-9722-7d2ba94d62db.png"/>
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/148434204-1365704c-e477-4512-8ed8-adb76f610212.png" /></td></tr>
</table>

Implementation notes: in some places I have added `tools:ignore="InefficientWeight"` because Android Studio suggests to set the width to 0dp to improve rendering performance, but it causes TextView sizes to be messed up after scrolling the RecyclerView.