### PR TITLE
add data loss functionality to issue fragment base

### DIFF
--- a/app/src/main/java/com/gh4a/widget/EditorBottomSheet.java
+++ b/app/src/main/java/com/gh4a/widget/EditorBottomSheet.java
@@ -367,6 +367,13 @@ public class EditorBottomSheet extends FrameLayout implements View.OnClickListen
         return mBasicEditor.getText();
     }
 
+    public Editable getText() {
+        if (isInAdvancedMode()) {
+            return mAdvancedEditor.getText();
+        }
+        return mBasicEditor.getText();
+    }
+
     private void setAdvancedEditorVisible(boolean visible) {
         mAdvancedEditorContainer.setVisibility(visible ? View.VISIBLE : View.GONE);
         mBasicEditorScrollView.setVisibility(visible ? View.GONE : View.VISIBLE);


### PR DESCRIPTION
Hello developers of octodroid

I am using your app octodroid. I think the app is great but I have one minor patch that could improve the user experience.

Here is a picture to help illustrate what activity that are changed in my patch:

https://ibb.co/6vgx1S3

When the user is typing a message to send. If the screen focus goes to another app or activity or if the user accidentally closes or press back the app, the user will lose any data they had put into this page

This feature will automatically store the data when the user leaves the activity without submitting and restore said data when they restart the activity(this can be seen here where I pressed back and went back into the activity https://ibb.co/gPL8BNB). Therefore, the user does not have to fill in the data again thus improving the user experience.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim