### PR TITLE
Update GitHub blog feed URL

### DIFF
--- a/app/src/main/java/com/gh4a/model/GitHubFeedService.java
+++ b/app/src/main/java/com/gh4a/model/GitHubFeedService.java
@@ -9,6 +9,6 @@ public interface GitHubFeedService {
     @GET("{url}")
     Single<Response<GitHubFeed>> getFeed(@Path(value = "url", encoded = true) String url);
 
-    @GET("https://github.blog/all.atom")
+    @GET("https://github.blog/feed/atom/")
     Single<Response<GitHubFeed>> getBlogFeed();
 }


### PR DESCRIPTION
A few days ago GitHub silently changed the URL of the atom feed of their blog.
This PR updates the URL in the app so that the feed can be retrieved correctly.