### PR TITLE
Fix a few hidden bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,8 +55,8 @@ android {
 
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 }
 

--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -88,14 +88,13 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
     }
 
     @Override
-    public Single<Response<Void>> doDeleteComment(long id) {
+    public Single<Response<Void>> deleteCommentSingle(long id) {
         RepositoryCommentService service = ServiceFactory.get(RepositoryCommentService.class, false);
-
         return service.deleteCommitComment(mRepoOwner, mRepoName, id);
     }
 
     @Override
-    protected Single<List<GitComment>> createCommentSingle(boolean bypassCache) {
+    protected Single<List<GitComment>> getCommentsSingle(boolean bypassCache) {
         final RepositoryCommentService service =
                 ServiceFactory.get(RepositoryCommentService.class, bypassCache);
         return ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -71,7 +71,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
     }
 
     @Override
-    protected PositionalCommentBase onUpdateReactions(PositionalCommentBase comment,
+    protected PositionalCommentBase buildCommentWithReactions(PositionalCommentBase comment,
             Reactions reactions) {
         return ((GitComment) comment).toBuilder()
                 .reactions(reactions)
@@ -104,7 +104,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
 
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
-        final CommitCommentWrapper comment = (CommitCommentWrapper) item;
+        final CommentWrapper comment = (CommentWrapper) item;
         final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitCommentReactions(mRepoOwner, mRepoName, comment.comment.id(), page));
@@ -112,7 +112,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
 
     @Override
     public Single<Reaction> addReaction(ReactionBar.Item item, String content) {
-        CommitCommentWrapper comment = (CommitCommentWrapper) item;
+        CommentWrapper comment = (CommentWrapper) item;
         final ReactionService service = ServiceFactory.get(ReactionService.class, false);
         ReactionRequest request = ReactionRequest.builder().content(content).build();
 

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -103,7 +103,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
     }
 
     @Override
-    protected PositionalCommentBase onUpdateReactions(PositionalCommentBase comment,
+    protected PositionalCommentBase buildCommentWithReactions(PositionalCommentBase comment,
             Reactions reactions) {
         return ((ReviewComment) comment).toBuilder()
                 .reactions(reactions)
@@ -119,7 +119,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
 
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
-        final CommitCommentWrapper comment = (CommitCommentWrapper) item;
+        final CommentWrapper comment = (CommentWrapper) item;
         final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestReviewCommentReactions(
@@ -128,7 +128,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
 
     @Override
     public Single<Reaction> addReaction(ReactionBar.Item item, String content) {
-        CommitCommentWrapper comment = (CommitCommentWrapper) item;
+        CommentWrapper comment = (CommentWrapper) item;
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         ReactionRequest request = ReactionRequest.builder().content(content).build();
 

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -69,7 +69,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
     }
 
     @Override
-    protected Single<List<ReviewComment>> createCommentSingle(boolean bypassCache) {
+    protected Single<List<ReviewComment>> getCommentsSingle(boolean bypassCache) {
         final PullRequestReviewCommentService service =
                 ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache);
         return ApiHelpers.PageIterator
@@ -111,7 +111,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
     }
 
     @Override
-    protected Single<Response<Void>> doDeleteComment(long id) {
+    protected Single<Response<Void>> deleteCommentSingle(long id) {
         PullRequestReviewCommentService service =
                 ServiceFactory.get(PullRequestReviewCommentService.class, false);
         return service.deleteComment(mRepoOwner, mRepoName, id);

--- a/app/src/main/java/com/gh4a/adapter/timeline/ReviewViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/ReviewViewHolder.java
@@ -116,14 +116,7 @@ class ReviewViewHolder
         mAvatarContainer.setTag(review.user());
 
         formatTitle(review);
-
-        boolean hasBody = !TextUtils.isEmpty(review.body());
-        if (hasBody) {
-            mImageGetter.bind(mBodyView, review.bodyHtml(), review.id());
-            mBodyView.setVisibility(View.VISIBLE);
-        } else {
-            mBodyView.setVisibility(View.GONE);
-        }
+        mImageGetter.bind(mBodyView, review.bodyHtml(), review.id());
 
         if (mCallback.canQuote()) {
             mBodyView.setCustomSelectionActionModeCallback(mQuoteActionModeCallback);
@@ -196,6 +189,7 @@ class ReviewViewHolder
             mDetailsHeader.setVisibility(View.GONE);
         }
 
+        boolean hasBody = !TextUtils.isEmpty(review.body());
         if (hasBody && mDisplayReviewDetails && hasDiffs) {
             mDetailsDivider.setVisibility(View.VISIBLE);
         } else {

--- a/app/src/main/java/com/gh4a/fragment/ContentListContainerFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ContentListContainerFragment.java
@@ -3,6 +3,8 @@ package com.gh4a.fragment;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -117,7 +119,7 @@ public class ContentListContainerFragment extends Fragment implements
     }
 
     @Override
-    public void onAttach(Context context) {
+    public void onAttach(@NonNull Context context) {
         super.onAttach(context);
         if (context instanceof CommitSelectionCallback) {
             mCommitCallback = (CommitSelectionCallback) context;
@@ -178,17 +180,19 @@ public class ContentListContainerFragment extends Fragment implements
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         mBreadcrumbs = view.findViewById(R.id.breadcrumbs);
         mBreadcrumbs.setCallback(this);
         mStateSaved = false;
         updateBreadcrumbs();
-        addFragmentForTopOfStack();
+        if (savedInstanceState == null) {
+            addFragmentForTopOfStack();
+        }
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putStringArrayList(STATE_KEY_DIR_STACK, new ArrayList<>(mDirStack));
         outState.putStringArrayList(STATE_KEY_INITIAL_PATH, mInitialPathToLoad);


### PR DESCRIPTION
- fixed comment deletion not working in diff viewer (the wrong method was being called)
- fixed reaction toggling not being reflected in the UI in diff viewer
- fixed a bug that caused the repository "Files" tab to misbehave after screen rotation.
When you pressed the back button for the first time after rotation, the path breadcrumbs were updated as if you navigated to the parent folder but the list of contents remained the same. Subsequent back presses updated the list of contents as expected, but at that point the breadcrumbs were out of sync with the directory contents shown.
- fixed a weird-looking bug when having multiple PR reviews without body followed by one with body: the body of the latter was being incorrectly "copied" to the other reviews when scrolling the conversation ([see the bug here](https://streamable.com/zs1hfu))
- **small extra:** enabled [Java 11 language features](https://developer.android.com/studio/releases/gradle-plugin#java-11) in build.gradle

PR split from #1173