### PR TITLE
Further improve WebView styling

### DIFF
--- a/app/src/main/assets/markdown-dark.css
+++ b/app/src/main/assets/markdown-dark.css
@@ -2,7 +2,6 @@ body {
     font-family: Helvetica,arial,sans-serif;
     font-size: 14px;
     line-height: 1.4;
-    background-color: #111;
     color: #A3A3A5;
     margin: 0;
     padding: 6px;
@@ -175,7 +174,6 @@ table {
 
 table tr {
     border-top: 1px solid #7A7A7A;
-    background-color: #111;
     margin: 0;
     padding: 0;
 }

--- a/app/src/main/assets/markdown-dark.css
+++ b/app/src/main/assets/markdown-dark.css
@@ -1,18 +1,14 @@
 body {
-    font-family: Helvetica,arial,sans-serif;
+    font-family: Roboto,sans-serif;
     font-size: 14px;
     line-height: 1.4;
-    color: #A3A3A5;
+    color: #f0f0f0;
     margin: 0;
-    padding: 6px;
+    padding: 16px;
 }
 
-body>:first-child {
+body>:first-child, #content>:first-child {
     margin-top: 0!important;
-}
-
-body>:last-child {
-    margin-bottom: 0!important;
 }
 
 a {
@@ -23,19 +19,8 @@ a.absent {
     color: #c00;
 }
 
-a.anchor {
-    display: block;
-    padding-left: 30px;
-    margin-left: -30px;
-    cursor: pointer;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-}
-
 h1,h2,h3,h4,h5,h6 {
-    margin: 10px 0 6px;
+    margin: 16px 0 8px;
     padding: 0;
     font-weight: 700;
     -webkit-font-smoothing: antialiased;
@@ -53,12 +38,10 @@ h1 code,h1 tt,h2 code,h2 tt,h3 code,h3 tt,h4 code,h4 tt,h5 code,h5 tt,h6 code,h6
 
 h1 {
     font-size: 28px;
-    color: #A3A3A5;
 }
 
 h2 {
     font-size: 24px;
-    color: #A3A3A5;
 }
 
 h3 {
@@ -78,8 +61,12 @@ h6 {
     font-size: 14px;
 }
 
-blockquote,dl,li,ol,p,pre,table,ul {
-    margin: 8px 0;
+blockquote,dl,ol,p,pre,table,ul {
+    margin: 12px 0;
+}
+
+li {
+  margin: 4px 0;
 }
 
 hr {
@@ -206,6 +193,7 @@ table tr td :last-child,table tr th :last-child {
 }
 
 img {
+    height: auto;
     max-width: 100%;
 }
 

--- a/app/src/main/assets/markdown-dark.css
+++ b/app/src/main/assets/markdown-dark.css
@@ -5,6 +5,7 @@ body {
     color: #f0f0f0;
     margin: 0;
     padding: 16px;
+    word-wrap: break-word;
 }
 
 body>:first-child, #content>:first-child {
@@ -289,7 +290,6 @@ code,tt {
     margin: 0 2px;
     padding: 1px 5px;
     white-space: pre-wrap;
-    overflow-wrap: break-word;
     background-color: #2A2A2A;
     border-radius: 3px;
     font-size: 13px;

--- a/app/src/main/assets/markdown-light.css
+++ b/app/src/main/assets/markdown-light.css
@@ -2,7 +2,6 @@ body {
     font-family: Helvetica,arial,sans-serif;
     font-size: 14px;
     line-height: 1.4;
-    background-color: #F7F7F9;
     color: #48484C;
     margin: 0;
     padding: 6px;
@@ -175,7 +174,6 @@ table {
 
 table tr {
     border-top: 1px solid #7A7A7A;
-    background-color: #F7F7F9;
     margin: 0;
     padding: 0;
 }

--- a/app/src/main/assets/markdown-light.css
+++ b/app/src/main/assets/markdown-light.css
@@ -1,18 +1,14 @@
 body {
-    font-family: Helvetica,arial,sans-serif;
+    font-family: Roboto,sans-serif;
     font-size: 14px;
     line-height: 1.4;
     color: #48484C;
     margin: 0;
-    padding: 6px;
+    padding: 16px;
 }
 
-body>:first-child {
+body>:first-child, #content>:first-child {
     margin-top: 0!important;
-}
-
-body>:last-child {
-    margin-bottom: 0!important;
 }
 
 a {
@@ -23,19 +19,8 @@ a.absent {
     color: #c00;
 }
 
-a.anchor {
-    display: block;
-    padding-left: 30px;
-    margin-left: -30px;
-    cursor: pointer;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-}
-
 h1,h2,h3,h4,h5,h6 {
-    margin: 10px 0 6px;
+    margin: 16px 0 8px;
     padding: 0;
     font-weight: 700;
     -webkit-font-smoothing: antialiased;
@@ -53,12 +38,10 @@ h1 code,h1 tt,h2 code,h2 tt,h3 code,h3 tt,h4 code,h4 tt,h5 code,h5 tt,h6 code,h6
 
 h1 {
     font-size: 28px;
-    color: #48484C;
 }
 
 h2 {
     font-size: 24px;
-    color: #48484C;
 }
 
 h3 {
@@ -78,8 +61,12 @@ h6 {
     font-size: 14px;
 }
 
-blockquote,dl,li,ol,p,pre,table,ul {
-    margin: 8px 0;
+blockquote,dl,ol,p,pre,table,ul {
+    margin: 12px 0;
+}
+
+li {
+  margin: 4px 0;
 }
 
 hr {
@@ -206,6 +193,7 @@ table tr td :last-child,table tr th :last-child {
 }
 
 img {
+    height: auto;
     max-width: 100%;
 }
 

--- a/app/src/main/assets/markdown-light.css
+++ b/app/src/main/assets/markdown-light.css
@@ -5,6 +5,7 @@ body {
     color: #48484C;
     margin: 0;
     padding: 16px;
+    word-wrap: break-word;
 }
 
 body>:first-child, #content>:first-child {
@@ -289,7 +290,6 @@ code,tt {
     margin: 0 2px;
     padding: 1px 5px;
     white-space: pre-wrap;
-    overflow-wrap: break-word;
     background-color: #D6D6D6;
     border-radius: 3px;
     font-size: 13px;

--- a/app/src/main/assets/markdown-print.css
+++ b/app/src/main/assets/markdown-print.css
@@ -174,7 +174,6 @@ table {
 
 table tr {
     border-top: 1px solid #7A7A7A;
-    background-color: #F7F7F9;
     margin: 0;
     padding: 0;
 }

--- a/app/src/main/assets/markdown-print.css
+++ b/app/src/main/assets/markdown-print.css
@@ -1,18 +1,14 @@
 body {
-    font-family: Helvetica,arial,sans-serif;
+    font-family: Roboto,sans-serif;
     font-size: 14px;
     line-height: 1.4;
     color: #48484C;
     margin: 0;
-    padding: 6px;
+    padding: 16px;
 }
 
-body>:first-child {
+body>:first-child, #content>:first-child {
     margin-top: 0!important;
-}
-
-body>:last-child {
-    margin-bottom: 0!important;
 }
 
 a {
@@ -23,19 +19,8 @@ a.absent {
     color: #c00;
 }
 
-a.anchor {
-    display: block;
-    padding-left: 30px;
-    margin-left: -30px;
-    cursor: pointer;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-}
-
 h1,h2,h3,h4,h5,h6 {
-    margin: 10px 0 6px;
+    margin: 16px 0 8px;
     padding: 0;
     font-weight: 700;
     -webkit-font-smoothing: antialiased;
@@ -53,12 +38,10 @@ h1 code,h1 tt,h2 code,h2 tt,h3 code,h3 tt,h4 code,h4 tt,h5 code,h5 tt,h6 code,h6
 
 h1 {
     font-size: 28px;
-    color: #48484C;
 }
 
 h2 {
     font-size: 24px;
-    color: #48484C;
 }
 
 h3 {
@@ -78,8 +61,12 @@ h6 {
     font-size: 14px;
 }
 
-blockquote,dl,li,ol,p,pre,table,ul {
-    margin: 8px 0;
+blockquote,dl,ol,p,pre,table,ul {
+    margin: 12px 0;
+}
+
+li {
+  margin: 4px 0;
 }
 
 hr {
@@ -206,6 +193,7 @@ table tr td :last-child,table tr th :last-child {
 }
 
 img {
+    height: auto;
     max-width: 100%;
 }
 

--- a/app/src/main/assets/markdown-print.css
+++ b/app/src/main/assets/markdown-print.css
@@ -5,6 +5,7 @@ body {
     color: #48484C;
     margin: 0;
     padding: 16px;
+    word-wrap: break-word;
 }
 
 body>:first-child, #content>:first-child {
@@ -289,7 +290,6 @@ code,tt {
     margin: 0 2px;
     padding: 1px 5px;
     white-space: pre-wrap;
-    overflow-wrap: break-word;
     background-color: #D6D6D6;
     border-radius: 3px;
     font-size: 13px;

--- a/app/src/main/assets/mdpreview-dark.css
+++ b/app/src/main/assets/mdpreview-dark.css
@@ -2,9 +2,7 @@ body {
     background-color: #303030;
     color: #ffffff;
     font-size: 14px;
-    margin-left: 10px;
-    margin-right: 10px;
-    margin-top: 16px;
+    padding-top: 20px;
     word-wrap: break-word;
 }
 

--- a/app/src/main/assets/mdpreview-light.css
+++ b/app/src/main/assets/mdpreview-light.css
@@ -2,9 +2,7 @@ body {
     background-color: #fafafa;
     color: #000000;
     font-size: 14px;
-    margin-left: 10px;
-    margin-right: 10px;
-    margin-top: 16px;
+    padding-top: 20px;
     word-wrap: break-word;
 }
 

--- a/app/src/main/assets/prettify-dark.css
+++ b/app/src/main/assets/prettify-dark.css
@@ -56,7 +56,6 @@ body {
 }
 
 pre.prettyprint {
-    background-color: #111;
     min-width: 100%;
     display: table;
 }

--- a/app/src/main/assets/prettify-light.css
+++ b/app/src/main/assets/prettify-light.css
@@ -51,7 +51,6 @@ body {
 }
 
 pre.prettyprint {
-    background-color: #F7F7F9;
     min-width: 100%;
     display: table;
 }

--- a/app/src/main/assets/text-dark.css
+++ b/app/src/main/assets/text-dark.css
@@ -1,8 +1,8 @@
 body {
-    font-family: Helvetica,arial,sans-serif;
+    font-family: Roboto,sans-serif;
     font-size: 12px;
     line-height: 1.4;
-    color: #A3A3A5;
+    color: #f0f0f0;
     margin: 6px 0 6px 0;
 }
 

--- a/app/src/main/assets/text-dark.css
+++ b/app/src/main/assets/text-dark.css
@@ -16,12 +16,6 @@ pre > div {
     margin-right: 6px;
 }
 
-.image {
-    border: 1px solid #7a7a7a;
-    display: table;
-    padding: 3px;
-}
-
 .change {
     background-color: #3a3c3d;
 }

--- a/app/src/main/assets/text-dark.css
+++ b/app/src/main/assets/text-dark.css
@@ -2,7 +2,6 @@ body {
     font-family: Helvetica,arial,sans-serif;
     font-size: 12px;
     line-height: 1.4;
-    background-color: #111;
     color: #A3A3A5;
     margin: 6px 0 6px 0;
 }

--- a/app/src/main/assets/text-light.css
+++ b/app/src/main/assets/text-light.css
@@ -16,12 +16,6 @@ pre > div {
     margin-right: 6px;
 }
 
-.image {
-    border: 1px solid #7a7a7a;
-    display: table;
-    padding: 3px;
-}
-
 .change {
     background-color: #9ea1a1;
     color: #eee;

--- a/app/src/main/assets/text-light.css
+++ b/app/src/main/assets/text-light.css
@@ -1,5 +1,5 @@
 body {
-    font-family: Helvetica,arial,sans-serif;
+    font-family: Roboto,sans-serif;
     font-size: 12px;
     line-height: 1.4;
     color: #48484C;

--- a/app/src/main/assets/text-light.css
+++ b/app/src/main/assets/text-light.css
@@ -2,7 +2,6 @@ body {
     font-family: Helvetica,arial,sans-serif;
     font-size: 12px;
     line-height: 1.4;
-    background-color: #F7F7F9;
     color: #48484C;
     margin: 6px 0 6px 0;
 }

--- a/app/src/main/assets/text-print.css
+++ b/app/src/main/assets/text-print.css
@@ -16,12 +16,6 @@ pre > div {
     margin-right: 6px;
 }
 
-.image {
-    border: 1px solid #7a7a7a;
-    display: table;
-    padding: 3px;
-}
-
 .change {
     background-color: #9ea1a1;
     color: #eee;

--- a/app/src/main/assets/text-print.css
+++ b/app/src/main/assets/text-print.css
@@ -1,5 +1,5 @@
 body {
-    font-family: Helvetica,arial,sans-serif;
+    font-family: Roboto,sans-serif;
     font-size: 12px;
     line-height: 1.4;
     color: #48484C;

--- a/app/src/main/java/com/gh4a/activities/BlogActivity.java
+++ b/app/src/main/java/com/gh4a/activities/BlogActivity.java
@@ -58,7 +58,7 @@ public class BlogActivity extends WebViewerActivity {
     @Override
     protected String generateHtml(String cssTheme, boolean addTitleHeader) {
         String title = addTitleHeader ? getDocumentTitle() : null;
-        return wrapUnthemedHtml(getIntent().getStringExtra("content"), cssTheme, title);
+        return wrapWithMarkdownStyling(getIntent().getStringExtra("content"), cssTheme, title);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/activities/FileViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/FileViewerActivity.java
@@ -329,14 +329,13 @@ public class FileViewerActivity extends WebViewerActivity
     private static String highlightImage(String imageUrl, String cssTheme, String title) {
         StringBuilder content = new StringBuilder();
         content.append("<html><head>");
-        HtmlUtils.writeCssInclude(content, "text", cssTheme);
+        HtmlUtils.writeCssInclude(content, "markdown", cssTheme);
         content.append("</head><body>");
         if (title != null) {
             content.append("<h2>").append(title).append("</h2>");
         }
-        content.append("<div class='image'>");
         content.append("<img src='").append(imageUrl).append("' />");
-        content.append("</div></body></html>");
+        content.append("</body></html>");
         return content.toString();
     }
 

--- a/app/src/main/java/com/gh4a/activities/WebViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/WebViewerActivity.java
@@ -446,14 +446,16 @@ public abstract class WebViewerActivity extends BaseActivity implements
                 : "txt";  // plain text, no highlighting
     }
 
-    protected static String wrapUnthemedHtml(String html, String cssTheme, String title) {
-        String style = TextUtils.equals(cssTheme, DARK_CSS_THEME)
-                ? "<style type=\"text/css\">" +
-                    "body { color: #A3A3A5 !important }" +
-                    "a { color: #4183C4 !important }</style>"
-                : "";
-        String titleHeader = title != null ? "<h2>" + title + "</h2>" : "";
-        return style + "<body>" + titleHeader + html + "</body>";
+    protected static String wrapWithMarkdownStyling(String html, String cssTheme, String title) {
+        StringBuilder content = new StringBuilder();
+        HtmlUtils.writeCssInclude(content, "markdown", cssTheme);
+        content.append("<body>");
+        if (title != null) {
+            content.append("<h2>").append(title).append("</h2>");
+        }
+        content.append(html);
+        content.append("</body>");
+        return content.toString();
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/activities/WebViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/WebViewerActivity.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
+import android.graphics.Color;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.Build;
@@ -151,9 +152,8 @@ public abstract class WebViewerActivity extends BaseActivity implements
             s.setTextZoom(ZOOM_SIZES[initialZoomLevel]);
         }
 
-        mWebView.setBackgroundColor(UiUtils.resolveColor(this, R.attr.colorWebViewBackground));
+        mWebView.setBackgroundColor(Color.TRANSPARENT);
         mWebView.setWebViewClient(mWebViewClient);
-
         mWebView.setOnTouchListener(this);
     }
 

--- a/app/src/main/java/com/gh4a/activities/WebViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/WebViewerActivity.java
@@ -162,10 +162,9 @@ public abstract class WebViewerActivity extends BaseActivity implements
     @SuppressLint("SetJavaScriptEnabled")
     private void initWebViewSettings(WebSettings s) {
         s.setLayoutAlgorithm(WebSettings.LayoutAlgorithm.NORMAL);
-        s.setAllowFileAccess(true);
+        s.setAllowFileAccess(false);
         s.setBuiltInZoomControls(true);
         s.setDisplayZoomControls(false);
-        s.setLightTouchEnabled(true);
         s.setLoadsImagesAutomatically(true);
         s.setSupportZoom(true);
         s.setJavaScriptEnabled(true);

--- a/app/src/main/java/com/gh4a/activities/WikiActivity.java
+++ b/app/src/main/java/com/gh4a/activities/WikiActivity.java
@@ -68,7 +68,7 @@ public class WikiActivity extends WebViewerActivity {
     @Override
     protected String generateHtml(String cssTheme, boolean addTitleHeader) {
         String title = addTitleHeader ? getDocumentTitle() : null;
-        return wrapUnthemedHtml(mWikiPageFeed.getContent(), cssTheme, title);
+        return wrapWithMarkdownStyling(mWikiPageFeed.getContent(), cssTheme, title);
     }
 
     @Override

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -34,7 +34,6 @@
     <color name="code_background">#30ffffff</color>
 
     <color name="drawer_background">@color/background_floating_material_dark</color>
-    <color name="webview_background">#111111</color>
     <color name="list_background">@android:color/transparent</color>
     <color name="icon_foreground">#ccffffff</color>
     <color name="breadcrumb_background">#587849</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -44,7 +44,6 @@
     <color name="code_background">#30aaaaaa</color>
 
     <color name="drawer_background">@color/background_floating_material_light</color>
-    <color name="webview_background">#f7f7f9</color>
     <color name="list_background">@android:color/white</color>
     <color name="icon_foreground">#99343434</color>
     <color name="breadcrumb_background">#7baa67</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -36,7 +36,6 @@
         <item name="colorCommitAddition">@color/commit_addition</item>
         <item name="colorCommitDeletion">@color/commit_deletion</item>
         <item name="colorCodeBackground">@color/code_background</item>
-        <item name="colorWebViewBackground">@color/webview_background</item>
         <item name="colorBreadcrumbBackground">@color/breadcrumb_background</item>
         <item name="colorIconForeground">@color/icon_foreground</item>
         <item name="drawerBackground">@color/drawer_background</item>


### PR DESCRIPTION
This PR makes more improvements to WebView styles, with a few more fixes and tweaks:
- fix printing of Markdown previews, which was not working anymore after leveraging `JavascriptInterface`s more extensively
- change background color of WebViews to be exactly the same as the app UI, by setting it to transparent.
Previously it was set to a slightly different shade of grey compared to the other screens.
- improve CSS styles, particularly spacing and text contrast in dark theme as you can see below:
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/153754340-ab7a821b-816c-4bb4-817d-1fb6bac5ed3f.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/153754368-78d489e2-9603-43c9-8875-3df7c5046247.png" /></td></tr>
</table>

- markdown CSS styling is now also applied to wiki pages and GH blog posts. It makes them look considerably better, as images do not overflow the page anymore:
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/153754909-77d045ef-207d-44c8-b935-2f73cb17ac2e.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/153754922-00cd485a-c723-4dbc-8b5c-a10d0402db5b.png" /></td></tr>
</table>

- images will now fit the screen size in file viewer (previously they were zoomed in if bigger than the screen)
- **extra:** disabled filesystem access in WebViews for improved security. It is never used by the app as far as I've seen.