### PR TITLE
Revert "Update GitHub blog feed URL"

### DIFF
--- a/app/src/main/java/com/gh4a/model/GitHubFeedService.java
+++ b/app/src/main/java/com/gh4a/model/GitHubFeedService.java
@@ -9,6 +9,6 @@ public interface GitHubFeedService {
     @GET("{url}")
     Single<Response<GitHubFeed>> getFeed(@Path(value = "url", encoded = true) String url);
 
-    @GET("https://github.blog/feed/atom/")
+    @GET("https://github.blog/all.atom")
     Single<Response<GitHubFeed>> getBlogFeed();
 }


### PR DESCRIPTION
Apparently GitHub changed their mind and brought back the old URL :)

Reverts #1176