### PR TITLE
Improve clarity for `referenced` and `cross-referenced` timeline events

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/timeline/EventViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/EventViewHolder.java
@@ -306,13 +306,19 @@ class EventViewHolder
         pos = text.toString().indexOf("[source]");
         if (pos >= 0) {
             final Issue source = event.source().issue();
-            String sourceLabel = "#" + source.number();
+            var sourceRepoOwnerAndName = ApiHelpers.extractRepoOwnerAndNameFromIssue(source);
+            String sourceRepoOwner = sourceRepoOwnerAndName.first;
+            String sourceRepoName = sourceRepoOwnerAndName.second;
+            boolean isSourceInDifferentRepo = !mRepoOwner.equals(sourceRepoOwner) || !mRepoName.equals(sourceRepoName);
+            String sourceLabel = isSourceInDifferentRepo
+                    ? sourceRepoOwner + "/" + sourceRepoName + "#" + source.number()
+                    : "#" + source.number();
             text.replace(pos, pos + 8, sourceLabel);
-            text.setSpan(new IntentSpan(mContext, context -> {
-                return source.pullRequest() != null
-                        ? PullRequestActivity.makeIntent(context, source)
-                        : IssueActivity.makeIntent(context, source);
-            }), pos, pos + sourceLabel.length(), 0);
+            text.setSpan(new IntentSpan(mContext, context ->
+                source.pullRequest() != null
+                    ? PullRequestActivity.makeIntent(context, sourceRepoOwner, sourceRepoName, source.number())
+                    : IssueActivity.makeIntent(context, sourceRepoOwner, sourceRepoName, source.number())
+            ), pos, pos + sourceLabel.length(), 0);
         }
 
         CharSequence time = event.createdAt() != null

--- a/app/src/main/java/com/gh4a/adapter/timeline/EventViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/EventViewHolder.java
@@ -258,52 +258,67 @@ class EventViewHolder
         if (textBase == null) {
             textBase = mContext.getString(textResId, getUserLoginWithBotSuffix(user));
         }
-        SpannableStringBuilder text = StringUtils.applyBoldTags(textBase, typefaceValue);
 
+        SpannableStringBuilder text = StringUtils.applyBoldTags(textBase, typefaceValue);
+        replaceCommitPlaceholder(event, text);
+        replaceLabelPlaceholder(event, text);
+        replaceBotPlaceholder(text);
+        replaceSourcePlaceholder(event, text);
+        replaceTimePlaceholder(event, text);
+        return text;
+    }
+
+    private void replaceCommitPlaceholder(IssueEvent event, SpannableStringBuilder text) {
         int pos = text.toString().indexOf("[commit]");
         if (event.commitId() != null && pos >= 0) {
             // The commit might be in a different repo. The API doesn't provide
             // that information directly, so get it indirectly by parsing the URL
-            String repoOwner = mRepoOwner;
-            String repoName = mRepoName;
-            boolean isInDifferentRepo = false;
+            String commitRepoOwner = mRepoOwner;
+            String commitRepoName = mRepoName;
+            boolean isCommitInDifferentRepo = false;
             String url = event.commitUrl();
             if (url != null) {
                 Matcher matcher = COMMIT_URL_REPO_NAME_AND_OWNER_PATTERN.matcher(url);
                 if (matcher.find()) {
-                    repoOwner = matcher.group(1);
-                    repoName = matcher.group(2);
-                    isInDifferentRepo = !mRepoOwner.equals(repoOwner) || !mRepoName.equals(repoName);
+                    commitRepoOwner = matcher.group(1);
+                    commitRepoName = matcher.group(2);
+                    isCommitInDifferentRepo = !mRepoOwner.equals(commitRepoOwner) || !mRepoName.equals(commitRepoName);
                 }
             }
             String shortCommitSha = event.commitId().substring(0, 7);
-            String commitText = isInDifferentRepo
-                    ? repoOwner + "/" + repoName + "#" + shortCommitSha
+            String commitText = isCommitInDifferentRepo
+                    ? commitRepoOwner + "/" + commitRepoName + "#" + shortCommitSha
                     : shortCommitSha;
             text.replace(pos, pos + 8, commitText);
 
-            String finalRepoOwner = repoOwner;
-            String finalRepoName = repoName;
+            String finalRepoOwner = commitRepoOwner;
+            String finalRepoName = commitRepoName;
             text.setSpan(new IntentSpan(mContext, context ->
                     CommitActivity.makeIntent(context, finalRepoOwner, finalRepoName, event.commitId())), pos, pos + commitText.length(), 0);
             text.setSpan(new TypefaceSpan("monospace"), pos, pos + commitText.length(), 0);
         }
+    }
 
-        pos = text.toString().indexOf("[label]");
+    private void replaceLabelPlaceholder(IssueEvent event, SpannableStringBuilder text) {
+        int pos = text.toString().indexOf("[label]");
         Label label = event.label();
         if (label != null && pos >= 0) {
             int length = label.name().length();
             text.replace(pos, pos + 7, label.name());
             text.setSpan(new IssueLabelSpan(mContext, label, false), pos, pos + length, 0);
         }
+    }
 
-        pos = text.toString().indexOf("[bot]");
+    private void replaceBotPlaceholder(SpannableStringBuilder text) {
+        int pos = text.toString().indexOf("[bot]");
         if (pos >= 0) {
             text.delete(pos, pos + 5);
             StringUtils.addUserTypeSpan(mContext, text, pos, mContext.getString(R.string.user_type_bot));
         }
+    }
 
-        pos = text.toString().indexOf("[source]");
+    private void replaceSourcePlaceholder(IssueEvent event, SpannableStringBuilder text) {
+        int pos = text.toString().indexOf("[source]");
         if (pos >= 0) {
             final Issue source = event.source().issue();
             var sourceRepoOwnerAndName = ApiHelpers.extractRepoOwnerAndNameFromIssue(source);
@@ -315,25 +330,24 @@ class EventViewHolder
                     : "#" + source.number();
             text.replace(pos, pos + 8, sourceLabel);
             text.setSpan(new IntentSpan(mContext, context ->
-                source.pullRequest() != null
-                    ? PullRequestActivity.makeIntent(context, sourceRepoOwner, sourceRepoName, source.number())
-                    : IssueActivity.makeIntent(context, sourceRepoOwner, sourceRepoName, source.number())
+                    source.pullRequest() != null
+                            ? PullRequestActivity.makeIntent(context, sourceRepoOwner, sourceRepoName, source.number())
+                            : IssueActivity.makeIntent(context, sourceRepoOwner, sourceRepoName, source.number())
             ), pos, pos + sourceLabel.length(), 0);
         }
+    }
 
-        CharSequence time = event.createdAt() != null
-                ? StringUtils.formatRelativeTime(mContext, event.createdAt(), true) : "";
-
-        pos = text.toString().indexOf("[time]");
+    private void replaceTimePlaceholder(IssueEvent event, SpannableStringBuilder text) {
+        int pos = text.toString().indexOf("[time]");
         if (pos >= 0) {
+            CharSequence time = event.createdAt() != null
+                    ? StringUtils.formatRelativeTime(mContext, event.createdAt(), true) : "";
             text.replace(pos, pos + 6, time);
             if (event.createdAt() != null) {
                 text.setSpan(new TimestampToastSpan(event.createdAt()), pos,
                         pos + time.length(), 0);
             }
         }
-
-        return text;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -289,7 +289,7 @@
     <string name="issue_event_closed_with_commit">[b]%1$s[/b] closed this issue in [commit] [time]</string>
     <string name="issue_event_reopened">[b]%1$s[/b] reopened this issue [time]</string>
     <string name="issue_event_referenced">[b]%1$s[/b] referenced this issue [time]</string>
-    <string name="issue_event_referenced_with_commit">[b]%1$s[/b] added commit [commit] that referenced this issue [time]</string>
+    <string name="issue_event_referenced_with_commit">[b]%1$s[/b] referenced this issue in commit [commit] [time]</string>
     <string name="issue_event_assigned">[b]%1$s[/b] assigned [b]%2$s[/b] [time]</string>
     <string name="issue_event_assigned_self">[b]%1$s[/b] self-assigned this issue [time]</string>
     <string name="issue_event_unassigned">[b]%1$s[/b] unassigned [b]%2$s[/b] [time]</string>
@@ -310,7 +310,7 @@
     <string name="pull_request_event_merged">[b]%1$s[/b] merged this pull request [time]</string>
     <string name="pull_request_event_merged_with_commit">[b]%1$s[/b] merged this pull request as commit [commit] [time]</string>
     <string name="pull_request_event_referenced">[b]%1$s[/b] referenced this pull request [time]</string>
-    <string name="pull_request_event_referenced_with_commit">[b]%1$s[/b] added commit [commit] that referenced this pull request [time]</string>
+    <string name="pull_request_event_referenced_with_commit">[b]%1$s[/b] referenced this pull request in commit [commit] [time]</string>
     <string name="pull_request_event_assigned_self">[b]%1$s[/b] self-assigned this pull request [time]</string>
     <string name="pull_request_event_review_approved">[b]%1$s[/b] approved these changes [time]</string>
     <string name="pull_request_event_review_requested_changes">[b]%1$s[/b] requested changes [time]</string>


### PR DESCRIPTION
This PR makes the following improvements to the way `referenced` and `cross-referenced` timeline events are displayed:
- `referenced`: display also repository owner and name together with the SHA of the commit that referenced the issue/PR, if it belongs to another repository.
I've also reworded the message for the event since I've discovered that references from commit comments (and not only from commit messages) appear as `referenced` events too (see [this](https://github.com/PowerShell/PowerShell/pull/16840#ref-commit-f8168cb) for an example), and therefore the message _"added commit [] that referenced this issue"_ could have been misleading.
- `cross-referenced`: display also repository owner and name together with the number of the issue that referenced the issue/PR, if it belongs to another repository (like GitHub does, e.g. `dotnet/runtime#12456`).

I've also extracted a few methods to improve code readability.