### PR TITLE
Fix incorrect handling of release assets links

### DIFF
--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -218,9 +218,11 @@ public class LinkParser {
         return new ParseResult(SearchActivity.makeIntent(activity, query, typeInt, true));
     }
 
-    @NonNull
     private static ParseResult parseReleaseLink(FragmentActivity activity, Uri uri,
             List<String> parts, String user, String repo, String id) {
+        if ("download".equals(id)) {
+            return null;
+        }
         if ("tag".equals(id)) {
             final String release = parts.size() >= 5 ? parts.get(4) : null;
             if (release != null) {

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -520,8 +520,7 @@ public class LinkParserTest {
     }
 
     @Test
-    public void pullRequestLink_withDiffMarker_andInvalidNumber__opensPullRequest() throws
-            Exception {
+    public void pullRequestLink_withDiffMarker_andInvalidNumber__opensPullRequest() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
                         "#diff-38f43208e0c158ca7b78e175b8846bc6LA3");

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -253,6 +253,11 @@ public class LinkParserTest {
     }
 
     @Test
+    public void releaseAssetLink__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/slapperwan/gh4a/releases/download/4.6.7/release.apk"));
+    }
+
+    @Test
     public void releaseLink_withoutTagId__opensReleaseListActivity() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/releases/tag");


### PR DESCRIPTION
I've discovered by chance that the app handles links to release assets (e.g. https://github.com/slapperwan/gh4a/releases/download/4.6.7/gh4a-467-release.apk) incorrectly, causing a redirect to the Releases list screen.
I've changed the behavior so that those links don't get handled and the browser is opened instead, so that the user can download the file.