### PR TITLE
Optimize image loading by avoiding redundant file read/writes

### DIFF
--- a/app/src/main/java/com/gh4a/utils/FileUtils.java
+++ b/app/src/main/java/com/gh4a/utils/FileUtils.java
@@ -43,35 +43,6 @@ public class FileUtils {
         MIME_TYPE_OVERRIDES.put("bat", "text/plain");
     }
 
-    public static boolean save(File file, InputStream inputStream) {
-        OutputStream out = null;
-        try {
-            out = new FileOutputStream(file);
-            int read;
-            byte[] bytes = new byte[1024];
-
-            while ((read = inputStream.read(bytes)) != -1) {
-                out.write(bytes, 0, read);
-            }
-            return true;
-        } catch (IOException e) {
-            Log.e(Gh4Application.LOG_TAG, e.getMessage(), e);
-        } finally {
-            try {
-                if (inputStream != null) {
-                    inputStream.close();
-                }
-                if (out != null) {
-                    out.flush();
-                    out.close();
-                }
-            } catch (IOException e) {
-                Log.e(Gh4Application.LOG_TAG, e.getMessage(), e);
-            }
-        }
-        return false;
-    }
-
     public static String getFileExtension(String filename) {
         int mid = filename.lastIndexOf(".");
         if (mid == -1) {

--- a/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
+++ b/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
@@ -31,6 +31,7 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.ImageSpan;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.TextView;
@@ -466,6 +467,7 @@ public class HttpImageGetter {
                     }
                 }
             } catch (IOException e) {
+                Log.e(Gh4Application.LOG_TAG, "Couldn't display image " + url, e);
                 // fall through to showing the error bitmap
             }
         }


### PR DESCRIPTION
While I was taking a look at how the app fetches images in comments and Readmes, I was surprised to discover that before rendering, images were being written to a temporary file just to be read from it immediately after.
Among a couple of small refactorings, the PR changes the logic to avoid this unnecessary and inefficient step, which also spares us quite a bit of boilerplate error handling code.