### PR TITLE
A couple of small MIME type detection fixes

### DIFF
--- a/app/src/main/java/com/gh4a/utils/FileUtils.java
+++ b/app/src/main/java/com/gh4a/utils/FileUtils.java
@@ -120,10 +120,11 @@ public class FileUtils {
         if (StringUtils.isBlank(extension)) {
             return null;
         }
-        if (MIME_TYPE_OVERRIDES.containsKey(extension)) {
-            return MIME_TYPE_OVERRIDES.get(extension);
+        String lowercasedExt = extension.toLowerCase(Locale.US);
+        if (MIME_TYPE_OVERRIDES.containsKey(lowercasedExt)) {
+            return MIME_TYPE_OVERRIDES.get(lowercasedExt);
         }
-        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(lowercasedExt);
     }
 
     private static boolean isExtensionIn(String filename, List<String> extensions) {

--- a/app/src/main/java/com/gh4a/utils/FileUtils.java
+++ b/app/src/main/java/com/gh4a/utils/FileUtils.java
@@ -33,6 +33,7 @@ public class FileUtils {
         // JavaScript can be resolved to both text/javascript and application/javascript,
         // for our purposes it's text in any case
         MIME_TYPE_OVERRIDES.put("js", "text/javascript");
+        MIME_TYPE_OVERRIDES.put("mjs", "text/javascript");
         // Same for Ruby, LaTeX, SQL, JSON
         MIME_TYPE_OVERRIDES.put("rb", "text/x-ruby");
         MIME_TYPE_OVERRIDES.put("latex", "text/x-latex");


### PR DESCRIPTION
This PR includes the following fixes:
- .mjs files (ES Modules) won't be recognized as binary files anymore on Android 11+ (#1177) and will therefore be opened in the in-app code viewer
- when querying the MIME type overrides map, we were assuming that the extension was always lowercased, and therefore a `.bat` file would have been opened in-app whereas a `.BAT` file would have been opened in the browser.
We now always use the lowercased extension to avoid this issue.

Fixes #1177