### PR TITLE
A few fixes to the repositories list

### DIFF
--- a/app/src/main/java/com/gh4a/activities/RepositoryListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryListActivity.java
@@ -116,6 +116,7 @@ public class RepositoryListActivity extends FragmentContainerActivity implements
         String type = mFilterDrawerHelper.handleSelectionAndGetFilterType(item);
         if (type != null) {
             mFragment.setFilterType(type);
+            mSortDrawerHelper.setFilterType(type);
             super.supportInvalidateOptionsMenu();
             updateRightNavigationDrawer();
             return true;

--- a/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryListContainerFragment.java
@@ -192,6 +192,9 @@ public class RepositoryListContainerFragment extends Fragment implements
         }
 
         switch (mFilterType) {
+            case "starred":
+                mMainFragment = StarredRepositoryListFragment.newInstance(mUserLogin);
+                break;
             case "watched":
                 mMainFragment = WatchedRepositoryListFragment.newInstance(mUserLogin);
                 break;
@@ -365,6 +368,7 @@ public class RepositoryListContainerFragment extends Fragment implements
             FILTER_LOOKUP.put(R.id.filter_type_sources, "sources");
             FILTER_LOOKUP.put(R.id.filter_type_forks, "forks");
             FILTER_LOOKUP.put(R.id.filter_type_watched, "watched");
+            FILTER_LOOKUP.put(R.id.filter_type_starred, "starred");
         }
 
         public static FilterDrawerHelper create(String userLogin, boolean isOrg) {
@@ -427,7 +431,7 @@ public class RepositoryListContainerFragment extends Fragment implements
         }
 
         public int getMenuResId() {
-            return TextUtils.equals(mFilterType, "watched") ? 0 : R.menu.repo_sort;
+            return "watched".equals(mFilterType) || "starred".equals(mFilterType) ? 0 : R.menu.repo_sort;
         }
 
         public void selectSortType(Menu menu, String order, String direction,

--- a/app/src/main/res/menu/repo_filter_org.xml
+++ b/app/src/main/res/menu/repo_filter_org.xml
@@ -7,26 +7,11 @@
                     android:id="@+id/filter_type_all"
                     android:title="@string/repo_type_all" />
                 <item
-                    android:id="@+id/filter_type_member"
-                    android:title="@string/repo_type_member" />
-                <item
-                    android:id="@+id/filter_type_public"
-                    android:title="@string/repo_type_public" />
-                <item
-                    android:id="@+id/filter_type_private"
-                    android:title="@string/repo_type_private" />
-                <item
                     android:id="@+id/filter_type_sources"
                     android:title="@string/repo_type_sources" />
                 <item
                     android:id="@+id/filter_type_forks"
                     android:title="@string/repo_type_forks" />
-                <item
-                    android:id="@+id/filter_type_watched"
-                    android:title="@string/repo_type_watched" />
-                <item
-                    android:id="@+id/filter_type_starred"
-                    android:title="@string/repo_type_starred" />
             </group>
         </menu>
     </item>


### PR DESCRIPTION
I've found and fixed a few bugs in the user repositories list screen, specifically:
- b56fdd4 accidentally broke the ability to list starred repositories of other users (the "Starred" filter did nothing)
- several repository list filters weren't working for organizations, because either didn't make sense (Starred, Watched, Member) or aren't supported by [the API endpoint we're using](https://docs.github.com/en/rest/reference/repos#list-repositories-for-a-user) (Public, Private). Those broken filters have been removed.
- available sorting options in the right navigation drawer weren't correctly refreshed when selecting the "Watched" or "Starred" filter. This bug affected only the repositories list screen of other users (not the "My repositories" screen of the home activity).