### PR TITLE
Remove workaround for releases API sorting misbehavior

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,14 +54,12 @@ android {
     }
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference:1.1.1'

--- a/app/src/main/java/com/gh4a/fragment/ReleaseListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ReleaseListFragment.java
@@ -13,22 +13,13 @@ import com.meisolsson.githubsdk.model.Page;
 import com.meisolsson.githubsdk.model.Release;
 import com.meisolsson.githubsdk.service.repositories.RepositoryReleaseService;
 
-import java.util.Collections;
-import java.util.Comparator;
-
 import io.reactivex.Single;
 import retrofit2.Response;
-
-import static java.util.Comparator.reverseOrder;
-import static java.util.Comparator.nullsFirst;
 
 public class ReleaseListFragment extends PagedDataBaseFragment<Release> implements
         RootAdapter.OnItemClickListener<Release> {
     private String mUserLogin;
     private String mRepoName;
-
-    private static final Comparator<Release> MOST_RECENT_RELEASES_AND_DRAFTS_FIRST =
-            Comparator.comparing(Release::publishedAt, nullsFirst(reverseOrder()));
 
     public static ReleaseListFragment newInstance(String owner, String repo) {
         ReleaseListFragment f = new ReleaseListFragment();
@@ -48,16 +39,9 @@ public class ReleaseListFragment extends PagedDataBaseFragment<Release> implemen
 
     @Override
     protected Single<Response<Page<Release>>> loadPage(int page, boolean bypassCache) {
-        final RepositoryReleaseService service = ServiceFactory.get(RepositoryReleaseService.class, bypassCache);
-        return service.getReleases(mUserLogin, mRepoName, page)
-                // Sometimes the API returns releases in a slightly wrong order (see TeamNewPipe/NewPipe repo
-                // for an example), so we need to fix the sorting locally
-                .map(response -> {
-                    if (response.body() != null) {
-                        Collections.sort(response.body().items(), MOST_RECENT_RELEASES_AND_DRAFTS_FIRST);
-                    }
-                    return response;
-                });
+        final RepositoryReleaseService service =
+                ServiceFactory.get(RepositoryReleaseService.class, bypassCache);
+        return service.getReleases(mUserLogin, mRepoName, page);
     }
 
     @Override


### PR DESCRIPTION
I've noticed that the sorting issue of the Releases API we worked around in #1112 has been fixed on GitHub side.
I asked to GH support for confirmation and they told me that "the fix was rolled out late last month". :tada: 
Therefore this PR removes the workaround since it's not needed anymore.