### PR TITLE
Show file stats (additions/deletions) when full diff is not available

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/CommitFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/CommitFragment.java
@@ -272,7 +272,7 @@ public class CommitFragment extends LoadingFragmentBase implements OnClickListen
     private void fillFileStats(View fileView, GitHubFile file, ForegroundColorSpan additionsSpan,
             ForegroundColorSpan deletionsSpan) {
         TextView statsView = fileView.findViewById(R.id.stats);
-        if (file.patch() != null) {
+        if (file.additions() > 0 || file.deletions() > 0) {
             SpannableStringBuilder stats = new SpannableStringBuilder();
             stats.append("+").append(String.valueOf(file.additions()));
             int addLength = stats.length();


### PR DESCRIPTION
Previously, added/removed lines weren't shown when the GitHub API didn't return the full diff of a file (most often because it was too big).
Additions/deletions are always returned by the API, even for non-text files (in those cases they will be both set to 0).