### PR TITLE
Show "History" but not "Download" context menu entries for submodules

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/FileAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/FileAdapter.java
@@ -29,10 +29,11 @@ import com.gh4a.utils.FileUtils;
 import com.meisolsson.githubsdk.model.Content;
 import com.meisolsson.githubsdk.model.ContentType;
 
+import java.util.Collections;
 import java.util.Set;
 
 public class FileAdapter extends RootAdapter<Content, FileAdapter.ViewHolder> {
-    private Set<String> mSubModuleNames;
+    private Set<String> mSubModuleNames = Collections.emptySet();
 
     public FileAdapter(Context context) {
         super(context);
@@ -52,7 +53,7 @@ public class FileAdapter extends RootAdapter<Content, FileAdapter.ViewHolder> {
     @Override
     public void onBindViewHolder(ViewHolder holder, Content content) {
         String name = content.name();
-        boolean isSubModule = mSubModuleNames != null && mSubModuleNames.contains(name);
+        boolean isSubModule = mSubModuleNames.contains(name);
 
         holder.icon.setBackgroundResource(getIconId(content.type(), name));
         holder.fileName.setText(name);

--- a/app/src/main/java/com/gh4a/fragment/ContentListContainerFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ContentListContainerFragment.java
@@ -36,6 +36,7 @@ import com.philosophicalhacker.lib.RxLoader;
 
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -258,7 +259,7 @@ public class ContentListContainerFragment extends Fragment implements
     @Override
     public Set<String> getSubModuleNames(ContentListFragment fragment) {
         if (mGitModuleMap == null) {
-            return null;
+            return Collections.emptySet();
         }
 
         String prefix = TextUtils.isEmpty(fragment.getPath()) ? null : fragment.getPath() + "/";

--- a/app/src/main/java/com/gh4a/fragment/ContentListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ContentListFragment.java
@@ -165,15 +165,13 @@ public class ContentListFragment extends ListDataBaseFragment<Content> implement
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);
 
-        ContextMenuAwareRecyclerView.RecyclerContextMenuInfo info =
-                (ContextMenuAwareRecyclerView.RecyclerContextMenuInfo) menuInfo;
+        var info = (ContextMenuAwareRecyclerView.RecyclerContextMenuInfo) menuInfo;
         Content contents = mAdapter.getItemFromAdapterPosition(info.position);
         Set<String> subModules = mCallback.getSubModuleNames(this);
+        boolean isSubModule = subModules != null && subModules.contains(contents.name());
 
-        if (subModules == null || !subModules.contains(contents.name())) {
-            menu.add(Menu.NONE, R.id.history, Menu.NONE, R.string.history);
-        }
-        if (contents.type() == ContentType.File) {
+        menu.add(Menu.NONE, R.id.history, Menu.NONE, R.string.history);
+        if (contents.type() == ContentType.File && !isSubModule) {
             menu.add(Menu.NONE, R.id.download, Menu.NONE, R.string.download);
         }
     }

--- a/app/src/main/java/com/gh4a/fragment/ContentListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ContentListFragment.java
@@ -168,7 +168,7 @@ public class ContentListFragment extends ListDataBaseFragment<Content> implement
         var info = (ContextMenuAwareRecyclerView.RecyclerContextMenuInfo) menuInfo;
         Content contents = mAdapter.getItemFromAdapterPosition(info.position);
         Set<String> subModules = mCallback.getSubModuleNames(this);
-        boolean isSubModule = subModules != null && subModules.contains(contents.name());
+        boolean isSubModule = subModules.contains(contents.name());
 
         menu.add(Menu.NONE, R.id.history, Menu.NONE, R.string.history);
         if (contents.type() == ContentType.File && !isSubModule) {


### PR DESCRIPTION
This PR makes a couple of small adjustments to the available context menu entries for submodules in files list:
- "Download" entry does not work (and doesn't make much sense for a submodule) and thus has been removed
- "History" entry was previously hidden for submodules, but I've discovered that works as intended and can be useful to see all commits in which a submodule has been updated

I've also made an extra commit to get rid of a few null checks by returning an empty collection instead of null.