### PR TITLE
Shorten F-Droid short description + Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Main features
 
 How to Build Octodroid
 ----------------------
-- Ensure Android SDK platform version 26 and build-tools version 26.0.2 are installed
+- Ensure Android SDK platform and build-tools are installed
 - Register an application for your OctoDroid usage under your [GitHub settings](https://github.com/settings/developers)
   * naming is up to you
   * callback URL must be gh4a://oauth

--- a/metadata/en-US/short_description.txt
+++ b/metadata/en-US/short_description.txt
@@ -1,1 +1,1 @@
-OctoDroid provides access to GitHub and the ability to stay connected with your networks.
+Provides access to GitHub and lets you stay connected with your network


### PR DESCRIPTION
I've made the F-Droid _short_description_ of the app more concise, as it is currently getting truncated on the [website](https://f-droid.org/packages/com.gh4a/).

Also, I've found out that build instructions in Readme referenced a specific SDK and build-tools version. I've decided to remove the version since it will keep changing in the future anyway, and it's too easy to forget to keep the Readme in sync.