### PR TITLE
Improve text sizes in Markdown rendering

### DIFF
--- a/app/src/main/java/com/gh4a/utils/HtmlUtils.java
+++ b/app/src/main/java/com/gh4a/utils/HtmlUtils.java
@@ -232,7 +232,7 @@ public class HtmlUtils {
 
     private static class HtmlToSpannedConverter implements ContentHandler {
         private static final float[] HEADING_SIZES = {
-            1.5f, 1.4f, 1.3f, 1.2f, 1.1f, 1f,
+            1.75f, 1.5f, 1.25f, 1.1f, 1f, 0.9f
         };
         private static final float SMALL_TEXT_SIZE = 0.8f;
 

--- a/app/src/main/java/com/gh4a/utils/HtmlUtils.java
+++ b/app/src/main/java/com/gh4a/utils/HtmlUtils.java
@@ -234,6 +234,7 @@ public class HtmlUtils {
         private static final float[] HEADING_SIZES = {
             1.5f, 1.4f, 1.3f, 1.2f, 1.1f, 1f,
         };
+        private static final float SMALL_TEXT_SIZE = 0.8f;
 
         private final float mDividerHeight;
         private final int mBulletMargin;
@@ -484,10 +485,10 @@ public class HtmlUtils {
                 endBlockElement();
             } else if (tag.equalsIgnoreCase("ul")) {
                 endBlockElement();
-                end(List.class, null);
+                end(List.class);
             } else if (tag.equalsIgnoreCase("ol")) {
                 endBlockElement();
-                end(List.class, null);
+                end(List.class);
             } else if (tag.equalsIgnoreCase("li")) {
                 endLi();
             } else if (tag.equalsIgnoreCase("div")) {
@@ -517,7 +518,7 @@ public class HtmlUtils {
             } else if (tag.equalsIgnoreCase("big")) {
                 end(Big.class, new RelativeSizeSpan(1.25f));
             } else if (tag.equalsIgnoreCase("small")) {
-                end(Small.class, new RelativeSizeSpan(0.8f));
+                end(Small.class, new RelativeSizeSpan(SMALL_TEXT_SIZE));
             } else if (tag.equalsIgnoreCase("font")) {
                 endFont();
             } else if (tag.equalsIgnoreCase("blockquote")) {
@@ -537,9 +538,9 @@ public class HtmlUtils {
             } else if (tag.equalsIgnoreCase("strike")) {
                 end(Strikethrough.class, new StrikethroughSpan());
             } else if (tag.equalsIgnoreCase("sup")) {
-                end(Super.class, new SuperscriptSpan());
+                end(Super.class, new SuperscriptSpan(), new RelativeSizeSpan(SMALL_TEXT_SIZE));
             } else if (tag.equalsIgnoreCase("sub")) {
-                end(Sub.class, new SubscriptSpan());
+                end(Sub.class, new SubscriptSpan(), new RelativeSizeSpan(SMALL_TEXT_SIZE));
             } else if (tag.equalsIgnoreCase("code")) {
                 Code code = getLast(Code.class);
                 if (code != null) {
@@ -757,10 +758,10 @@ public class HtmlUtils {
             mSpannableStringBuilder.setSpan(mark, len, len, Spannable.SPAN_INCLUSIVE_EXCLUSIVE);
         }
 
-        private void end(Class<?> kind, Object repl) {
+        private void end(Class<?> kind, Object... spans) {
             Object obj = getLast(kind);
             if (obj != null) {
-                setSpanFromMark(obj, repl);
+                setSpanFromMark(obj, spans);
             }
         }
 


### PR DESCRIPTION
I've made a couple of adjustments regarding text sizes to Markdown rendering in comments/Readme:
- <sub>subscript</sub>/<sup>superscript</sup> text is now smaller, to make it look as it does in GitHub web UI
- sizes of H1 to H6 has been changed to make the different types of heading more clearly distinguishable. Previously I had a hard time finding the difference between an H1 and an H2, or between an H2 and an H3. You can see below the difference:
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/169643728-46f11b65-0d71-4994-b734-b0c270912a11.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/169643743-45a65247-7c58-433f-921e-3980ba9937ba.png" /></td></tr>
</table>