### PR TITLE
A couple of regression fixes and link handling improvements

### DIFF
--- a/app/src/main/java/com/gh4a/activities/IssueActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueActivity.java
@@ -89,7 +89,7 @@ public class IssueActivity extends BaseActivity implements
     private final ActivityResultLauncher<Intent> mEditIssueLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(),
             new ActivityResultHelpers.ActivityResultSuccessCallback(() -> {
-                loadIssue(true);
+                onRefresh();
                 setResult(RESULT_OK);
             }));
 

--- a/app/src/main/java/com/gh4a/utils/IntentUtils.java
+++ b/app/src/main/java/com/gh4a/utils/IntentUtils.java
@@ -20,6 +20,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.fragment.app.FragmentActivity;
+
 import android.widget.Toast;
 
 import com.gh4a.BaseActivity;
@@ -44,7 +46,7 @@ public class IntentUtils {
     private IntentUtils() {
     }
 
-    public static void openLinkInternallyOrExternally(BaseActivity activity, Uri uri) {
+    public static void openLinkInternallyOrExternally(FragmentActivity activity, Uri uri) {
         String uriScheme = uri.getScheme();
         if (uriScheme == null || uriScheme.equals("file") || uriScheme.equals("content")) {
             // We can't do anything about relative or anchor URLs here, and there are no good reasons to
@@ -63,12 +65,13 @@ public class IntentUtils {
         }
 
         LinkParser.ParseResult result = LinkParser.parseUri(activity, uri, null);
+        int headerColor = activity instanceof BaseActivity ? ((BaseActivity) activity).getCurrentHeaderColor() : 0;
         if (result == null) {
-            openInCustomTabOrBrowser(activity, uri, activity.getCurrentHeaderColor());
+            openInCustomTabOrBrowser(activity, uri, headerColor);
         } else if (result.intent != null) {
             activity.startActivity(result.intent);
         } else if (result.loadTask != null) {
-            result.loadTask.setOpenUnresolvedUriInCustomTab(activity.getCurrentHeaderColor());
+            result.loadTask.setOpenUnresolvedUriInCustomTab(headerColor);
             result.loadTask.execute();
         }
     }

--- a/app/src/main/java/com/gh4a/widget/LinkSpan.java
+++ b/app/src/main/java/com/gh4a/widget/LinkSpan.java
@@ -4,10 +4,10 @@ import android.net.Uri;
 import android.text.style.ClickableSpan;
 import android.view.View;
 
-import com.gh4a.BaseActivity;
 import com.gh4a.utils.IntentUtils;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
 
 public class LinkSpan extends ClickableSpan {
     private final String mUrl;
@@ -19,7 +19,7 @@ public class LinkSpan extends ClickableSpan {
     @Override
     public void onClick(@NonNull View widget) {
         Uri clickedUri = Uri.parse(mUrl);
-        BaseActivity activity = (BaseActivity) widget.getContext();
+        var activity = (FragmentActivity) widget.getContext();
         IntentUtils.openLinkInternallyOrExternally(activity, clickedUri);
     }
 }

--- a/app/src/main/java/com/gh4a/widget/MarkdownPreviewWebView.java
+++ b/app/src/main/java/com/gh4a/widget/MarkdownPreviewWebView.java
@@ -1,22 +1,30 @@
 package com.gh4a.widget;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.Context;
+
 import androidx.core.view.NestedScrollingChild2;
 import androidx.core.view.NestedScrollingChildHelper;
 import androidx.core.view.ViewCompat;
+import androidx.fragment.app.FragmentActivity;
+
+import android.net.Uri;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.webkit.JavascriptInterface;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.EditText;
 
 import com.gh4a.R;
 import com.gh4a.activities.WebViewerActivity;
 import com.gh4a.utils.HtmlUtils;
+import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.StringUtils;
 
 public class MarkdownPreviewWebView extends WebView implements NestedScrollingChild2 {
@@ -46,8 +54,26 @@ public class MarkdownPreviewWebView extends WebView implements NestedScrollingCh
 
         if (!isInEditMode()) {
             initWebViewSettings(getSettings());
+            setWebViewClient(getUrlHandlingClient());
             setContent("");
         }
+    }
+
+    private WebViewClient getUrlHandlingClient() {
+        return new WebViewClient() {
+            @Override
+            @TargetApi(24)
+            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                IntentUtils.openLinkInternallyOrExternally((FragmentActivity) getContext(), request.getUrl());
+                return true;
+            }
+
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                IntentUtils.openLinkInternallyOrExternally((FragmentActivity) getContext(), Uri.parse(url));
+                return true;
+            }
+        };
     }
 
     public void setEditText(EditText editor) {
@@ -168,6 +194,7 @@ public class MarkdownPreviewWebView extends WebView implements NestedScrollingCh
         s.setLoadsImagesAutomatically(true);
         s.setJavaScriptEnabled(true);
         s.setUseWideViewPort(false);
+        s.setAllowFileAccess(false);
     }
 
     private void setContent(String content) {

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -4,6 +4,8 @@
     <color name="primary_dark">#2d501e</color>
     <color name="accent">#559639</color>
 
+    <color name="link_text">@color/accent</color>
+
     <color name="label_fg">@color/label_fg_light</color>
 
     <color name="issue_open">#396426</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,7 +2,9 @@
 <resources>
     <color name="primary">#65b345</color>
     <color name="primary_dark">#5aa03d</color>
-    <color name="accent">@color/primary_dark</color>
+    <color name="accent">@color/primary</color>
+
+    <color name="link_text">@color/primary_dark</color>
 
     <color name="label_fg_dark">#ff000000</color>
     <color name="label_fg_light">#fff3f3f3</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,8 @@
         <item name="cardViewTheme">@style/CardView.DayNight</item>
         <item name="inlineButtonStyle">@style/Widget.MaterialComponents.Button.TextButton</item>
 
+        <item name="android:textColorLink">@color/link_text</item>
+
         <item name="colorAccent">@color/accent</item>
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary_dark</item>


### PR DESCRIPTION
This PR fixes the following small regressions:
- issue conversation wasn't being refreshed anymore after editing the issue, introduced by #1193 
- #1114 accidentally made the accent color slightly darker for light theme, causing icons and some headings to have a darker tone of green

The PR also extends the improved link-handling logic introduced in #1118 to Markdown previews (724cf56 was needed for it to work in the comment editor) and disabled WebView filesystem access for them as we did in #1180.