### PR TITLE
Fix regression when marking notifications as read

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -17,7 +17,6 @@ import com.gh4a.ServiceFactory;
 import com.gh4a.activities.RepositoryActivity;
 import com.gh4a.adapter.NotificationAdapter;
 import com.gh4a.adapter.RootAdapter;
-import com.gh4a.resolver.LinkParser;
 import com.gh4a.worker.NotificationsWorker;
 import com.gh4a.model.NotificationHolder;
 import com.gh4a.resolver.BrowseFilter;
@@ -138,26 +137,15 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
             String url = subject.url();
             if (url != null) {
                 Uri uri = ApiHelpers.normalizeUri(Uri.parse(url));
-                IntentUtils.InitialCommentMarker initialComment =
-                        new IntentUtils.InitialCommentMarker(item.notification.lastReadAt());
-                LinkParser.ParseResult result = LinkParser.parseUri(getActivity(), uri, initialComment);
-                if (result != null && result.intent != null) {
-                    intent = result.intent;
-                } else {
-                    // We either can't handle the URL ourselves or need to resolve it
-                    // asynchronously. Pass it to the BrowseFilter for resolving or redirection
-                    intent = BrowseFilter.makeRedirectionIntent(getActivity(), uri, initialComment);
-                    // Only auto-mark the notification as read if we can handle the URL ourselves
-                    if (result != null) {
-                        markAsRead(null, item.notification);
-                    }
-                }
+                intent = BrowseFilter.makeRedirectionIntent(getActivity(), uri,
+                        new IntentUtils.InitialCommentMarker(item.notification.lastReadAt()));
             } else {
                 intent = null;
             }
         }
 
         if (intent != null) {
+            markAsRead(null, item.notification);
             startActivity(intent);
         }
     }


### PR DESCRIPTION
74e01129 introduced a regression that caused notifications not being marked as read after opening them in most cases:

https://github.com/slapperwan/gh4a/blob/74e01129f3f1df50451afaf28808dbacc1cd84e8/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java#L143-L146

When the above `if` condition is true, the notification is not marked as read.

This PR proposes a simpler fix for #1208 since the problem with "unsupported" notifications (like discussion ones) is that they don't have a URL, because if they had it, the URL would be opened in a browser/custom tab instead of doing nothing.

I've tested this fix with a PR notification and a discussion notification and it behaved as expected.