### PR TITLE
Fix a few smallish bugs

### DIFF
--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -19,9 +19,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -49,7 +46,9 @@ import com.meisolsson.githubsdk.service.repositories.RepositoryReleaseService;
 
 import java.util.Date;
 
-import io.reactivex.disposables.Disposable;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class ReleaseInfoActivity extends BaseActivity implements
         View.OnClickListener, SwipeRefreshLayout.ChildScrollDelegate,
@@ -76,7 +75,6 @@ public class ReleaseInfoActivity extends BaseActivity implements
     private Release mRelease;
     private long mReleaseId;
 
-    private Disposable mBodySubscription;
     private View mRootView;
     private HttpImageGetter mImageGetter;
 
@@ -140,16 +138,17 @@ public class ReleaseInfoActivity extends BaseActivity implements
     }
 
     @Override
+    protected boolean canSwipeToRefresh() {
+        // Allow refresh only when the release is not passed via intent extras
+        return mReleaseId != 0;
+    }
+
+    @Override
     public void onRefresh() {
-        if (!getIntent().hasExtra("release")) {
-            mRelease = null;
-            setContentShown(false);
-            mImageGetter.clearHtmlCache();
-            if (mBodySubscription != null) {
-                mBodySubscription.dispose();
-            }
-            loadRelease(true);
-        }
+        mRelease = null;
+        setContentShown(false);
+        mImageGetter.clearHtmlCache();
+        loadRelease(true);
         super.onRefresh();
     }
 

--- a/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
@@ -150,6 +150,10 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
     }
 
     private void updateTitle() {
+        // The repository may have been moved or renamed, so we want to make sure that
+        // the title matches the current name of the repository
+        mActionBar.setTitle(mRepository.fullName());
+
         mActionBar.setSubtitle(getCurrentRef());
         invalidateFragments();
     }

--- a/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
@@ -120,7 +120,7 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
 
         setContentShown(false);
 
-        loadRepository(false);
+        loadRepository();
     }
 
     @Override
@@ -243,7 +243,7 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
         clearRefDependentFragments();
         setContentShown(false);
         invalidateTabs();
-        loadRepository(true);
+        loadRepository();
         super.onRefresh();
     }
 
@@ -349,11 +349,14 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
         mCommitListFragment = null;
     }
 
-    private void loadRepository(boolean force) {
-        RepositoryService service = ServiceFactory.get(RepositoryService.class, force);
+    private void loadRepository() {
+        // We always skip the cache in this case, since the repository endpoint incorrectly returns the
+        // same ETag even if some fields are changed (like the open issues count and the watchers count)
+        boolean skipCache = true;
+        RepositoryService service = ServiceFactory.get(RepositoryService.class, skipCache);
         service.getRepository(mRepoOwner, mRepoName)
                 .map(ApiHelpers::throwOnFailure)
-                .compose(makeLoaderSingle(ID_LOADER_REPO, force))
+                .compose(makeLoaderSingle(ID_LOADER_REPO, skipCache))
                 .subscribe(result -> {
                     mRepository = result;
                     updateTitle();

--- a/app/src/main/res/layout/error.xml
+++ b/app/src/main/res/layout/error.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/error"
     android:layout_width="match_parent"
@@ -18,6 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:autoLink="web"
+        app:needsLinkHandling="true"
         android:gravity="center_horizontal|top"
         android:paddingBottom="8dp"
         android:paddingLeft="16dp"


### PR DESCRIPTION
This PR fixes #886 by skipping the cache for the API call that retrieves the repository details.
I've also added a few more fixes:
- when opening a renamed/moved repository from a link with the older name (e.g. https://github.com/k9mail/k-9), the repo name in the title bar will be updated with the actual repository name instead of displaying the older name
- added a missing `needsLinkHandling` attribute that made impossible to open links found in the loading error message (an example of an error message containing links is the DMCA takedown notice)
- swipe-to-refresh in the Release details screen has been disabled in all cases in which it did nothing (that is, when the release was passed via intent extras)