### PR TITLE
Display issue closed reason in timeline events

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/timeline/EventViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/EventViewHolder.java
@@ -198,7 +198,12 @@ class EventViewHolder
                 textResId = R.string.issue_event_unlabeled;
                 break;
             case Locked:
-                textResId = R.string.issue_event_locked;
+                if (event.lockReason() == null) {
+                    textResId = R.string.issue_event_locked;
+                } else {
+                    textBase = mContext.getString(R.string.issue_event_locked_with_reason,
+                        getUserLoginWithBotSuffix(user), event.lockReason());
+                }
                 break;
             case Unlocked:
                 textResId = R.string.issue_event_unlocked;

--- a/app/src/main/res/drawable-night/issue_event_closed_completed.xml
+++ b/app/src/main/res/drawable-night/issue_event_closed_completed.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#563996"
+        android:pathData="M12,0A12,12 0,0 1,24 12,12 12,0 0,1 12,24 12,12 0,0 1,-0 12,12 12,0 0,1 12,0"
+        android:strokeWidth="1.19999993" />
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#ffffff"
+        android:pathData="m10.75,16.205 l7,-7 -1.41,-1.41 -5.59,5.58 -3.09,-3.08 -1.41,1.41z" />
+</vector>

--- a/app/src/main/res/drawable/issue_event_closed_completed.xml
+++ b/app/src/main/res/drawable/issue_event_closed_completed.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#8558e6"
+        android:pathData="M12,0A12,12 0,0 1,24 12,12 12,0 0,1 12,24 12,12 0,0 1,-0 12,12 12,0 0,1 12,0"
+        android:strokeWidth="1.19999993" />
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#ffffff"
+        android:pathData="m10.75,16.205 l7,-7 -1.41,-1.41 -5.59,5.58 -3.09,-3.08 -1.41,1.41z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,8 +286,10 @@
     <string name="repo_activity">Activity</string>
 
     <!-- Issue events -->
-    <string name="issue_event_closed">[b]%1$s[/b] closed this issue [time]</string>
-    <string name="issue_event_closed_with_commit">[b]%1$s[/b] closed this issue in [commit] [time]</string>
+    <string name="issue_event_closed_completed">[b]%1$s[/b] closed this issue as completed [time]</string>
+    <string name="issue_event_closed_completed_with_commit">[b]%1$s[/b] closed this issue as completed in [commit] [time]</string>
+    <string name="issue_event_closed_not_planned">[b]%1$s[/b] closed this issue as not planned [time]</string>
+    <string name="issue_event_closed_not_planned_with_commit">[b]%1$s[/b] closed this issue as not planned in [commit] [time]</string>
     <string name="issue_event_reopened">[b]%1$s[/b] reopened this issue [time]</string>
     <string name="issue_event_referenced">[b]%1$s[/b] referenced this issue [time]</string>
     <string name="issue_event_referenced_with_commit">[b]%1$s[/b] referenced this issue in commit [commit] [time]</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,6 +303,7 @@
     <string name="issue_event_demilestoned">[b]%1$s[/b] removed this from the [b]%2$s[/b] milestone [time]</string>
     <string name="issue_event_renamed">[b]%1$s[/b] changed the title from [b]%2$s[/b] to [b]%3$s[/b] [time]</string>
     <string name="issue_event_locked">[b]%1$s[/b] locked and limited conversation to collaborators [time]</string>
+    <string name="issue_event_locked_with_reason">[b]%1$s[/b] locked as [b]%2$s[/b] and limited conversation to collaborators [time]</string>
     <string name="issue_event_unlocked">[b]%1$s[/b] unlocked this conversation [time]</string>
     <string name="issue_event_mentioned">[b]%1$s[/b] mentioned this issue in [b][source][/b] [time]</string>
 


### PR DESCRIPTION
This PR keeps OctoDroid up with the [changes GitHub has recently made to the "closed" issue status](https://github.com/github/roadmap/issues/289):
- the "closed as completed" and "closed as not planned" information has been added to the `closed` timeline event
  <img src="https://user-images.githubusercontent.com/30041551/184928121-80bc0795-9833-4f89-8e25-fa163be1d4e0.png" width="500px"/>
- ~~the IssueActivity/Fragment color has been changed to purple if the issue is _closed as completed_.~~
~~For _closed as not planned_ issues I've kept the classic red color - even if GitHub UI uses dark grey - for consistency with the closed red icon that is already used in the app, and because the grey color used by GH is very similar to the grey used for PR draft status (and draft issues may be a thing in the future, according to the issue linked above)~~
- ~~the Closed tab in the Issues list has had its color changed from red to purple (since issues are by default _closed as completed_)~~
  - ~~following the same logic, the color of the _My issues_ list has been changed to purple when showing closed issues~~
- small extra: I've added the reason why the issue has been locked in the `locked` timeline event when available

I haven't added the ability to close an issue as not planned since it seems it can't be done via the REST API: we need to use the [closeIssue GraphQL mutation](https://docs.github.com/en/graphql/reference/mutations#closeissue). Also, when we introduce that feature, the UI will need to be revised since it's possible to change the closed reason of an issue by "re-closing" it.

**A few more technical details that will be useful while reviewing this:**
- in timeline events, the `stateReason` field is null if the issue was closed before the introduction of closed reasons. The GitHub UI displays the event with _closed as completed_ when `stateReason` is `completed` or `null`
- the Issue `stateReason` field is never null for closed issues: it's set to `completed` for both _closed as completed_ issues and issues that were closed before the introduction of closed reasons