### PR TITLE
Miscellanous quality-of-life changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     implementation 'com.github.maniac103:githubsdk:0.7.0.14'
     implementation 'com.larswerkman:HoloColorPicker:1.5@aar'
     implementation 'com.caverock:androidsvg-aar:1.4'
-    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.21'
+    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.25'
     implementation 'org.ocpsoft.prettytime:prettytime:4.0.6.Final'
     implementation 'com.github.castorflex.smoothprogressbar:library:1.3.0'
     implementation 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'

--- a/app/src/main/java/com/gh4a/adapter/SearchAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/SearchAdapter.java
@@ -93,7 +93,7 @@ public class SearchAdapter extends RootAdapter<Object, RecyclerView.ViewHolder> 
         @Override
         public void onBindViewHolder(ViewHolder holder, SearchCode result) {
             Repository repo = result.repository();
-            holder.tvTitle.setText(result.name());
+            holder.tvTitle.setText(result.path());
             holder.tvRepo.setText(ApiHelpers.formatRepoName(mContext, repo));
 
             List<TextMatch> matches = result.textMatches();
@@ -127,6 +127,7 @@ public class SearchAdapter extends RootAdapter<Object, RecyclerView.ViewHolder> 
                     tvMatch.setText(builder);
                     tvMatch.setTag(result);
                     tvMatch.setTag(R.id.search_match_index, i);
+                    tvMatch.setTypeface(Typeface.MONOSPACE);
                     row.setVisibility(View.VISIBLE);
                 }
                 for (int i = matches.size(); i < holder.matchesContainer.getChildCount(); i++) {

--- a/app/src/main/java/com/gh4a/fragment/BookmarkListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/BookmarkListFragment.java
@@ -107,7 +107,9 @@ public class BookmarkListFragment extends LoadingListFragmentBase implements
 
         public BookmarkDragHelperCallback(BaseActivity baseActivity, BookmarkAdapter adapter) {
             super(ItemTouchHelper.UP | ItemTouchHelper.DOWN,
-                    ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT);
+                  // disable left swipe to avoid accidentally removing a bookmark when
+                  // moving to the Stars tab in the "Bookmarks and Stars" screen
+                  ItemTouchHelper.RIGHT);
             mBaseActivity = baseActivity;
             mAdapter = adapter;
         }

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -20,11 +20,6 @@ import android.content.Intent;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.os.Parcelable;
-
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.recyclerview.widget.RecyclerView;
 import android.text.SpannableString;
 import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
@@ -64,13 +59,17 @@ import com.meisolsson.githubsdk.model.Reactions;
 import com.meisolsson.githubsdk.model.User;
 import com.meisolsson.githubsdk.model.request.CommentRequest;
 import com.meisolsson.githubsdk.model.request.ReactionRequest;
-import com.meisolsson.githubsdk.service.reactions.ReactionService;
 import com.meisolsson.githubsdk.service.issues.IssueCommentService;
+import com.meisolsson.githubsdk.service.reactions.ReactionService;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.recyclerview.widget.RecyclerView;
 import io.reactivex.Single;
 import retrofit2.Response;
 
@@ -309,19 +308,15 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         if (mInitialComment != null) {
             for (int i = 0; i < data.size(); i++) {
                 TimelineItem item = data.get(i);
-
+                long itemId = 0;
                 if (item instanceof TimelineItem.TimelineComment) {
-                    TimelineItem.TimelineComment comment = (TimelineItem.TimelineComment) item;
-                    if (mInitialComment.matches(comment.comment().id(), comment.getCreatedAt())) {
-                        scrollToAndHighlightPosition(i + 1 /* adjust for header view */);
-                        break;
-                    }
+                    itemId = ((TimelineItem.TimelineComment) item).comment().id();
                 } else if (item instanceof TimelineItem.TimelineReview) {
-                    TimelineItem.TimelineReview review = (TimelineItem.TimelineReview) item;
-                    if (mInitialComment.matches(review.review().id(), review.getCreatedAt())) {
-                        scrollToAndHighlightPosition(i + 1 /* adjust for header view */);
-                        break;
-                    }
+                    itemId = ((TimelineItem.TimelineReview) item).review().id();
+                }
+                if (mInitialComment.matches(itemId, item.getCreatedAt())) {
+                    scrollToAndHighlightPosition(i + 1 /* adjust for header view */);
+                    break;
                 }
             }
             mInitialComment = null;

--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -5,8 +5,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -17,13 +15,13 @@ import com.gh4a.ServiceFactory;
 import com.gh4a.activities.RepositoryActivity;
 import com.gh4a.adapter.NotificationAdapter;
 import com.gh4a.adapter.RootAdapter;
-import com.gh4a.worker.NotificationsWorker;
 import com.gh4a.model.NotificationHolder;
 import com.gh4a.resolver.BrowseFilter;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.RxUtils;
 import com.gh4a.utils.SingleFactory;
+import com.gh4a.worker.NotificationsWorker;
 import com.meisolsson.githubsdk.model.NotificationSubject;
 import com.meisolsson.githubsdk.model.NotificationThread;
 import com.meisolsson.githubsdk.model.Repository;
@@ -34,6 +32,8 @@ import com.meisolsson.githubsdk.service.activity.NotificationService;
 import java.util.Date;
 import java.util.List;
 
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
 import io.reactivex.Single;
 import retrofit2.Response;
 
@@ -138,7 +138,7 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
             if (url != null) {
                 Uri uri = ApiHelpers.normalizeUri(Uri.parse(url));
                 intent = BrowseFilter.makeRedirectionIntent(getActivity(), uri,
-                        new IntentUtils.InitialCommentMarker(item.notification.lastReadAt()));
+                        new IntentUtils.InitialCommentMarker(item.notification.updatedAt()));
             } else {
                 intent = null;
             }

--- a/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
+++ b/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
@@ -323,6 +323,7 @@ public class HttpImageGetter {
 
     private final Handler mHandler = new Handler();
     private final Map<Object, ObjectInfo> mObjectInfos = new HashMap<>();
+    private final Drawable mGifPlaceholderDrawable;
     private final Drawable mLoadingDrawable;
     private final Drawable mErrorDrawable;
     private final OkHttpClient mClient;
@@ -344,11 +345,15 @@ public class HttpImageGetter {
         mMaxWidth = size.x;
         mMaxHeight = size.y;
 
+        mGifPlaceholderDrawable = ContextCompat.getDrawable(context, R.drawable.image_gif_placeholder);
+        mGifPlaceholderDrawable.setBounds(0, 0,
+                mGifPlaceholderDrawable.getIntrinsicWidth(), mGifPlaceholderDrawable.getIntrinsicHeight());
+
         mLoadingDrawable = ContextCompat.getDrawable(context, R.drawable.image_loading);
         mLoadingDrawable.setBounds(0, 0,
                 mLoadingDrawable.getIntrinsicWidth(), mLoadingDrawable.getIntrinsicHeight());
 
-        mErrorDrawable = ContextCompat.getDrawable(context, R.drawable.content_picture);
+        mErrorDrawable = ContextCompat.getDrawable(context, R.drawable.image_error);
         mErrorDrawable.setBounds(0, 0,
                 mErrorDrawable.getIntrinsicWidth(), mErrorDrawable.getIntrinsicHeight());
     }
@@ -457,11 +462,15 @@ public class HttpImageGetter {
                         bitmap = renderSvgToBitmap(mContext.getResources(), is);
                     } else {
                         boolean isGif = mime != null && mime.startsWith("image/gif");
-                        if (isGif && canLoadGif()) {
-                            GifDrawable d = new GifDrawable(responseBody);
-                            d.setBounds(0, 0, d.getIntrinsicWidth(), d.getIntrinsicHeight());
-                            return d;
-                        } else if (!isGif) {
+                        if (isGif) {
+                            if (canLoadGif()) {
+                                GifDrawable d = new GifDrawable(responseBody);
+                                d.setBounds(0, 0, d.getIntrinsicWidth(), d.getIntrinsicHeight());
+                                return d;
+                            } else {
+                                return mGifPlaceholderDrawable;
+                            }
+                        } else {
                             bitmap = getBitmap(responseBody);
                         }
                     }

--- a/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
+++ b/app/src/main/java/com/gh4a/utils/HttpImageGetter.java
@@ -517,7 +517,7 @@ public class HttpImageGetter {
         BitmapFactory.decodeByteArray(image, 0, image.length, options);
 
         int scale = 1;
-        while (options.outWidth >= mMaxWidth || options.outHeight >= mMaxHeight) {
+        while (options.outWidth >= mMaxWidth) {
             options.outWidth /= 2;
             options.outHeight /= 2;
             scale *= 2;
@@ -561,7 +561,7 @@ public class HttpImageGetter {
                     density = null;
                 }
 
-                while (docWidth >= mMaxWidth || docHeight >= mMaxHeight) {
+                while (docWidth >= mMaxWidth) {
                     docWidth /= 2;
                     docHeight /= 2;
                     if (density != null) {

--- a/app/src/main/java/com/gh4a/utils/IntentUtils.java
+++ b/app/src/main/java/com/gh4a/utils/IntentUtils.java
@@ -16,13 +16,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
-import androidx.browser.customtabs.CustomTabColorSchemeParams;
-import androidx.browser.customtabs.CustomTabsIntent;
-import androidx.fragment.app.FragmentActivity;
-
 import android.widget.Toast;
 
 import com.gh4a.BaseActivity;
@@ -38,8 +31,16 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.browser.customtabs.CustomTabColorSchemeParams;
+import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.fragment.app.FragmentActivity;
 
 public class IntentUtils {
     private static final String EXTRA_NEW_TASK = "IntentUtils.new_task";
@@ -377,12 +378,16 @@ public class IntentUtils {
             this.date = date;
         }
 
-        public boolean matches(long id, Date date) {
+        public boolean matches(long id, Date dateToMatch) {
             if (commentId >= 0 && id >= 0) {
                 return commentId == id;
             }
-            if (date != null && this.date != null) {
-                return date.after(this.date);
+            if (dateToMatch != null && this.date != null) {
+                // We consider the date matching even if it's slightly behind this marker's date (which
+                // is likely to come from a notification timestamp), because GH notification timestamps
+                // tend to be ~10 seconds ahead the event that triggered them
+                long dateDiff = this.date.getTime() - dateToMatch.getTime();
+                return dateDiff >= 0 && dateDiff < TimeUnit.SECONDS.toMillis(30);
             }
             return false;
         }

--- a/app/src/main/res/drawable-night/image_error.xml
+++ b/app/src/main/res/drawable-night/image_error.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#ccffffff"
+      android:pathData="M21,5v6.59l-3,-3.01 -4,4.01 -4,-4 -4,4 -3,-3.01L3,5c0,-1.1 0.9,-2 2,-2h14c1.1,0 2,0.9 2,2zM18,11.42l3,3.01L21,19c0,1.1 -0.9,2 -2,2L5,21c-1.1,0 -2,-0.9 -2,-2v-6.58l3,2.99 4,-4 4,4 4,-3.99z"/>
+</vector>

--- a/app/src/main/res/drawable-night/image_gif_placeholder.xml
+++ b/app/src/main/res/drawable-night/image_gif_placeholder.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#ccffffff"
+      android:pathData="M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3zM9 13.2v-1.2h1.2v1.2c0 0.66-0.54 1.2-1.2 1.2h-1.2c-0.66 0-1.2-.54-1.2-1.2v-2.4c0-.66.54-1.2 1.2-1.2h1.2c.66 0 1.2.54 1.2 1.2h-2.4v2.4h1.2zm3.6 1.2h-1.2v-4.8h1.2v4.8zm4.8-3.6h-2.4v.6h1.8v1.2h-1.8v1.8h-1.2v-4.8h3.6v1.2z"/>
+</vector>

--- a/app/src/main/res/drawable/image_error.xml
+++ b/app/src/main/res/drawable/image_error.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#99343434"
+      android:pathData="M21,5v6.59l-3,-3.01 -4,4.01 -4,-4 -4,4 -3,-3.01L3,5c0,-1.1 0.9,-2 2,-2h14c1.1,0 2,0.9 2,2zM18,11.42l3,3.01L21,19c0,1.1 -0.9,2 -2,2L5,21c-1.1,0 -2,-0.9 -2,-2v-6.58l3,2.99 4,-4 4,4 4,-3.99z"/>
+</vector>

--- a/app/src/main/res/drawable/image_gif_placeholder.xml
+++ b/app/src/main/res/drawable/image_gif_placeholder.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#99343434"
+      android:pathData="M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3zM9 13.2v-1.2h1.2v1.2c0 0.66-0.54 1.2-1.2 1.2h-1.2c-0.66 0-1.2-.54-1.2-1.2v-2.4c0-.66.54-1.2 1.2-1.2h1.2c.66 0 1.2.54 1.2 1.2h-2.4v2.4h1.2zm3.6 1.2h-1.2v-4.8h1.2v4.8zm4.8-3.6h-2.4v.6h1.8v1.2h-1.8v1.8h-1.2v-4.8h3.6v1.2z"/>
+</vector>

--- a/app/src/main/res/layout/row_search_match.xml
+++ b/app/src/main/res/layout/row_search_match.xml
@@ -9,5 +9,5 @@
     android:layout_marginTop="8dp"
     android:background="?colorControlHighlight"
     android:padding="8dp"
-    android:textAppearance="@style/TextAppearance.VerySmall"
+    android:textSize="11sp"
     tools:text="code match" />

--- a/app/src/main/res/layout/row_timeline_event.xml
+++ b/app/src/main/res/layout/row_timeline_event.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:padding="@dimen/content_padding">


### PR DESCRIPTION
This PR is centered around small improvements to the user experience and minor usability fixes:

- placeholder icons for images that aren't loaded in comments/READMEs have been changed: now they differ when an image can't be loaded or when a GIF is not loaded because of the loading preferences (previously the same placeholder was used)
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/187680652-f944d7b2-73e3-477c-bc76-6edb172a86ba.jpg" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/187680748-2112a1f5-33e5-43d7-9070-be68cca64cc8.jpg" /></td></tr>
</table>

- in code search results, the full path to the matching file is shown instead of just the file name
- the scaling logic for images in comments/READMEs has been adjusted, so that images that are taller than the screen height are not uselessly resized when they aren't wider than the screen (the diagram in [TeamNewPipe/NewPipe#7673](https://github.com/TeamNewPipe/NewPipe/issues/7673) is a good example).
While I was at it, I've noticed that the scaling of SVGs whose size is not in pixels was incorrect and I've fixed it (1d60a97)
- bookmarks cannot be removed by swiping them to the left anymore, to avoid the usability issue described in #861.
They can still be removed by swiping to the right.
- last but not least, I've improved the logic to jump to the most recent comment in an issue/PR when clicking on a notification (addresses #1228):
  - we now support scrolling down to the most recent _event_ too (it doesn't need to be a comment or a review anymore)
  - we now look at the `updated_at` field of the notification and not at `last_read_at` to determine the timestamp of the latest event. The latter field is updated once the notification is read, and therefore tapping a notification just after reading it would make the user jump to a different position (most of the time it wouldn't jump anywhere, because there would be no events matching the `last_read_at` timestamp)