### PR TITLE
HTML conversion fixes and small improvements

### DIFF
--- a/app/src/main/java/com/gh4a/model/Feed.java
+++ b/app/src/main/java/com/gh4a/model/Feed.java
@@ -81,7 +81,12 @@ public class Feed implements Parcelable {
             return null;
         }
         String preview = content.length() > 2000 ? content.substring(0, 2000) : content;
-        preview = preview.replaceAll("<(.|\n)*?>", "").trim();
+        preview = preview.replaceAll("<(.|\n)*?>", "")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&")
+                .replace("&#8217;", "’")
+                .trim();
         if (preview.length() > 500) {
             preview = preview.substring(0, 500);
         }

--- a/app/src/main/java/com/gh4a/utils/HtmlUtils.java
+++ b/app/src/main/java/com/gh4a/utils/HtmlUtils.java
@@ -399,11 +399,11 @@ public class HtmlUtils {
                 startCssStyle(attributes);
             } else if (tag.equalsIgnoreCase("hr")) {
                 HorizontalLineSpan span = new HorizontalLineSpan(mDividerHeight, 0x60aaaaaa);
-                // enforce the following newlines to be written
-                mSpannableStringBuilder.append(' ');
-                appendNewlines(2);
+                appendNewlines(1);
+                mSpannableStringBuilder.append(' '); // enforce the following newline to be written
+                appendNewlines(1);
                 int len = mSpannableStringBuilder.length();
-                mSpannableStringBuilder.setSpan(span, len - 1, len, Spannable.SPAN_INCLUSIVE_EXCLUSIVE);
+                mSpannableStringBuilder.setSpan(span, len - 2, len, Spannable.SPAN_INCLUSIVE_EXCLUSIVE);
             } else if (tag.equalsIgnoreCase("strong")) {
                 start(new Bold());
             } else if (tag.equalsIgnoreCase("b")) {


### PR DESCRIPTION
This PR includes some changes to the HTML-to-spanned-text converter that fix some formatting inconsistencies between the app and the GitHub UI:

- `<pre>` tags are now treated as code blocks (as the GitHub UI does) instead of being rendered as monospaced pre-formatted blocks without a background.
This change also allows to simplify the handling of highlighted code blocks: they don't need to be handled in a special way since they are just `pre`s wrapped in a `div`.
- `<tt>` tags are now treated in the same way as `<code>` tags
- `<samp>` tags are now rendered as simple monospaced inline text (they were previously ignored)
- rendering of numbered lists was improved: nested `<ol>s` and ordered lists which have newlines between each item are now displayed correctly.
This was done by implementing a custom `LeadingMarginSpan` to render the number (like `1. `) before the content of the list item. The implementation was inspired by [this SO answer](https://stackoverflow.com/a/27541189) and by the [BulletSpan implementation](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/text/style/BulletSpan.java;l=203).
- horizontal separators spacing has been fixed
- in GH blog/wiki feed lists, HTML entities in the description preview of each item were not escaped. To address this, I've decided to escape only the most common entities in order to have a "good enough" solution. Otherwise, we would have to pull in a dedicated library to escape everything properly (which I think is not worth).

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/190899930-2218b505-0047-41f4-b33b-bbc4d5d78253.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/190899940-5eb25659-f20a-4ef0-8305-be81f71298a0.png" /></td></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/190900012-803fc20d-1de4-44fd-b715-263b1d905c94.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/190900026-83e8fd1a-6dda-40f9-a090-29a81bb5979c.png" /></td></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/190900056-584072cd-8a11-4528-b443-1b6a3cc367f5.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/190900074-67090243-19f5-4b56-9c5f-19b898f402c2.png" /></td></tr>
</table>
