### PR TITLE
Fix a few PR-related bugs

### DIFF
--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -22,23 +22,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
-
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
-
-import com.gh4a.utils.ActivityResultHelpers;
-import com.gh4a.utils.UiUtils;
-import com.google.android.material.appbar.AppBarLayout;
-
-import androidx.appcompat.view.ContextThemeWrapper;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.Fragment;
-import androidx.appcompat.app.AlertDialog;
-
 import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -56,16 +39,18 @@ import com.gh4a.R;
 import com.gh4a.ServiceFactory;
 import com.gh4a.fragment.CommitCompareFragment;
 import com.gh4a.fragment.ConfirmationDialogFragment;
-import com.gh4a.fragment.PullRequestFilesFragment;
 import com.gh4a.fragment.PullRequestConversationFragment;
+import com.gh4a.fragment.PullRequestFilesFragment;
+import com.gh4a.utils.ActivityResultHelpers;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.RxUtils;
 import com.gh4a.utils.SingleFactory;
 import com.gh4a.utils.Triplet;
+import com.gh4a.utils.UiUtils;
 import com.gh4a.widget.BottomSheetCompatibleScrollingViewBehavior;
 import com.gh4a.widget.IssueStateTrackingFloatingActionButton;
-
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.textfield.TextInputLayout;
 import com.meisolsson.githubsdk.model.Issue;
 import com.meisolsson.githubsdk.model.IssueState;
@@ -82,6 +67,16 @@ import com.meisolsson.githubsdk.service.pull_request.PullRequestService;
 
 import java.util.Locale;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 
@@ -637,25 +632,11 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
                 public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                     MergeMethodDesc selectedItem = (MergeMethodDesc) parent.getItemAtPosition(position);
                     toggleFieldsVisibility(selectedItem.action);
-                    setCommitTitleHint(selectedItem.action);
                 }
                 @Override
                 public void onNothingSelected(AdapterView<?> adapterView) {
                 }
             });
-        }
-
-        private void setCommitTitleHint(MergeRequest.Method mergeMethod) {
-            switch (mergeMethod) {
-                case Merge:
-                    String username = ApiHelpers.getUserLogin(getContext(), mPr.head().user());
-                    mTitleField.setPlaceholderText(
-                            "Merge pull request #" + mPr.number() + " from " + username + "/" + mPr.head().ref());
-                    break;
-                case Squash:
-                    mTitleField.setPlaceholderText(mPr.title() + " (#" + mPr.number() + ")");
-                    break;
-            }
         }
 
         private void toggleFieldsVisibility(MergeRequest.Method mergeMethod) {

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -203,9 +203,14 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
         if (!canMerge || isClosed) {
             menu.removeItem(R.id.pull_merge);
-        } else if (mPullRequest.mergeable() == null || !mPullRequest.mergeable()) {
-            MenuItem mergeItem = menu.findItem(R.id.pull_merge);
-            mergeItem.setEnabled(false);
+        } else {
+            // Mergeability is checked according to the information found here: https://github.com/octokit/octokit.net/issues/1763
+            boolean isMergeable = mPullRequest.mergeableState() == PullRequest.MergeableState.Clean ||
+                    mPullRequest.mergeableState() == PullRequest.MergeableState.Unstable;
+            if (!isMergeable) {
+                MenuItem mergeItem = menu.findItem(R.id.pull_merge);
+                mergeItem.setEnabled(false);
+            }
         }
 
         if (mPullRequest == null) {

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -197,15 +197,13 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
         if (!canClose || isClosed) {
             menu.removeItem(R.id.pull_close);
         }
-        if (!canOpen || !isClosed) {
+        if (!canOpen || !isClosed || mPullRequest.merged()) {
             menu.removeItem(R.id.pull_reopen);
-        } else if (isClosed && mPullRequest.merged()) {
-            menu.findItem(R.id.pull_reopen).setEnabled(false);
         }
-        if (!canMerge) {
+
+        if (!canMerge || isClosed) {
             menu.removeItem(R.id.pull_merge);
-        } else if (mPullRequest.merged()
-                || mPullRequest.mergeable() == null || !mPullRequest.mergeable()) {
+        } else if (mPullRequest.mergeable() == null || !mPullRequest.mergeable()) {
             MenuItem mergeItem = menu.findItem(R.id.pull_merge);
             mergeItem.setEnabled(false);
         }

--- a/app/src/main/java/com/gh4a/adapter/timeline/CommentViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/CommentViewHolder.java
@@ -2,8 +2,6 @@ package com.gh4a.adapter.timeline;
 
 import android.content.Context;
 import android.content.Intent;
-import androidx.annotation.Nullable;
-
 import android.text.SpannableStringBuilder;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -31,6 +29,7 @@ import com.meisolsson.githubsdk.model.User;
 import java.util.Date;
 import java.util.List;
 
+import androidx.annotation.Nullable;
 import io.reactivex.Single;
 
 class CommentViewHolder
@@ -171,7 +170,7 @@ class CommentViewHolder
         Menu menu = mPopupMenu.getMenu();
         menu.findItem(R.id.edit).setVisible(canEdit);
         menu.findItem(R.id.delete).setVisible(canEdit);
-        menu.findItem(R.id.view_in_file).setVisible(item.file != null && position != -1);
+        menu.findItem(R.id.view_in_file).setVisible(item.hasFilePatch() && position != -1);
     }
 
     @Nullable

--- a/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
@@ -18,9 +18,6 @@ package com.gh4a.fragment;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
-import androidx.annotation.AttrRes;
-import androidx.annotation.StringRes;
-import androidx.collection.LongSparseArray;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.view.Menu;
@@ -40,7 +37,6 @@ import com.gh4a.utils.Optional;
 import com.gh4a.utils.RxUtils;
 import com.gh4a.widget.CommitStatusBox;
 import com.gh4a.widget.PullRequestBranchInfoView;
-
 import com.meisolsson.githubsdk.model.CheckRun;
 import com.meisolsson.githubsdk.model.GitHubCommentBase;
 import com.meisolsson.githubsdk.model.Issue;
@@ -73,6 +69,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import androidx.annotation.AttrRes;
+import androidx.annotation.StringRes;
+import androidx.collection.LongSparseArray;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
@@ -401,7 +400,7 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
         String repo = head.repo().name();
 
         service.deleteGitReference(owner, repo, "heads/" + head.ref())
-                .map(ApiHelpers::mapToBooleanOrThrowOnFailure)
+                .map(ApiHelpers::mapToTrueOnSuccess)
                 .compose(RxUtils.wrapForBackgroundTask(getBaseActivity(),
                         R.string.deleting_msg, R.string.delete_branch_error))
                 .subscribe(result -> {

--- a/app/src/main/java/com/gh4a/model/TimelineItem.java
+++ b/app/src/main/java/com/gh4a/model/TimelineItem.java
@@ -2,8 +2,6 @@ package com.gh4a.model;
 
 import android.content.Context;
 import android.content.Intent;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.gh4a.activities.PullRequestDiffViewerActivity;
 import com.gh4a.utils.IntentUtils;
@@ -25,6 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public abstract class TimelineItem {
     public static final Comparator<TimelineItem> COMPARATOR = (lhs, rhs) -> {
@@ -74,6 +75,10 @@ public abstract class TimelineItem {
             } else {
                 comment = ((GitHubComment) comment).toBuilder().reactions(reactions).build();
             }
+        }
+
+        public boolean hasFilePatch() {
+            return file != null && file.patch() != null;
         }
 
         @Nullable

--- a/app/src/main/java/com/gh4a/utils/FileUtils.java
+++ b/app/src/main/java/com/gh4a/utils/FileUtils.java
@@ -20,6 +20,9 @@ public class FileUtils {
         // .ts can be both a TypeScript file and a MPEG2 transport stream file. As the former is the
         // more likely case for us and the framework returns the latter, override to assume a text file.
         MIME_TYPE_OVERRIDES.put("ts", "text/x-typescript");
+        // The same applies to .pot files: the framework assumes they are PowerPoint templates, but in
+        // GitHub repos they are most often gettext translation templates.
+        MIME_TYPE_OVERRIDES.put("pot", "text/plain");
         // there is no general MIME type mapping for Java properties files, but they're text
         MIME_TYPE_OVERRIDES.put("properties", "text/x-java-properties");
         // JavaScript can be resolved to both text/javascript and application/javascript,

--- a/app/src/main/res/layout/pull_merge_message_dialog.xml
+++ b/app/src/main/res/layout/pull_merge_message_dialog.xml
@@ -27,8 +27,8 @@
             android:id="@+id/title_field"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:expandedHintEnabled="false"
-            android:hint="@string/pull_merge_title_description">
+            android:hint="@string/pull_merge_title_description"
+            app:helperText="@string/pull_merge_title_helper">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
@@ -42,12 +42,10 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/details_field"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="8dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/pull_merge_message_description"
-            app:expandedHintEnabled="false"
-            app:placeholderText="@string/pull_merge_message_hint">
+            android:hint="@string/pull_merge_message_description">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -449,8 +449,8 @@
     <string name="pull_error_merge">Merging pull request #%1$d failed.</string>
     <string name="pull_message_dialog_title">Merge pull request #%1$d</string>
     <string name="pull_merge_title_description">Merge commit title</string>
+    <string name="pull_merge_title_helper">Leave this empty to use the default title provided by GitHub.</string>
     <string name="pull_merge_message_description">Merge commit details</string>
-    <string name="pull_merge_message_hint">If you want to add more details to the merge commit, enter them here.</string>
     <string name="pull_merge_status_loading">Loading pull request status…</string>
     <string name="pull_merge_status_behind">This branch is out-of-date with the base branch</string>
     <string name="pull_merge_status_blocked">Merging is blocked</string>


### PR DESCRIPTION
This PR batches together a few bug fixes, mostly regarding PRs (it's easier to review commit by commit):
- avoid showing the "View in file" action in review comments and diff fragments if the entire patch for that file wasn't returned by GH API (e.g. when the diff is too big). Previously, when tapping on "View in file" in these cases, the code viewer would open with a blank screen.
- completely hide (not just disable) Merge and Reopen actions in the app bar when a PR is already merged, since those actions are not possible in that context.
Also, the condition used to determine PR mergeability has been fixed: the Merge action will now be disabled when a PR can't be merged due to conflicts or missing approval.
- the app now shows the error snackbar when the deletion of a pull request branch fails and GH returns a 404 error (previously the error wasn't reported to the user)
- revamp (again) the merge dialog since a recent update of the Material components library broke the appearance of multi-line text field hints, as you can see below.
My solution was to get rid of the hints altogether, and use a helper text under the commit title field without "guessing" the default title (which is even better since users [can now change the default merge commit message](https://github.blog/changelog/2022-08-23-new-options-for-controlling-the-default-commit-message-when-merging-a-pull-request/)).
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/194771483-796c7da9-0b8c-422e-9216-eef5f9c59d06.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/194771496-52d72b54-7250-4002-946e-57faf3a84bd9.png" /></td></tr>
</table>

- small extra: POT files (gettext translation templates) were incorrectly recognized as binary files by the app and therefore were opened in the browser. That's been fixed too.