### PR TITLE
Fix an HTML conversion crash and improve rendering of <details> elements

### DIFF
--- a/app/src/main/java/com/gh4a/utils/HtmlUtils.java
+++ b/app/src/main/java/com/gh4a/utils/HtmlUtils.java
@@ -429,8 +429,10 @@ public class HtmlUtils {
                     mSpannableStringBuilder.setSpan(span, mSpannableStringBuilder.length() - 2,
                             mSpannableStringBuilder.length() - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 }
-            } else if (tag.equalsIgnoreCase("div")) {
+            } else if (tag.equalsIgnoreCase("div") || tag.equalsIgnoreCase("details")) {
                 startBlockElement(attributes);
+            } else if (tag.equalsIgnoreCase("summary")) {
+                startBlockElement(attributes, 1);
             } else if (tag.equalsIgnoreCase("span")) {
                 startCssStyle(attributes);
             } else if (tag.equalsIgnoreCase("hr")) {
@@ -518,7 +520,9 @@ public class HtmlUtils {
                 end(List.class);
             } else if (tag.equalsIgnoreCase("li")) {
                 endLi();
-            } else if (tag.equalsIgnoreCase("div")) {
+            } else if (tag.equalsIgnoreCase("div") ||
+                       tag.equalsIgnoreCase("details") ||
+                       tag.equalsIgnoreCase("summary")) {
                 endBlockElement();
             } else if (tag.equalsIgnoreCase("span")) {
                 endCssStyle();

--- a/app/src/main/java/com/gh4a/utils/HtmlUtils.java
+++ b/app/src/main/java/com/gh4a/utils/HtmlUtils.java
@@ -463,6 +463,7 @@ public class HtmlUtils {
             } else if (tag.equalsIgnoreCase("samp")) {
                 start(new Monospace());
             } else if (tag.equalsIgnoreCase("pre")) {
+                startBlockElement(attributes, 1);
                 start(new Pre());
             } else if (tag.equalsIgnoreCase("a")) {
                 startA(attributes);
@@ -544,7 +545,7 @@ public class HtmlUtils {
             } else if (tag.equalsIgnoreCase("samp")) {
                 end(Monospace.class, new TypefaceSpan("monospace"));
             } else if (tag.equalsIgnoreCase("pre")) {
-                appendNewlines(1);
+                endBlockElement();
                 end(Pre.class, new TypefaceSpan("monospace"), new CodeBlockSpan(mCodeBlockBackgroundColor));
             } else if (tag.equalsIgnoreCase("a")) {
                 endA();


### PR DESCRIPTION
This PR fixes the crash reported in #1253.
It was a regression introduced by #1239 that highlighted a bug that existed in the HTML-to-spanned conversion before that PR: `<pre>` tags weren't treated as block elements, and therefore they weren't always guaranteed to start on a new line (which is incorrect and was the cause of the crash).
While I was at it, I've noticed that `<details>`/`<summary>` tags weren't handled at all in the HTML conversion. This lead to missing linebreaks which could make the text quite messy like in the following example:

![octo_before](https://user-images.githubusercontent.com/30041551/199793419-4118eabe-3089-44e1-886f-59850f0041b6.png)

Which results from the following HTML:
```html
<details>
Details without summary
</details>
<details>
<summary>
Custom summary
</summary>
Hello, world!
</details>inline text after details
<summary>
Summary tag outside details
</summary>
more text
```
After the fix, this is how it looks in the app compared to the GitHub UI.
<table>
<tr><th>App (with this PR)</th><th>GitHub UI</th></tr>
<tr><td>
<img src="https://user-images.githubusercontent.com/30041551/199794519-8e892c4a-4322-4f18-9ee2-7f55ed2141f1.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/30041551/199794438-2aad17eb-da16-4723-82c9-71e6f63bcfde.png" /></td></tr>
</table>

We still don't support collapsing `<details>` tags, but at least they will now look tidy and readable.

Closes #1253 
Closes #1256 