### PR TITLE
Authenticate API calls with OAuth clientId/clientSecret when user is not logged in

### DIFF
--- a/app/src/main/java/com/gh4a/ServiceFactory.java
+++ b/app/src/main/java/com/gh4a/ServiceFactory.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 
 import okhttp3.Cache;
 import okhttp3.CacheControl;
+import okhttp3.Credentials;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -152,6 +153,9 @@ public class ServiceFactory {
                             ? token : Gh4Application.get().getAuthToken();
                     if (tokenToUse != null) {
                         requestBuilder.header("Authorization", "Token " + tokenToUse);
+                    } else {
+                        requestBuilder.header("Authorization",
+                                Credentials.basic(BuildConfig.CLIENT_ID, BuildConfig.CLIENT_SECRET));
                     }
                     if (pageSize != null) {
                         requestBuilder.url(original.url().newBuilder()


### PR DESCRIPTION
This allows to have a much higher rate limit (5000 vs 60 requests per hour) when the user is not logged in, [as described here](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#increasing-the-unauthenticated-rate-limit-for-oauth-apps).

Fixes #717 