### PR TITLE
A few fixes to the notification screen

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -128,20 +128,21 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
 
     @Override
     public void onItemClick(NotificationHolder item) {
-        final Intent intent;
-
         if (item.notification == null) {
-            intent = RepositoryActivity.makeIntent(getActivity(), item.repository);
+            var intent = RepositoryActivity.makeIntent(getActivity(), item.repository);
+            startActivity(intent);
+            return;
+        }
+
+        NotificationSubject subject = item.notification.subject();
+        String url = subject.url();
+        final Intent intent;
+        if (url != null) {
+            Uri uri = ApiHelpers.normalizeUri(Uri.parse(url));
+            intent = BrowseFilter.makeRedirectionIntent(getActivity(), uri,
+                    new IntentUtils.InitialCommentMarker(item.notification.updatedAt()));
         } else {
-            NotificationSubject subject = item.notification.subject();
-            String url = subject.url();
-            if (url != null) {
-                Uri uri = ApiHelpers.normalizeUri(Uri.parse(url));
-                intent = BrowseFilter.makeRedirectionIntent(getActivity(), uri,
-                        new IntentUtils.InitialCommentMarker(item.notification.updatedAt()));
-            } else {
-                intent = null;
-            }
+            intent = null;
         }
 
         if (intent != null) {

--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -256,6 +256,9 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
         NotificationService service = ServiceFactory.get(NotificationService.class, false);
         final Single<Response<Void>> responseSingle;
         if (notification != null) {
+            if (!notification.unread()) {
+                return;
+            }
             responseSingle = service.markNotificationRead(notification.id());
         } else {
             NotificationReadRequest request = NotificationReadRequest.builder()

--- a/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/NotificationListFragment.java
@@ -9,6 +9,7 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import com.gh4a.R;
 import com.gh4a.ServiceFactory;
@@ -206,7 +207,7 @@ public class NotificationListFragment extends LoadingListFragmentBase implements
         service.setNotificationThreadSubscription(notification.id(), request)
                 .map(ApiHelpers::throwOnFailure)
                 .compose(RxUtils::doInBackground)
-                .subscribe(result -> handleMarkAsRead(null, notification),
+                .subscribe(result -> Toast.makeText(getContext(), R.string.unsubscribe_success, Toast.LENGTH_SHORT).show(),
                         error -> handleActionFailure("Unsubscribing notification failed", error));
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
     <string name="mark_all_as_read">Mark all as read</string>
     <string name="mark_as_read">Mark as read</string>
     <string name="unsubscribe">Unsubscribe</string>
+    <string name="unsubscribe_success">Unsubscribed from the conversation</string>
     <string name="mark_repository_as_read_question">Mark all notifications from %1$s as read?</string>
     <string name="mark_all_as_read_question">Mark all notifications as read?</string>
     <string name="unread">Unread</string>


### PR DESCRIPTION
This small PR puts together a few fixes for some minor bugs I found in the Notifications screen:
- tapping on the repository name accidentally marks all notifications as read (#1255)
- unsubscribing from a notification thread marks the notification as read in the UI, however this isn't done on the server side: after refreshing the screen the notification is still displayed as unread (#1258). 
To address this, I've decided to display a toast to let the user know that the unsubscription was successful, without marking the notification as read.
- if a notification has already been read, avoid calling the API to mark it as read again when the user taps on it.
This prevents useless API calls and works around a weird side-effect (maybe a bug?) of the GH API endpoint, which marks a notification as read but also unexpectedly moves it to Inbox if it was marked as _done_.

Fixes #1255 
Fixes #1258