### PR TITLE
Fix some unescaped HTML entities in GitHub blog titles

### DIFF
--- a/app/src/main/java/com/gh4a/model/Feed.java
+++ b/app/src/main/java/com/gh4a/model/Feed.java
@@ -73,6 +73,8 @@ public class Feed implements Parcelable {
         preview = generatePreview(content);
         if (StringUtils.isBlank(title)) {
             title = getTitleFromUrl(link);
+        } else {
+            title = StringUtils.unescapeCommonHtmlEntities(title);
         }
     }
 
@@ -81,12 +83,7 @@ public class Feed implements Parcelable {
             return null;
         }
         String preview = content.length() > 2000 ? content.substring(0, 2000) : content;
-        preview = preview.replaceAll("<(.|\n)*?>", "")
-                .replace("&lt;", "<")
-                .replace("&gt;", ">")
-                .replace("&amp;", "&")
-                .replace("&#8217;", "’")
-                .trim();
+        preview = StringUtils.unescapeCommonHtmlEntities(preview.replaceAll("<(.|\n)*?>", "")).trim();
         if (preview.length() > 500) {
             preview = preview.substring(0, 500);
         }

--- a/app/src/main/java/com/gh4a/utils/StringUtils.java
+++ b/app/src/main/java/com/gh4a/utils/StringUtils.java
@@ -211,4 +211,12 @@ public class StringUtils {
         final Set<String> value = prefs.getStringSet(key, null);
         return value != null ? new HashSet<>(value) : new HashSet<>();
     }
+
+    public static String unescapeCommonHtmlEntities(String sourceText) {
+        return sourceText.replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&")
+                .replace("&#8217;", "’")
+                .replace("&#8211;", "–");
+    }
 }


### PR DESCRIPTION
This is a small fix for a few titles in the GitHub blog feed which contain some unescaped HTML entities.
![unescaped_titles](https://user-images.githubusercontent.com/30041551/219866332-003dda0f-697a-41ff-a417-3a65e79028e6.png)

I've extracted the logic for unescaping the entities in the `StringUtils` class so that it can be reused in other places, if needed.