### PR TITLE
Improvements and fixes to issue/PR list filtering

### DIFF
--- a/app/src/main/java/com/gh4a/activities/IssueListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueListActivity.java
@@ -94,6 +94,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
     private int mSelectedParticipatingStatus = 0;
 
     private FloatingActionButton mCreateFab;
+    private MenuItem mRemoveFilterButton;
     private IssueListFragment mOpenFragment;
     private Boolean mIsCollaborator;
     private List<Label> mLabels;
@@ -399,6 +400,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.issue_list_menu, menu);
+        mRemoveFilterButton = menu.findItem(R.id.remove_filter);
 
         MenuItem searchItem = menu.findItem(R.id.search);
         searchItem.setOnActionExpandListener(this);
@@ -411,11 +413,14 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         searchView.setOnCloseListener(this);
         searchView.setOnQueryTextListener(this);
 
-        if (isFiltering()) {
-            menu.findItem(R.id.remove_filter).setVisible(true);
-        }
-
+        updateRemoveFilterButtonVisibility();
         return super.onCreateOptionsMenu(menu);
+    }
+
+    private void updateRemoveFilterButtonVisibility() {
+        if (mRemoveFilterButton != null) {
+            mRemoveFilterButton.setVisible(isFiltering());
+        }
     }
 
     @Override
@@ -577,7 +582,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
 
     private void onFilterUpdated() {
         invalidateFragments();
-        invalidateOptionsMenu();
+        updateRemoveFilterButtonVisibility();
         updateRightNavigationDrawer();
     }
 

--- a/app/src/main/java/com/gh4a/activities/IssueListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueListActivity.java
@@ -129,19 +129,20 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        mUserLogin = Gh4Application.get().getAuthLogin();
-
+        // We're restoring instance state before calling super.onCreate() because some of the fields
+        // are used to populate the right navigation drawer, which is done in BaseActivity.onCreate()
         if (savedInstanceState != null) {
             mSearchQuery = savedInstanceState.getString(STATE_KEY_SEARCH_QUERY);
             mSearchMode = savedInstanceState.getBoolean(STATE_KEY_SEARCH_MODE);
             mSearchIsExpanded = savedInstanceState.getBoolean(STATE_KEY_SEARCH_IS_EXPANDED);
+            mSelectedMilestone = savedInstanceState.getString(STATE_KEY_SELECTED_MILESTONE);
             mSelectedLabel = savedInstanceState.getString(STATE_KEY_SELECTED_LABEL);
             mSelectedAssignee = savedInstanceState.getString(STATE_KEY_SELECTED_ASSIGNEE);
-            mSelectedParticipatingStatus =
-                    savedInstanceState.getInt(STATE_KEY_PARTICIPATING_STATUS);
+            mSelectedParticipatingStatus = savedInstanceState.getInt(STATE_KEY_PARTICIPATING_STATUS);
         }
+
+        super.onCreate(savedInstanceState);
+        mUserLogin = Gh4Application.get().getAuthLogin();
 
         if (!mIsPullRequest && Gh4Application.get().isAuthorized()) {
             CoordinatorLayout rootLayout = getRootLayout();

--- a/app/src/main/java/com/gh4a/activities/IssueListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueListActivity.java
@@ -340,7 +340,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
                     mSelectedLabel.isEmpty() ? getString(R.string.issue_filter_by_no_label) :
                     mSelectedLabel;
             UiUtils.setMenuItemText(this, labelFilterItem,
-                    getString(R.string.issue_filter_by_labels), subtitle);
+                    getString(R.string.issue_filter_by_label), subtitle);
         }
         MenuItem assigneeFilterItem = menu.findItem(R.id.filter_by_assignee);
         if (assigneeFilterItem != null) {
@@ -549,7 +549,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         }
 
         SingleChoiceDialogFragment.show(this, labels,
-                R.string.issue_filter_by_labels, selected, "labelselect");
+                R.string.issue_filter_by_label, selected, "labelselect");
     }
 
     private void showMilestonesDialog() {

--- a/app/src/main/java/com/gh4a/activities/IssueListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueListActivity.java
@@ -257,7 +257,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
                 buildParticipatingFilterItem()).trim();
 
         @StringRes int emptyTextResId;
-        if (mSearchMode) {
+        if (mSearchMode || isFiltering()) {
             emptyTextResId = mIsPullRequest
                     ? R.string.no_search_pull_requests_found : R.string.no_search_issues_found;
         } else {
@@ -410,8 +410,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         searchView.setOnCloseListener(this);
         searchView.setOnQueryTextListener(this);
 
-        if (mSelectedMilestone != null || mSelectedAssignee != null
-                || mSelectedLabel != null || mSelectedParticipatingStatus != 0) {
+        if (isFiltering()) {
             menu.findItem(R.id.remove_filter).setVisible(true);
         }
 
@@ -429,6 +428,11 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private boolean isFiltering() {
+        return mSelectedMilestone != null || mSelectedAssignee != null
+                || mSelectedLabel != null || mSelectedParticipatingStatus != 0;
     }
 
     private void removeFilter() {

--- a/app/src/main/java/com/gh4a/fragment/SingleChoiceDialogFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/SingleChoiceDialogFragment.java
@@ -16,6 +16,10 @@ import java.util.List;
 
 public class SingleChoiceDialogFragment extends DialogFragment
         implements DialogInterface.OnClickListener {
+    private static final String KEY_ENTRIES = "entries";
+    private static final String KEY_TITLE_RES_ID = "titleResId";
+    private static final String KEY_SELECTED_POSITION = "selectedPosition";
+
     private List<String> mEntries;
 
     public interface Callback {
@@ -25,9 +29,9 @@ public class SingleChoiceDialogFragment extends DialogFragment
     public static <C extends FragmentActivity & Callback> void show(C parent,
             List<String> entries, @StringRes int titleResId, int selectedPosition, String tag) {
         Bundle args = new Bundle();
-        args.putStringArrayList("entries", new ArrayList<>(entries));
-        args.putInt("titleResId", titleResId);
-        args.putInt("selectionPosition", selectedPosition);
+        args.putStringArrayList(KEY_ENTRIES, new ArrayList<>(entries));
+        args.putInt(KEY_TITLE_RES_ID, titleResId);
+        args.putInt(KEY_SELECTED_POSITION, selectedPosition);
 
         SingleChoiceDialogFragment f = new SingleChoiceDialogFragment();
         f.setArguments(args);
@@ -39,13 +43,13 @@ public class SingleChoiceDialogFragment extends DialogFragment
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         Bundle args = getArguments();
 
-        mEntries = args.getStringArrayList("entries");
+        mEntries = args.getStringArrayList(KEY_ENTRIES);
 
         String[] entryArray = mEntries.toArray(new String[0]);
-        int selectedPosition = args.getInt("selectedPosition");
+        int selectedPosition = args.getInt(KEY_SELECTED_POSITION);
 
         return new AlertDialog.Builder(getContext())
-                .setTitle(args.getInt("titleResId"))
+                .setTitle(args.getInt(KEY_TITLE_RES_ID))
                 .setSingleChoiceItems(entryArray, selectedPosition, this)
                 .setNegativeButton(R.string.cancel, null)
                 .create();

--- a/app/src/main/res/layout/base_activity.xml
+++ b/app/src/main/res/layout/base_activity.xml
@@ -95,6 +95,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="right"
-        android:background="?attr/drawerBackground" />
+        android:background="?attr/drawerBackground"
+        app:itemMaxLines="2" />
 
 </com.gh4a.widget.InvalidatingDrawerLayout>

--- a/app/src/main/res/menu/issue_list_filter.xml
+++ b/app/src/main/res/menu/issue_list_filter.xml
@@ -7,7 +7,7 @@
                 android:title="@string/issue_filter_by_milestone" />
             <item
                 android:id="@+id/filter_by_label"
-                android:title="@string/issue_filter_by_labels" />
+                android:title="@string/issue_filter_by_label" />
             <item
                 android:id="@+id/filter_by_assignee"
                 android:title="@string/issue_filter_by_assignee" />

--- a/app/src/main/res/menu/issue_list_filter_collab.xml
+++ b/app/src/main/res/menu/issue_list_filter_collab.xml
@@ -7,7 +7,7 @@
                 android:title="@string/issue_filter_by_milestone" />
             <item
                 android:id="@+id/filter_by_label"
-                android:title="@string/issue_filter_by_labels" />
+                android:title="@string/issue_filter_by_label" />
             <item
                 android:id="@+id/filter_by_assignee"
                 android:title="@string/issue_filter_by_assignee" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -412,7 +412,7 @@
     <string name="issue_milestone_close_error">Closing milestone failed.</string>
     <string name="issue_milestone_reopen_error">Reopening milestone failed.</string>
     <string name="issue_filter">Filter</string>
-    <string name="issue_filter_by_labels">Filter by labels</string>
+    <string name="issue_filter_by_label">Filter by label</string>
     <string name="issue_filter_by_milestone">Filter by milestone</string>
     <string name="issue_filter_by_assignee">Filter by assignee</string>
     <string name="issue_filter_by_participating">Filter by participating status</string>


### PR DESCRIPTION
The primary goal of this PR is to allow searching by text and filtering by milestone/label etc. at the same time in issue/PR lists.
Previously, searching for issues by text would silently ignore the filters applied by the user, which was IMHO a confusing and unnecessarily restrictive behavior.
While implementing this, I've also discovered and fixed some issues:
- in the right drawer, the currently selected milestone/label/etc. wasn't being displayed because menu items' text was truncated to 1 line by default

| Before fix | After fix |
|--------|--------|
| ![Screenshot_filter_before](https://user-images.githubusercontent.com/30041551/230727770-20b89787-5e33-40c3-873b-e923c95d1070.png) | ![Screenshot_filter_after](https://user-images.githubusercontent.com/30041551/230727756-35a19a0d-8519-4906-a09d-8910e3ef3d66.png) | 

- "Filter by X" dialogs would always start with the first item selected, no matter what the current selection was. The issue was caused by a mistyped Fragment argument name, so I've moved those names to constants to avoid the same problem in the future.
- the empty placeholder text (the one shown when there are no matching issues) now displays the correct message when the user is filtering but not searching by text (previously it showed "No issues have been reported so far")
- small tweak: I've renamed "Filter by labels" menu item into "Filter by label" because it allows searching only by a single label and not by multiple ones