### PR TITLE
Make launcher icon independent from DayNight mode

### DIFF
--- a/app/src/main/res/drawable-anydpi-v26/launcher_bg.xml
+++ b/app/src/main/res/drawable-anydpi-v26/launcher_bg.xml
@@ -9,8 +9,8 @@
         android:pathData="M0,0 H100 V100 H-100 Z">
         <aapt:attr name="android:fillColor">
             <gradient
-                android:startColor="@color/primary"
-                android:endColor="@color/primary"
+                android:startColor="@color/launcher_bg"
+                android:endColor="@color/launcher_bg"
                 android:startY="0"
                 android:endY="100"
                 android:type="linear" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -51,4 +51,5 @@
     <color name="breadcrumb_background">#7baa67</color>
 
     <color name="octodroid">#97C03E</color>
+    <color name="launcher_bg">#396426</color>
 </resources>


### PR DESCRIPTION
Before the launcher icon background was brighter when the device was in day mode when the icon has been added. It didn't follow the DayNight mode, so it felt wrong to me to respect DayNight mode.