### PR TITLE
Use dynamic status bar height in the left drawer header

### DIFF
--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -51,6 +51,8 @@ import com.google.android.material.snackbar.Snackbar;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.GravityCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -275,6 +277,11 @@ public abstract class BaseActivity extends AppCompatActivity implements
     }
 
     protected void configureLeftDrawerHeader(View header) {
+        ViewCompat.setOnApplyWindowInsetsListener(header, (view, insets) -> {
+            int statusBarHeight = insets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
+            view.setPadding(0, statusBarHeight, 0, 0);
+            return insets;
+        });
     }
 
     protected boolean canSwipeToRefresh() {

--- a/app/src/main/res/layout/drawer_header_left.xml
+++ b/app/src/main/res/layout/drawer_header_left.xml
@@ -15,8 +15,7 @@
         android:layout_gravity="center_vertical"
         android:orientation="vertical"
         android:paddingBottom="8dp"
-        android:paddingLeft="16dp"
-        android:paddingTop="24dp">
+        android:paddingLeft="16dp">
 
         <ImageView
             android:id="@+id/avatar"


### PR DESCRIPTION
Use dynamic status bar height in the left drawer header instead of the 24dp hard coded

Before / After

![Screenshot_20230529_190130 Medium](https://github.com/slapperwan/gh4a/assets/3964819/526451af-cd6c-41d9-ac90-c497d614c03c)![Screenshot_20230529_190100 Medium](https://github.com/slapperwan/gh4a/assets/3964819/1422616b-bd2a-41e0-aa68-10ab4092660b)
