### PR TITLE
Re-introduce ability to install downloaded APKs directly

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <queries>
         <intent>


### PR DESCRIPTION
Since we no longer target the Play Store, we can re-add the permission that allows downloaded APKs to be installed by tapping directly on the download notification. This was initially introduced in #1130 and reverted in f6f325e.