### PR TITLE
Fix a few crashes

### DIFF
--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -62,12 +62,12 @@ public class ReleaseInfoActivity extends BaseActivity implements
                 .putExtra("id", id);
     }
 
-    public static Intent makeIntent(Context context, String repoOwner, String repoName,
-                                    Release release) {
-        return new Intent(context, ReleaseInfoActivity.class)
+    public static Intent makeIntent(Context context, String repoOwner, String repoName, Release release) {
+        Intent intent = new Intent(context, ReleaseInfoActivity.class)
                 .putExtra("owner", repoOwner)
-                .putExtra("repo", repoName)
-                .putExtra("release", release);
+                .putExtra("repo", repoName);
+        IntentUtils.putCompressedParcelableExtra(intent, "release", release, 800_000);
+        return intent;
     }
 
     private static final int ID_LOADER_RELEASE = 0;
@@ -115,7 +115,7 @@ public class ReleaseInfoActivity extends BaseActivity implements
         super.onInitExtras(extras);
         mRepoOwner = extras.getString("owner");
         mRepoName = extras.getString("repo");
-        mRelease = extras.getParcelable("release");
+        mRelease = IntentUtils.readCompressedParcelableFromBundle(extras, "release");
         mReleaseId = extras.getLong("id");
     }
 

--- a/app/src/main/java/com/gh4a/adapter/SearchAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/SearchAdapter.java
@@ -109,7 +109,10 @@ public class SearchAdapter extends RootAdapter<Object, RecyclerView.ViewHolder> 
                         for (TextMatch.MatchItem item : items) {
                             int start = item.getStartPos();
                             int end = item.getEndPos();
-                            if (start >= 0 && end > start) {
+                            // GH API returns incorrect indices for match items when the code snippet contains multi-byte characters.
+                            // We want to make sure we don't crash when those indices fall outside the text length.
+                            boolean isInsideTextRange = start < builder.length() && end < builder.length();
+                            if (start >= 0 && end > start && isInsideTextRange) {
                                 builder.setSpan(new StyleSpan(Typeface.BOLD), start, end, 0);
                             }
                         }

--- a/app/src/main/java/com/gh4a/utils/SingleFactory.java
+++ b/app/src/main/java/com/gh4a/utils/SingleFactory.java
@@ -83,15 +83,15 @@ public class SingleFactory {
 
         // sort each group by updatedAt
         for (ArrayList<NotificationThread> list : notificationsByRepo.values()) {
-            Collections.sort(list, (lhs, rhs) -> rhs.updatedAt().compareTo(lhs.updatedAt()));
+            Collections.sort(list, SingleFactory::compareNotificationsByUpdateDate);
         }
 
         // sort groups by updatedAt of top notification
         ArrayList<Repository> reposByTimestamp = new ArrayList<>(notificationsByRepo.keySet());
-        Collections.sort(reposByTimestamp, (lhs, rhs) -> {
-            NotificationThread lhsNotification = notificationsByRepo.get(lhs).get(0);
-            NotificationThread rhsNotification = notificationsByRepo.get(rhs).get(0);
-            return rhsNotification.updatedAt().compareTo(lhsNotification.updatedAt());
+        Collections.sort(reposByTimestamp, (lhsRepo, rhsRepo) -> {
+            NotificationThread lhsNotification = notificationsByRepo.get(lhsRepo).get(0);
+            NotificationThread rhsNotification = notificationsByRepo.get(rhsRepo).get(0);
+            return compareNotificationsByUpdateDate(lhsNotification, rhsNotification);
         });
 
         // add to list
@@ -115,6 +115,19 @@ public class SingleFactory {
         }
 
         return new NotificationListLoadResult(result);
+    }
+
+    private static int compareNotificationsByUpdateDate(NotificationThread lhs, NotificationThread rhs) {
+        if (lhs.updatedAt() == null && rhs.updatedAt() == null) {
+            return 0;
+        }
+        if (lhs.updatedAt() == null) {
+            return 1;
+        }
+        if (rhs.updatedAt() == null) {
+            return -1;
+        }
+        return rhs.updatedAt().compareTo(lhs.updatedAt());
     }
 
     public static Single<List<Feed>> loadFeed(String relativeUrl) {


### PR DESCRIPTION
This PR includes some fixes for a few crashes that I have encountered myself or that others have reported:
- #1312: this is caused by incorrect results returned by GitHub code search API. I have already reported the bug to them several months ago, but it still hasn't been fixed on their side. I have added a simple workaround to ignore incorrect match data returned by the API.
- 64b8e550f: this crash could be reproduced by opening https://github.com/rails/rails/releases/tag/v7.1.0, which features an incredibly long changelog
- 3dda7ce5: this is an attempt to fix #1326, which I'm not able to reproduce on my side. It looks like it crashes due to a null `updated_at` field of a notification (which shouldn't even occur according to [their response schema](https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#list-notifications-for-the-authenticated-user)). However, I really cannot understand why the exception occurs at line 94 of SingleFactory but not at line 86, where it does the same comparison for all notifications. :thinking: 

Fixes #1312 
Fixes #1326 