### PR TITLE
Fix handling of some organization links

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     implementation 'com.github.Tunous:MarkdownEdit:1.0.0'
     implementation 'com.github.qoqa:traceur:2.2.12'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.robolectric:robolectric:4.4'
+    testImplementation 'org.robolectric:robolectric:4.13'
 }
 
 def props = new Properties()

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -100,7 +100,7 @@ public class LinkParser {
             case "blog":
                 return parseBlogLink(activity, parts);
             case "orgs":
-                return parseOrganizationLink(activity, parts);
+                return parseOrganizationLink(activity, uri, parts);
             case "search":
                 return parseSearchLink(activity, uri);
         }
@@ -169,7 +169,7 @@ public class LinkParser {
     }
 
     @Nullable
-    private static ParseResult parseOrganizationLink(FragmentActivity activity,
+    private static ParseResult parseOrganizationLink(FragmentActivity activity, Uri uri,
             List<String> parts) {
         String org = parts.size() >= 2 ? parts.get(1) : null;
         String action = parts.size() >= 3 ? parts.get(2) : null;
@@ -177,10 +177,16 @@ public class LinkParser {
         if (org == null) {
             return null;
         }
+        if (action == null) {
+            return new ParseResult(UserActivity.makeIntent(activity, org));
+        }
         if ("people".equals(action)) {
             return new ParseResult(OrganizationMemberListActivity.makeIntent(activity, org));
         }
-        return new ParseResult(UserActivity.makeIntent(activity, org));
+        if ("repositories".equals(action)) {
+            return new ParseResult(new UserReposLoadTask(activity, uri, org, false));
+        }
+        return null;
     }
 
     private static ParseResult parseUserLink(FragmentActivity activity, @NonNull Uri uri,

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -163,17 +163,29 @@ public class LinkParserTest {
     }
 
     @Test
-    public void organizationLink_withoutName__opensBrowser() {
-        assertRedirectsToBrowser(parseLink("https://github.com/orgs"));
-    }
-
-    @Test
-    public void organisationLink_leadingToMembers__opensOrganizationMemberListActivity() {
+    public void organizationLink_leadingToMembers__opensOrganizationMemberListActivity() {
         LinkParser.ParseResult result = parseLink("https://github.com/orgs/android/people");
         assertRedirectsTo(result, OrganizationMemberListActivity.class);
         Bundle extras = result.intent.getExtras();
         assertThat("Extras are missing", extras, is(notNullValue()));
         assertThat("Organization name is incorrect", extras.getString("login"), is("android"));
+    }
+
+    public void organizationLink_leadingToRepositories__loadsOrganizationRepos() {
+        LinkParser.ParseResult result = parseLink("https://github.com/orgs/android/repositories/");
+        UserReposLoadTask loadTask = assertThatLoadTaskIs(result.loadTask, UserReposLoadTask.class);
+        assertThat("Loading starred repos is set to true", loadTask.mShowStars, is(false));
+        assertThat("User name is incorrect", loadTask.mUserLogin, is("android"));
+    }
+
+    @Test
+    public void organizationLink_leadingToAnotherSubPage__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/orgs/community/discussions/"));
+    }
+
+    @Test
+    public void organizationLink_withoutName__opensBrowser() {
+        assertRedirectsToBrowser(parseLink("https://github.com/orgs"));
     }
 
     @Test


### PR DESCRIPTION
Just a small PR to fix an issue in organization links handling that I've accidentally discovered thanks to the link in [this comment](https://github.com/slapperwan/gh4a/issues/1336#issuecomment-2212551262).
Before this change, links pointing to an organization subpage (e.g. Discussions, Packages, Settings) confusingly redirected the user to the organization details screen. Now all subpages are opened in the browser, with the exception of _Members_ and _Repositories_ which open the relevant app screens.

I've also updated Robolectric, since the old version was causing unit tests to blow up with a `NoClassDefFoundError` (I guess updating SDK/dependencies broke something).