### PR TITLE
Fix a couple of layout overflow issues + reaction fixes

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/timeline/CommentViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/CommentViewHolder.java
@@ -93,7 +93,7 @@ class CommentViewHolder
         mPopupMenu.setOnMenuItemClickListener(this);
 
         MenuItem reactItem = mPopupMenu.getMenu().findItem(R.id.react);
-        if (callback.canAddReaction()) {
+        if (Gh4Application.get().isAuthorized() && callback.canAddReaction()) {
             mPopupMenu.getMenuInflater().inflate(R.menu.reaction_menu, reactItem.getSubMenu());
             mReactionMenuHelper = new ReactionBar.AddReactionMenuHelper(view.getContext(),
                     reactItem.getSubMenu(), this, this, reactionDetailsCache);

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -264,7 +264,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         inflater.inflate(R.menu.issue_fragment_menu, menu);
 
         MenuItem reactItem = menu.findItem(R.id.react);
-        if (isLocked()) {
+        if (!Gh4Application.get().isAuthorized() || isLocked()) {
             reactItem.setVisible(false);
         } else {
             inflater.inflate(R.menu.reaction_menu, reactItem.getSubMenu());

--- a/app/src/main/java/com/gh4a/widget/ReactionBar.java
+++ b/app/src/main/java/com/gh4a/widget/ReactionBar.java
@@ -23,8 +23,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
+import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.gh4a.Gh4Application;
@@ -45,7 +45,7 @@ import java.util.List;
 
 import io.reactivex.Single;
 
-public class ReactionBar extends LinearLayout implements View.OnClickListener {
+public class ReactionBar extends HorizontalScrollView implements View.OnClickListener {
     public interface Item {
         Object getCacheKey();
     }
@@ -104,7 +104,6 @@ public class ReactionBar extends LinearLayout implements View.OnClickListener {
     public ReactionBar(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
 
-        setOrientation(HORIZONTAL);
         inflate(context, R.layout.reaction_bar, this);
 
         mPlusOneView = findViewById(R.id.plus_one);

--- a/app/src/main/java/com/gh4a/widget/ReactionBar.java
+++ b/app/src/main/java/com/gh4a/widget/ReactionBar.java
@@ -152,7 +152,8 @@ public class ReactionBar extends HorizontalScrollView implements View.OnClickLis
         for (int id : VIEW_IDS) {
             findViewById(id).setOnClickListener(callback != null ? this : null);
         }
-        mReactButton.setVisibility(callback != null && callback.canAddReaction()
+        boolean isUserLoggedIn = Gh4Application.get().isAuthorized();
+        mReactButton.setVisibility(isUserLoggedIn && callback != null && callback.canAddReaction()
                 ? View.VISIBLE : View.GONE);
         mReactButton.setOnClickListener(callback != null ? this : null);
     }

--- a/app/src/main/res/layout/reaction_bar.xml
+++ b/app/src/main/res/layout/reaction_bar.xml
@@ -1,53 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <TextView
-        android:id="@+id/plus_one"
-        style="@style/ReactionBarButton"
-        android:drawableLeft="@drawable/reaction_plus_one" />
-
-    <TextView
-        android:id="@+id/minus_one"
-        style="@style/ReactionBarButton"
-        android:drawableLeft="@drawable/reaction_minus_one" />
-
-    <TextView
-        android:id="@+id/laugh"
-        style="@style/ReactionBarButton"
-        android:drawableLeft="@drawable/reaction_laugh" />
-
-    <TextView
-        android:id="@+id/hooray"
-        style="@style/ReactionBarButton"
-        android:drawableLeft="@drawable/reaction_hooray" />
-
-    <TextView
-        android:id="@+id/confused"
-        style="@style/ReactionBarButton"
-        android:drawableLeft="@drawable/reaction_confused" />
-
-    <TextView
-        android:id="@+id/heart"
-        style="@style/ReactionBarButton"
-        android:drawableLeft="@drawable/reaction_heart" />
-
-    <TextView
-        android:id="@+id/rocket"
-        style="@style/ReactionBarButton"
-        android:drawableLeft="@drawable/reaction_rocket" />
-
-    <TextView
-        android:id="@+id/eyes"
-        style="@style/ReactionBarButton"
-        android:drawableLeft="@drawable/reaction_eyes" />
-
-    <ImageView
-        android:id="@+id/react"
-        style="@style/SelectableBorderlessItem"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:padding="8dp"
-        android:src="@drawable/overflow" />
+        android:orientation="horizontal">
 
+        <TextView
+            android:id="@+id/plus_one"
+            style="@style/ReactionBarButton"
+            android:drawableLeft="@drawable/reaction_plus_one" />
+
+        <TextView
+            android:id="@+id/minus_one"
+            style="@style/ReactionBarButton"
+            android:drawableLeft="@drawable/reaction_minus_one" />
+
+        <TextView
+            android:id="@+id/laugh"
+            style="@style/ReactionBarButton"
+            android:drawableLeft="@drawable/reaction_laugh" />
+
+        <TextView
+            android:id="@+id/hooray"
+            style="@style/ReactionBarButton"
+            android:drawableLeft="@drawable/reaction_hooray" />
+
+        <TextView
+            android:id="@+id/confused"
+            style="@style/ReactionBarButton"
+            android:drawableLeft="@drawable/reaction_confused" />
+
+        <TextView
+            android:id="@+id/heart"
+            style="@style/ReactionBarButton"
+            android:drawableLeft="@drawable/reaction_heart" />
+
+        <TextView
+            android:id="@+id/rocket"
+            style="@style/ReactionBarButton"
+            android:drawableLeft="@drawable/reaction_rocket" />
+
+        <TextView
+            android:id="@+id/eyes"
+            style="@style/ReactionBarButton"
+            android:drawableLeft="@drawable/reaction_eyes" />
+
+        <ImageView
+            android:id="@+id/react"
+            style="@style/SelectableBorderlessItem"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:padding="8dp"
+            android:src="@drawable/overflow" />
+
+    </LinearLayout>
 </merge>

--- a/app/src/main/res/layout/row_trend.xml
+++ b/app/src/main/res/layout/row_trend.xml
@@ -26,41 +26,48 @@
         android:textAppearance="?android:attr/textAppearanceSmall"
         tools:text="Repository description" />
 
-    <LinearLayout
+    <HorizontalScrollView
+        android:clickable="false"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:orientation="horizontal">
+        android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/tv_lang"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:drawableLeft="@drawable/language_small"
-            android:drawablePadding="4dp"
-            android:layout_marginRight="16dp"
-            android:textAppearance="@style/TextAppearance.VerySmall"
-            tools:text="Language" />
+            android:layout_marginTop="4dp"
+            android:orientation="horizontal">
 
-        <TextView
-            android:id="@+id/tv_stars"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="16dp"
-            android:drawableLeft="@drawable/star_small"
-            android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall"
-            tools:text="1000 this month, 3468 total" />
+            <TextView
+                android:id="@+id/tv_lang"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawableLeft="@drawable/language_small"
+                android:drawablePadding="4dp"
+                android:layout_marginRight="16dp"
+                android:textAppearance="@style/TextAppearance.VerySmall"
+                tools:text="Language" />
 
-        <TextView
-            android:id="@+id/tv_forks"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:drawableLeft="@drawable/fork_small"
-            android:drawablePadding="4dp"
-            android:textAppearance="@style/TextAppearance.VerySmall"
-            tools:text="2" />
+            <TextView
+                android:id="@+id/tv_stars"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="16dp"
+                android:drawableLeft="@drawable/star_small"
+                android:drawablePadding="4dp"
+                android:textAppearance="@style/TextAppearance.VerySmall"
+                tools:text="1000 this month, 3468 total" />
 
-    </LinearLayout>
+            <TextView
+                android:id="@+id/tv_forks"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawableLeft="@drawable/fork_small"
+                android:drawablePadding="4dp"
+                android:textAppearance="@style/TextAppearance.VerySmall"
+                tools:text="2" />
+
+        </LinearLayout>
+
+    </HorizontalScrollView>
 
 </LinearLayout>


### PR DESCRIPTION
This PR addresses two layout bugs that can occur on devices with small screens:
- the first is the trending repository details row overflowing the screen, as seen in the following screenshot:

<img src="https://github.com/user-attachments/assets/7eb0224a-476c-45f5-885c-10b543655b8c" width=350 />

- the other one is #1284.

While I was at it, I've also fixed #1283 by hiding "Add reaction" menu items and the corresponding button in the reaction bar when the user is not logged in.

Closes #1284 
Closes #1283