### PR TITLE
Add ability to select a reason when closing an issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -59,6 +60,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference:1.2.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,8 +49,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     namespace 'com.gh4a'
     buildFeatures {

--- a/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
@@ -79,6 +79,7 @@ import com.meisolsson.githubsdk.service.repositories.RepositoryContentService;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -603,12 +604,10 @@ public class IssueEditActivity extends BasePagerActivity implements
                         if (templates.size() == 1) {
                             handleIssueTemplateSelected(templates.get(0));
                         } else {
-                            List<IssueTemplate> namedTemplates = new ArrayList<>();
-                            for (IssueTemplate t : templates) {
-                                if (t.name != null) {
-                                    namedTemplates.add(t);
-                                }
-                            }
+                            List<IssueTemplate> namedTemplates = templates.stream()
+                                    .filter(template -> template.name != null)
+                                    .sorted(Comparator.comparing(template -> template.name))
+                                    .collect(toList());
                             IssueTemplateSelectionDialogFragment f =
                                     IssueTemplateSelectionDialogFragment.newInstance(namedTemplates);
                             f.show(getSupportFragmentManager(), "template-selection");

--- a/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
@@ -829,7 +829,7 @@ public class IssueEditActivity extends BasePagerActivity implements
             private LayoutInflater mInflater;
 
             public Adapter(Context context, List<IssueTemplate> templates) {
-                super(context, R.layout.row_issue_template, templates);
+                super(context, R.layout.row_item_with_description, templates);
                 mInflater = LayoutInflater.from(context);
             }
 
@@ -838,7 +838,7 @@ public class IssueEditActivity extends BasePagerActivity implements
             public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
                 final View view;
                 if (convertView == null) {
-                    view = mInflater.inflate(R.layout.row_issue_template, parent, false);
+                    view = mInflater.inflate(R.layout.row_item_with_description, parent, false);
                 } else {
                     view = convertView;
                 }

--- a/app/src/main/java/com/gh4a/adapter/ItemsWithDescriptionAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/ItemsWithDescriptionAdapter.java
@@ -1,0 +1,48 @@
+package com.gh4a.adapter;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+import com.gh4a.R;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class ItemsWithDescriptionAdapter extends ArrayAdapter<ItemsWithDescriptionAdapter.Item> {
+    public record Item(String title, String description) {}
+
+    private final LayoutInflater mInflater;
+
+    public ItemsWithDescriptionAdapter(Context context, List<Item> items) {
+        super(context, R.layout.row_item_with_description, items);
+        mInflater = LayoutInflater.from(context);
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        final View view;
+        if (convertView == null) {
+            view = mInflater.inflate(R.layout.row_item_with_description, parent, false);
+        } else {
+            view = convertView;
+        }
+
+        TextView titleView = view.findViewById(R.id.title);
+        TextView descriptionView = view.findViewById(R.id.description);
+        var item = getItem(position);
+
+        titleView.setText(item.title());
+        descriptionView.setText(item.description());
+        descriptionView.setVisibility(TextUtils.isEmpty(item.description()) ? View.GONE : View.VISIBLE);
+
+        return view;
+    }
+}

--- a/app/src/main/res/layout/row_item_with_description.xml
+++ b/app/src/main/res/layout/row_item_with_description.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -11,12 +13,14 @@
         android:id="@+id/title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+        android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+        tools:text="Title"/>
 
     <TextView
         android:id="@+id/description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+        android:textAppearance="@style/TextAppearance.AppCompat.Small"
+        tools:text="Description"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -432,8 +432,13 @@
     <string name="issue_comment_hint">Comment on this issue</string>
     <string name="commit_comment_header">%1$s added a note %2$s</string>
     <string name="issue_no_description">No description provided.</string>
-    <string name="close_issue_confirm">Do you really want to close this issue?</string>
     <string name="reopen_issue_confirm">Do you really want to reopen this issue?</string>
+    <string name="close_issue_dialog_title">Close issue as\u2026</string>
+    <string name="issue_reason_not_planned">Not planned</string>
+    <string name="issue_reason_not_planned_description">Won\'t fix, duplicate, stale</string>
+    <string name="issue_reason_completed">Completed</string>
+    <string name="issue_reason_completed_description">Done, closed, fixed, resolved</string>
+    <string name="close_issue">Close issue</string>
     <string name="issue_template_dialog_title">Select issue type</string>
 
     <!-- Pull Request -->


### PR DESCRIPTION
This PR implements the ability to specify a reason (_completed_ or _not planned_) when closing an issue by tapping the "Close" action in the app bar.
In #1223 I initially thought that this couldn't be done with the REST API, but luckily I was wrong.

![close_as_new](https://github.com/user-attachments/assets/2b5e902c-860e-4852-bc8b-68b8d5c3d0b1)

I intentionally kept the close reason descriptions short (almost the same as the GH web UI) so that they fit on a single line even on smaller screens. 

One minor feature that this PR lacks compared to the GH web UI is the ability to change the close reason of an issue without first reopening it. I didn't bother to add it, since I think it will rarely be useful in practice.
In case we really want to have it, we could simply add a "Close as not planned"/"Close as completed" action in the dropdown menu when the issue has already been closed.