### PR TITLE
Add support for release reactions

### DIFF
--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
+import com.gh4a.R;
 import com.gh4a.ServiceFactory;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.IntentUtils;
@@ -117,7 +118,8 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
         ReactionRequest request = ReactionRequest.builder().content(content).build();
 
         return service.createCommitCommentReaction(mRepoOwner, mRepoName, comment.comment.id(), request)
-                .map(ApiHelpers::throwOnFailure);
+                .map(ApiHelpers::throwOnFailure)
+                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.add_reaction_error));
     }
 
     @Override
@@ -125,6 +127,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
         CommentWrapper comment = (CommentWrapper) item;
         final ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deleteCommitCommentReaction(mRepoOwner, mRepoName, comment.comment.id(), reactionId)
-                .map(ApiHelpers::mapToTrueOnSuccess);
+                .map(ApiHelpers::mapToTrueOnSuccess)
+                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.remove_reaction_error));
     }
 }

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
+import com.gh4a.R;
 import com.gh4a.ServiceFactory;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.IntentUtils;
@@ -133,7 +134,8 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
         ReactionRequest request = ReactionRequest.builder().content(content).build();
 
         return service.createPullRequestReviewCommentReaction(mRepoOwner, mRepoName, comment.comment.id(), request)
-                .map(ApiHelpers::throwOnFailure);
+                .map(ApiHelpers::throwOnFailure)
+                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.add_reaction_error));
     }
 
     @Override
@@ -141,6 +143,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
         CommentWrapper comment = (CommentWrapper) item;
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deletePullRequestReviewCommentReaction(mRepoOwner, mRepoName, comment.comment.id(), reactionId)
-                .map(ApiHelpers::mapToTrueOnSuccess);
+                .map(ApiHelpers::mapToTrueOnSuccess)
+                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.remove_reaction_error));
     }
 }

--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -37,6 +37,7 @@ import com.gh4a.utils.AvatarHandler;
 import com.gh4a.utils.DownloadUtils;
 import com.gh4a.utils.HttpImageGetter;
 import com.gh4a.utils.IntentUtils;
+import com.gh4a.utils.RxUtils;
 import com.gh4a.utils.StringUtils;
 import com.gh4a.utils.UiUtils;
 import com.gh4a.widget.ReactionBar;
@@ -275,14 +276,16 @@ public class ReleaseInfoActivity extends BaseActivity implements
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         ReactionRequest request = ReactionRequest.builder().content(content).build();
         return service.createReleaseReaction(mRepoOwner, mRepoName, mRelease.id(), request)
-                .map(ApiHelpers::throwOnFailure);
+                .map(ApiHelpers::throwOnFailure)
+                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.add_reaction_error));
     }
 
     @Override
     public Single<Boolean> deleteReaction(ReactionBar.Item item, long reactionId) {
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deleteReleaseReaction(mRepoOwner, mRepoName, mRelease.id(), reactionId)
-                .map(ApiHelpers::mapToTrueOnSuccess);
+                .map(ApiHelpers::mapToTrueOnSuccess)
+                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.remove_reaction_error));
     }
 
     private void onReactionsUpdated(ReactionBar.Item item, Reactions reactions) {

--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -130,7 +130,7 @@ public class ReleaseInfoActivity extends BaseActivity implements
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.release, menu);
         MenuItem reactItem = menu.findItem(R.id.react);
-        getMenuInflater().inflate(R.menu.reaction_menu, reactItem.getSubMenu());
+        getMenuInflater().inflate(R.menu.release_reaction_menu, reactItem.getSubMenu());
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -241,6 +241,7 @@ public class ReleaseInfoActivity extends BaseActivity implements
         ReactionBar reactionBar = findViewById(R.id.reactions);
         reactionBar.setReactions(mRelease.reactions());
         reactionBar.setDetailsCache(mReactionDetailsCache);
+        reactionBar.setAddReactionPopupMenu(R.menu.release_reaction_menu);
         reactionBar.setCallback(this, () -> mRelease.id());
 
         if (mRelease.assets() != null && !mRelease.assets().isEmpty()) {

--- a/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
@@ -187,7 +187,7 @@ public class CommitNoteAdapter extends RootAdapter<GitComment, CommitNoteAdapter
         holder.tvExtra.setTag(user);
 
         holder.reactions.setReactions(item.reactions());
-        holder.mReactionMenuHelper.update();
+        holder.mReactionMenuHelper.updateMenuItems();
 
         String ourLogin = Gh4Application.get().getAuthLogin();
         boolean canEdit = ApiHelpers.loginEquals(user, ourLogin)
@@ -237,7 +237,7 @@ public class CommitNoteAdapter extends RootAdapter<GitComment, CommitNoteAdapter
         holder.mBoundItem = holder.mBoundItem.toBuilder().reactions(reactions).build();
         holder.reactions.setReactions(reactions);
         if (holder.mReactionMenuHelper != null) {
-            holder.mReactionMenuHelper.update();
+            holder.mReactionMenuHelper.updateMenuItems();
         }
         notifyItemChanged(holder.getBindingAdapterPosition());
     }

--- a/app/src/main/java/com/gh4a/adapter/timeline/CommentViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/CommentViewHolder.java
@@ -241,7 +241,7 @@ class CommentViewHolder
         }
         this.reactions.setReactions(reactions);
         if (mReactionMenuHelper != null) {
-            mReactionMenuHelper.update();
+            mReactionMenuHelper.updateMenuItems();
         }
     }
 

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -268,12 +268,8 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
             reactItem.setVisible(false);
         } else {
             inflater.inflate(R.menu.reaction_menu, reactItem.getSubMenu());
-            if (mReactionMenuHelper == null) {
-                mReactionMenuHelper = new ReactionBar.AddReactionMenuHelper(getActivity(),
-                        reactItem.getSubMenu(), this, this, mReactionDetailsCache);
-            } else {
-                mReactionMenuHelper.updateFromMenu(reactItem.getSubMenu());
-            }
+            mReactionMenuHelper = new ReactionBar.AddReactionMenuHelper(getActivity(),
+                    reactItem.getSubMenu(), this, this, mReactionDetailsCache);
             mReactionMenuHelper.startLoadingIfNeeded();
         }
     }
@@ -530,7 +526,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
             bar.setReactions(reactions);
         }
         if (mReactionMenuHelper != null) {
-            mReactionMenuHelper.update();
+            mReactionMenuHelper.updateMenuItems();
             getActivity().invalidateOptionsMenu();
         }
     }

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -485,14 +485,16 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         ReactionRequest request = ReactionRequest.builder().content(content).build();
         return service.createIssueReaction(mRepoOwner, mRepoName, mIssue.number(), request)
-                .map(ApiHelpers::throwOnFailure);
+                .map(ApiHelpers::throwOnFailure)
+                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.add_reaction_error));
     }
 
     @Override
     public Single<Boolean> deleteReaction(ReactionBar.Item item, long reactionId) {
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deleteIssueReaction(mRepoOwner, mRepoName, mIssue.number(), reactionId)
-                .map(ApiHelpers::mapToTrueOnSuccess);
+                .map(ApiHelpers::mapToTrueOnSuccess)
+                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.remove_reaction_error));
     }
 
     @Override
@@ -508,14 +510,16 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         ReactionRequest request = ReactionRequest.builder().content(content).build();
         return service.createIssueCommentReaction(mRepoOwner, mRepoName, comment.id(), request)
-                .map(ApiHelpers::throwOnFailure);
+                .map(ApiHelpers::throwOnFailure)
+                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.add_reaction_error));
     }
 
     @Override
     public Single<Boolean> deleteReaction(GitHubCommentBase comment, long reactionId) {
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deleteIssueCommentReaction(mRepoOwner, mRepoName, comment.id(), reactionId)
-                .map(ApiHelpers::mapToTrueOnSuccess);
+                .map(ApiHelpers::mapToTrueOnSuccess)
+                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.remove_reaction_error));
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
@@ -434,7 +434,8 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
         final Single<Response<Reaction>> responseSingle = comment instanceof ReviewComment
                 ? service.createPullRequestReviewCommentReaction(mRepoOwner, mRepoName, comment.id(), request)
                 : service.createIssueCommentReaction(mRepoOwner, mRepoName, comment.id(), request);
-        return responseSingle.map(ApiHelpers::throwOnFailure);
+        return responseSingle.map(ApiHelpers::throwOnFailure)
+                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.add_reaction_error));
     }
 
     @Override
@@ -443,7 +444,8 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
         final Single<Response<Void>> responseSingle = comment instanceof ReviewComment
                 ? service.deletePullRequestReviewCommentReaction(mRepoOwner, mRepoName, comment.id(), reactionId)
                 : service.deleteIssueCommentReaction(mRepoOwner, mRepoName, comment.id(), reactionId);
-        return responseSingle.map(ApiHelpers::mapToTrueOnSuccess);
+        return responseSingle.map(ApiHelpers::mapToTrueOnSuccess)
+                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.remove_reaction_error));
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/utils/RxUtils.java
+++ b/app/src/main/java/com/gh4a/utils/RxUtils.java
@@ -148,6 +148,10 @@ public class RxUtils {
         };
     }
 
+    public static <T> SingleTransformer<T, T> wrapWithRetrySnackbar(BaseActivity activity, @StringRes int errorMessageResId) {
+        return wrapWithRetrySnackbar(activity.getRootLayout(), activity.getString(errorMessageResId));
+    }
+
     public static <T> SingleTransformer<T, T> wrapWithRetrySnackbar(
             final CoordinatorLayout rootLayout, final String errorMessage) {
         return new SingleTransformer<T, T>() {

--- a/app/src/main/res/layout/release.xml
+++ b/app/src/main/res/layout/release.xml
@@ -75,7 +75,7 @@
                 android:layout_marginBottom="@dimen/overview_header_spacing"
                 android:orientation="vertical">
 
-                <com.gh4a.widget.LinkHandlingTextView
+                <TextView
                     android:id="@+id/release_notes_title"
                     style="@style/HeaderLabel"
                     android:layout_width="match_parent"
@@ -86,12 +86,20 @@
                     android:id="@+id/tv_release_notes"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingBottom="@dimen/content_padding"
+                    android:paddingBottom="@dimen/overview_item_spacing"
                     android:paddingLeft="@dimen/content_padding"
                     android:paddingRight="@dimen/content_padding"
                     android:textIsSelectable="true"
                     app:needsLinkHandling="true"
                     tools:text="Release notes text" />
+
+                <com.gh4a.widget.ReactionBar
+                    android:id="@+id/reactions"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="8dp"
+                    android:paddingLeft="@dimen/content_padding"
+                    android:paddingRight="@dimen/content_padding" />
 
             </LinearLayout>
 
@@ -108,7 +116,7 @@
                 android:layout_marginBottom="@dimen/overview_header_spacing"
                 android:orientation="vertical">
 
-                <com.gh4a.widget.LinkHandlingTextView
+                <TextView
                     android:id="@+id/downloads_title"
                     style="@style/HeaderLabel"
                     android:layout_width="match_parent"

--- a/app/src/main/res/menu/release.xml
+++ b/app/src/main/res/menu/release.xml
@@ -6,4 +6,11 @@
         android:icon="@drawable/menu_web"
         android:title="@string/open_in_browser"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/react"
+        android:title="@string/add_reaction"
+        android:visible="false">
+        <menu />
+    </item>
 </menu>

--- a/app/src/main/res/menu/release_reaction_menu.xml
+++ b/app/src/main/res/menu/release_reaction_menu.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/loading"
+        android:title="@string/loading_msg" />
+
+    <item
+        android:id="@+id/plus_one"
+        android:icon="@drawable/reaction_plus_one"
+        android:title="@string/reaction_plus_one"
+        android:visible="false" />
+
+    <item
+        android:id="@+id/laugh"
+        android:icon="@drawable/reaction_laugh"
+        android:title="@string/reaction_laugh"
+        android:visible="false" />
+
+    <item
+        android:id="@+id/hooray"
+        android:icon="@drawable/reaction_hooray"
+        android:title="@string/reaction_hooray"
+        android:visible="false" />
+
+    <item
+        android:id="@+id/heart"
+        android:icon="@drawable/reaction_heart"
+        android:title="@string/reaction_heart"
+        android:visible="false" />
+
+    <item
+        android:id="@+id/rocket"
+        android:icon="@drawable/reaction_rocket"
+        android:title="@string/reaction_rocket"
+        android:visible="false" />
+
+    <item
+        android:id="@+id/eyes"
+        android:icon="@drawable/reaction_eyes"
+        android:title="@string/reaction_eyes"
+        android:visible="false" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,8 @@
     <string name="add_comment">Add comment</string>
     <string name="add_reaction">Add reaction</string>
     <string name="remove_reaction">Remove reaction</string>
+    <string name="add_reaction_error">Adding reaction failed.</string>
+    <string name="remove_reaction_error">Removing reaction failed.</string>
     <string name="edit">Edit</string>
     <string name="members">Members</string>
     <string name="open">Open</string>


### PR DESCRIPTION
This PR implements full support for viewing and toggling reactions on releases. Here's an example:

![reactions](https://github.com/user-attachments/assets/14cad40b-95d5-4932-b98c-f02255fd27ef)

The implementation has been harder than I initially hoped for a few reasons:
- GitHub allows to react on releases only with "positive" reactions (so no :-1: or :confused:), and that's where I started going down the rabbit hole.
The approach I chose - which to me looked the less impactful for existing logic in the ReactionBar - was to use a different menu resource for the "add reaction popup" without :-1:/:confused: items, and set up the ReactionBar use that.
However, the `AddReactionMenuHelper` wasn't designed to support showing only a subset of all possible reaction types in the menu. So I had to heavily refactor it to accommodate for that, replacing parallel arrays used to store menu items and user's own reaction IDs with a `List` and a `HashMap` respectively. I've used this opportunity to simplify the logic of several methods of the class (using Streams where possible) and improve some method/field names (commits 0a7f49d and 3bf3077)
- when the user is logged into the app via OAuth, API calls for reacting on a release always fail if the repo belongs to an org that has [OAuth restrictions enabled](https://docs.github.com/en/organizations/managing-oauth-access-to-your-organizations-data/about-oauth-app-access-restrictions) (two notable examples I've encountered are PowerShell and rails).
While it looks like a weird API behavior (or maybe a bug, I'll ask GH support when I have some time), it's also true that the app didn't show an error message if toggling a reaction failed. So I've decided to handle this by displaying a snackbar as we already do in other situations when a user action fails. I plan to try to improve those snackbars with more details on the error in a future PR.

I recommend reviewing this PR commit by commit. I have added some review comments to explain the context behind some smaller changes.