### PR TITLE
Build adjustments and minor dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This application provides access to [GitHub](https://github.com/) and lets you s
 
 Download
 --------
-<a href='https://play.google.com/store/apps/details?id=com.gh4a'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="80px" align="left"/></a>[<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="80px">](https://f-droid.org/packages/com.gh4a/)
+[<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="80px">](https://f-droid.org/packages/com.gh4a/)
 
 Main features
 -------------

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,10 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'
+
+    def okHttpVersion = '3.14.9'
+    def retrofitVersion = '2.11.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference:1.2.1'
@@ -75,24 +78,24 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.print:print:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
-    implementation 'androidx.work:work-runtime:2.9.0'
+    implementation 'androidx.work:work-runtime:2.9.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.14.9'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.9'
-    implementation('com.squareup.retrofit2:converter-simplexml:2.6.4') {
+    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
+    implementation("com.squareup.retrofit2:converter-simplexml:$retrofitVersion") {
         exclude group: 'stax', module: 'stax-api'
         exclude group: 'stax', module: 'stax'
         exclude group: 'xpp3', module: 'xpp3'
     }
+    implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
+    implementation "com.squareup.okhttp3:logging-interceptor:$okHttpVersion"
     implementation 'com.github.maniac103:rxloader:master-SNAPSHOT'
-    implementation 'com.github.maniac103:githubsdk:0.7.0.15'
+    implementation 'com.github.maniac103:githubsdk:0.7.0.17'
     implementation 'com.larswerkman:HoloColorPicker:1.5@aar'
     implementation 'com.caverock:androidsvg-aar:1.4'
-    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.25'
-    implementation 'org.ocpsoft.prettytime:prettytime:4.0.6.Final'
+    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.29'
+    implementation 'org.ocpsoft.prettytime:prettytime:5.0.9.Final'
     implementation 'com.github.castorflex.smoothprogressbar:library:1.3.0'
     implementation 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
     implementation 'com.github.pluscubed:recycler-fast-scroll:3de76812553a77bfd25d3aea0a0af4d96516c3e3@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ android {
         versionName "4.6.12"
         applicationId "com.gh4a"
 
+        resConfigs "en"
         buildConfigField 'String', 'CLIENT_ID', ClientId
         buildConfigField 'String', 'CLIENT_SECRET', ClientSecret
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,11 @@ android {
     buildFeatures {
         buildConfig true
     }
+
+    dependenciesInfo {
+        includeInApk false
+        includeInBundle false
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,9 +23,6 @@ ext {
 }
 
 android {
-    signingConfigs {
-        playStore
-    }
     compileSdk 34
     defaultConfig {
         minSdkVersion 23
@@ -39,13 +36,17 @@ android {
         buildConfigField 'String', 'CLIENT_SECRET', ClientSecret
     }
 
+    signingConfigs {
+        release
+    }
+
     buildTypes {
         debug {
             applicationIdSuffix '.debug'
         }
         release {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.playStore
+            signingConfig signingConfigs.release
         }
     }
 
@@ -114,10 +115,10 @@ if (props.containsKey('STORE_FILE')
         && props.containsKey('STORE_PASSWORD')
         && props.containsKey('KEY_ALIAS')
         && props.containsKey('KEY_PASSWORD')) {
-    android.signingConfigs.playStore.storeFile = file(props['STORE_FILE'])
-    android.signingConfigs.playStore.storePassword = props['STORE_PASSWORD']
-    android.signingConfigs.playStore.keyAlias = props['KEY_ALIAS']
-    android.signingConfigs.playStore.keyPassword = props['KEY_PASSWORD']
+    android.signingConfigs.release.storeFile = file(props['STORE_FILE'])
+    android.signingConfigs.release.storePassword = props['STORE_PASSWORD']
+    android.signingConfigs.release.keyAlias = props['KEY_ALIAS']
+    android.signingConfigs.release.keyPassword = props['KEY_PASSWORD']
 } else {
     println 'signing.properties not found or incomplete'
     android.buildTypes.release.signingConfig = null

--- a/app/src/main/java/com/gh4a/BaseActivity.java
+++ b/app/src/main/java/com/gh4a/BaseActivity.java
@@ -29,7 +29,6 @@ import android.content.pm.PackageManager;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 
@@ -725,12 +724,12 @@ public abstract class BaseActivity extends AppCompatActivity implements
     private void setupHeaderDrawable() {
         ensureContent();
 
-        int primaryColor = UiUtils.resolveColor(this, R.attr.colorPrimary);
+        int primaryColor = UiUtils.resolveColor(this, androidx.appcompat.R.attr.colorPrimary);
         assignBackground(mLeftDrawerHeader, primaryColor);
         assignBackground(mRightDrawerHeader, primaryColor);
         assignBackground(mHeader, primaryColor);
 
-        int primaryDarkColor = UiUtils.resolveColor(this, R.attr.colorPrimaryDark);
+        int primaryDarkColor = UiUtils.resolveColor(this, androidx.appcompat.R.attr.colorPrimaryDark);
         ColorDrawable d = new ColorDrawable(primaryDarkColor);
         mDrawerLayout.setStatusBarBackground(d);
         mStatusBarDrawables.add(d);
@@ -757,8 +756,8 @@ public abstract class BaseActivity extends AppCompatActivity implements
         if (canSwipeToRefresh()) {
             mSwipeLayout.setOnRefreshListener(this);
             mSwipeLayout.setColorSchemeColors(
-                    UiUtils.resolveColor(this, R.attr.colorPrimary), 0,
-                    UiUtils.resolveColor(this, R.attr.colorPrimaryDark), 0
+                    UiUtils.resolveColor(this, androidx.appcompat.R.attr.colorPrimary), 0,
+                    UiUtils.resolveColor(this, androidx.appcompat.R.attr.colorPrimaryDark), 0
             );
         }
 
@@ -860,7 +859,7 @@ public abstract class BaseActivity extends AppCompatActivity implements
             return null;
         }
         ColorStateList baseColor = ContextCompat.getColorStateList(this, value.resourceId);
-        if (!getTheme().resolveAttribute(R.attr.colorAccent, value, true)) {
+        if (!getTheme().resolveAttribute(androidx.appcompat.R.attr.colorAccent, value, true)) {
             return null;
         }
         int colorAccent = value.data;
@@ -889,8 +888,8 @@ public abstract class BaseActivity extends AppCompatActivity implements
             return;
         }
         mProgress = findViewById(R.id.progress);
-        mProgressColors[0] = UiUtils.resolveColor(this, R.attr.colorPrimary);
-        mProgressColors[1] = UiUtils.resolveColor(this, R.attr.colorPrimaryDark);
+        mProgressColors[0] = UiUtils.resolveColor(this, androidx.appcompat.R.attr.colorPrimary);
+        mProgressColors[1] = UiUtils.resolveColor(this, androidx.appcompat.R.attr.colorPrimaryDark);
         mProgress.setSmoothProgressDrawableColors(mProgressColors);
 
         mCoordinatorLayout = findViewById(R.id.coordinator_layout);

--- a/app/src/main/java/com/gh4a/BasePagerActivity.java
+++ b/app/src/main/java/com/gh4a/BasePagerActivity.java
@@ -34,7 +34,7 @@ public abstract class BasePagerActivity extends BaseActivity implements
         setContentView(R.layout.view_pager);
         mPager = setupPager();
 
-        mCurrentHeaderColor = UiUtils.resolveColor(this, R.attr.colorPrimary);
+        mCurrentHeaderColor = UiUtils.resolveColor(this, androidx.appcompat.R.attr.colorPrimary);
         updateTabHeaderColors();
         updateTabVisibility();
     }
@@ -69,7 +69,7 @@ public abstract class BasePagerActivity extends BaseActivity implements
             if (colorAttrs != null) {
                 transitionHeaderToColor(colorAttrs[0], colorAttrs[1]);
             } else {
-                transitionHeaderToColor(R.attr.colorPrimary, R.attr.colorPrimaryDark);
+                transitionHeaderToColor(androidx.appcompat.R.attr.colorPrimary, androidx.appcompat.R.attr.colorPrimaryDark);
             }
         }
         tryUpdatePagerColor();

--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -27,7 +27,6 @@ import com.gh4a.utils.RxUtils;
 import com.gh4a.widget.ReactionBar;
 import com.meisolsson.githubsdk.model.PositionalCommentBase;
 import com.meisolsson.githubsdk.model.Reaction;
-import com.meisolsson.githubsdk.model.Reactions;
 import com.meisolsson.githubsdk.model.git.GitComment;
 import com.meisolsson.githubsdk.model.request.ReactionRequest;
 import com.meisolsson.githubsdk.service.reactions.ReactionService;
@@ -69,14 +68,6 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
     @Override
     protected boolean canReply() {
         return false;
-    }
-
-    @Override
-    protected PositionalCommentBase buildCommentWithReactions(PositionalCommentBase comment,
-            Reactions reactions) {
-        return ((GitComment) comment).toBuilder()
-                .reactions(reactions)
-                .build();
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
@@ -253,7 +253,7 @@ public abstract class DiffViewerActivity<C extends PositionalCommentBase> extend
     @Override
     public void onReactionsUpdated(ReactionBar.Item item, Reactions reactions) {
         CommentWrapper wrapper = (CommentWrapper) item;
-        wrapper.comment = buildCommentWithReactions(wrapper.comment, reactions);
+        wrapper.comment = wrapper.comment.withReactions(reactions);
         replaceOutdatedComment(wrapper.comment);
         onDataReady();
     }
@@ -497,8 +497,6 @@ public abstract class DiffViewerActivity<C extends PositionalCommentBase> extend
     protected abstract Single<Response<Void>> deleteCommentSingle(long id);
     protected abstract boolean canReply();
     protected abstract Uri createUrl(String lineId, long replyId);
-    protected abstract PositionalCommentBase buildCommentWithReactions(PositionalCommentBase comment,
-            Reactions reactions);
 
     private String createLineLinkId(int line, boolean isRight) {
         return (isRight ? "R" : "L") + line;

--- a/app/src/main/java/com/gh4a/activities/IssueActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueActivity.java
@@ -275,7 +275,7 @@ public class IssueActivity extends BaseActivity implements
         mIsCollaborator = null;
         setContentShown(false);
 
-        transitionHeaderToColor(R.attr.colorPrimary, R.attr.colorPrimaryDark);
+        transitionHeaderToColor(androidx.appcompat.R.attr.colorPrimary, androidx.appcompat.R.attr.colorPrimaryDark);
         mHeader.setVisibility(View.GONE);
 
         if (mFragment != null) {

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -28,7 +28,6 @@ import com.gh4a.utils.RxUtils;
 import com.gh4a.widget.ReactionBar;
 import com.meisolsson.githubsdk.model.PositionalCommentBase;
 import com.meisolsson.githubsdk.model.Reaction;
-import com.meisolsson.githubsdk.model.Reactions;
 import com.meisolsson.githubsdk.model.ReviewComment;
 import com.meisolsson.githubsdk.model.request.ReactionRequest;
 import com.meisolsson.githubsdk.service.reactions.ReactionService;
@@ -101,14 +100,6 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
     @Override
     protected boolean canReply() {
         return true;
-    }
-
-    @Override
-    protected PositionalCommentBase buildCommentWithReactions(PositionalCommentBase comment,
-            Reactions reactions) {
-        return ((ReviewComment) comment).toBuilder()
-                .reactions(reactions)
-                .build();
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
+++ b/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
@@ -145,7 +145,7 @@ public class HomeActivity extends BaseFragmentPagerActivity implements
         }
 
         @AttrRes int colorResId = checkedItemId == R.id.notifications
-                ? R.attr.colorAccent : android.R.attr.textColorPrimary;
+                ? androidx.appcompat.R.attr.colorAccent : android.R.attr.textColorPrimary;
         @ColorInt int tint = UiUtils.resolveColor(this, colorResId);
         DrawableCompat.setTint(mNotificationsIndicatorIcon, tint);
         mNotificationsIndicator.setImageDrawable(mNotificationsIndicatorIcon);

--- a/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
@@ -234,7 +234,7 @@ public class CommitNoteAdapter extends RootAdapter<GitComment, CommitNoteAdapter
     @Override
     public void onReactionsUpdated(ReactionBar.Item item, Reactions reactions) {
         ViewHolder holder = (ViewHolder) item;
-        holder.mBoundItem = holder.mBoundItem.toBuilder().reactions(reactions).build();
+        holder.mBoundItem = holder.mBoundItem.withReactions(reactions);
         holder.reactions.setReactions(reactions);
         if (holder.mReactionMenuHelper != null) {
             holder.mReactionMenuHelper.updateMenuItems();

--- a/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
@@ -239,7 +239,6 @@ public class CommitNoteAdapter extends RootAdapter<GitComment, CommitNoteAdapter
         if (holder.mReactionMenuHelper != null) {
             holder.mReactionMenuHelper.updateMenuItems();
         }
-        notifyItemChanged(holder.getBindingAdapterPosition());
     }
 
     public static class ViewHolder extends RecyclerView.ViewHolder implements

--- a/app/src/main/java/com/gh4a/adapter/timeline/DiffViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/DiffViewHolder.java
@@ -70,7 +70,7 @@ class DiffViewHolder extends TimelineItemAdapter.TimelineItemViewHolder<Timeline
         mDefaultBackgroundColor = ContextCompat.getColor(context, R.color.diff_default_background);
         mDefaultLineNumberBackgroundColor =
                 ContextCompat.getColor(context, R.color.diff_default_line_number_background);
-        mAccentColor = UiUtils.resolveColor(context, R.attr.colorAccent);
+        mAccentColor = UiUtils.resolveColor(context, androidx.appcompat.R.attr.colorAccent);
         mPadding = context.getResources().getDimensionPixelSize(R.dimen.code_diff_padding);
 
         mDiffHunkTextView = itemView.findViewById(R.id.diff_hunk);

--- a/app/src/main/java/com/gh4a/fragment/LoadingFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/LoadingFragmentBase.java
@@ -55,8 +55,8 @@ public abstract class LoadingFragmentBase extends Fragment implements
         super.onViewCreated(view, savedInstanceState);
 
         mProgress = view.findViewById(R.id.progress);
-        mProgressColors[0] = UiUtils.resolveColor(mProgress.getContext(), R.attr.colorPrimary);
-        mProgressColors[1] = UiUtils.resolveColor(mProgress.getContext(), R.attr.colorPrimaryDark);
+        mProgressColors[0] = UiUtils.resolveColor(mProgress.getContext(), androidx.appcompat.R.attr.colorPrimary);
+        mProgressColors[1] = UiUtils.resolveColor(mProgress.getContext(), androidx.appcompat.R.attr.colorPrimaryDark);
         mProgress.setSmoothProgressDrawableColors(mProgressColors);
         updateContentVisibility();
     }

--- a/app/src/main/java/com/gh4a/model/TimelineItem.java
+++ b/app/src/main/java/com/gh4a/model/TimelineItem.java
@@ -70,11 +70,7 @@ public abstract class TimelineItem {
         }
 
         public void setReactions(Reactions reactions) {
-            if (comment instanceof ReviewComment) {
-                comment = ((ReviewComment) comment).toBuilder().reactions(reactions).build();
-            } else {
-                comment = ((GitHubComment) comment).toBuilder().reactions(reactions).build();
-            }
+            comment = comment.withReactions(reactions);
         }
 
         public boolean hasFilePatch() {

--- a/app/src/main/java/com/gh4a/utils/IntentUtils.java
+++ b/app/src/main/java/com/gh4a/utils/IntentUtils.java
@@ -138,7 +138,7 @@ public class IntentUtils {
 
         if (pkg != null && customTabsEnabled) {
             if (headerColor == 0) {
-                headerColor = UiUtils.resolveColor(activity, R.attr.colorPrimary);
+                headerColor = UiUtils.resolveColor(activity, androidx.appcompat.R.attr.colorPrimary);
             }
             CustomTabColorSchemeParams colorParams = new CustomTabColorSchemeParams.Builder()
                     .setToolbarColor(headerColor)

--- a/app/src/main/java/com/gh4a/widget/OverviewRow.java
+++ b/app/src/main/java/com/gh4a/widget/OverviewRow.java
@@ -127,7 +127,7 @@ public class OverviewRow extends LinearLayoutCompat implements View.OnClickListe
             return;
         }
         int tintColor = UiUtils.resolveColor(getContext(),
-                mIconClickListener != null ? R.attr.colorAccent : R.attr.colorIconForeground);
+                mIconClickListener != null ? androidx.appcompat.R.attr.colorAccent : R.attr.colorIconForeground);
         DrawableCompat.setTint(drawable, tintColor);
         DrawableCompat.setTintMode(drawable, PorterDuff.Mode.SRC_IN);
     }

--- a/app/src/main/java/com/gh4a/widget/ReactionBar.java
+++ b/app/src/main/java/com/gh4a/widget/ReactionBar.java
@@ -557,7 +557,7 @@ public class ReactionBar extends HorizontalScrollView implements View.OnClickLis
         }
 
         private void updateDrawableColors() {
-            @ColorInt int accentColor = UiUtils.resolveColor(mContext, R.attr.colorAccent);
+            @ColorInt int accentColor = UiUtils.resolveColor(mContext, androidx.appcompat.R.attr.colorAccent);
             @ColorInt int secondaryColor = UiUtils.resolveColor(mContext,
                     android.R.attr.textColorSecondary);
             for (MenuItem item : mReactionMenuItems) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 android.enableJetifier=true
 android.nonFinalResIds=false
-android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
Aside from some minor dependency updates (including GH bindings), this PR introduces some tweaks to the build configuration:
- removed the [dependency info block](https://developer.android.com/build/dependencies#dependency-info-play) from the APK, which is useless for apps that aren't published on the Play Store
- migrated to [non-transitive R classes](https://developer.android.com/build/optimize-your-build#use-non-transitive-r-classes), which are now the default for new projects
- renamed the signing config for release builds to `release` (was previously named `playStore`)
- added the configuration to [remove non-English strings from built APKs via `resConfigs`](https://developer.android.com/build/shrink-code#unused-alt-resources) (will need to be updated in case a new translation is added to the app). In my testing this saves ~700KB from the release APK, due to several translated strings coming from AppCompat and Material libraries which are hardly ever visible to the user. Note that this doesn't affect PrettyTime translations because they do not use Android resources.

I have also removed the outdated Play Store badge from the Readme (closes #1319, closes #1422) and extracted a one-line bugfix that was initially included in #1402 (0acc437, fixes a incorrect UI update that occurs when toggling commit comment reactions) since I ended up changing the same file in this PR.