### PR TITLE
Add "Discussions" shortcut to repository screen

### DIFF
--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -18,6 +18,7 @@ package com.gh4a.fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Typeface;
+import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import android.text.SpannableString;
@@ -45,6 +46,7 @@ import com.gh4a.activities.WikiListActivity;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.HtmlUtils;
 import com.gh4a.utils.HttpImageGetter;
+import com.gh4a.utils.IntentUtils;
 import com.gh4a.utils.Optional;
 import com.gh4a.utils.RxUtils;
 import com.gh4a.utils.StringUtils;
@@ -283,15 +285,15 @@ public class RepositoryFragment extends LoadingFragmentBase implements
             updateStargazerUi();
         }
 
+        mReadmeTitleView.setOnClickListener(view -> toggleReadmeExpanded());
         mContentView.findViewById(R.id.tv_contributors_label).setOnClickListener(this);
         mContentView.findViewById(R.id.other_info).setOnClickListener(this);
         mContentView.findViewById(R.id.tv_releases_label).setOnClickListener(this);
-        mReadmeTitleView.setOnClickListener(this);
 
         Permissions permissions = mRepository.permissions();
-        updateClickableLabel(R.id.tv_collaborators_label,
-                permissions != null && permissions.push());
+        updateClickableLabel(R.id.tv_collaborators_label, permissions != null && permissions.push());
         updateClickableLabel(R.id.tv_wiki_label, mRepository.hasWiki());
+        updateClickableLabel(R.id.tv_discussions_label, mRepository.hasDiscussions());
     }
 
     @NonNull
@@ -344,8 +346,8 @@ public class RepositoryFragment extends LoadingFragmentBase implements
     public void onClick(View view) {
         int id = view.getId();
 
-        if (id == R.id.readme_title) {
-            toggleReadmeExpanded();
+        if (id == R.id.tv_discussions_label) {
+            IntentUtils.openInCustomTabOrBrowser(getActivity(), Uri.parse(mRepository.htmlUrl() + "/discussions"));
             return;
         }
 

--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -71,7 +71,7 @@ import io.reactivex.Single;
 import retrofit2.Response;
 
 public class RepositoryFragment extends LoadingFragmentBase implements
-        OverviewRow.OnIconClickListener, View.OnClickListener {
+        OverviewRow.OnIconClickListener {
     public static RepositoryFragment newInstance(Repository repository, String ref) {
         RepositoryFragment f = new RepositoryFragment();
 
@@ -286,9 +286,8 @@ public class RepositoryFragment extends LoadingFragmentBase implements
         }
 
         mReadmeTitleView.setOnClickListener(view -> toggleReadmeExpanded());
-        mContentView.findViewById(R.id.tv_contributors_label).setOnClickListener(this);
-        mContentView.findViewById(R.id.other_info).setOnClickListener(this);
-        mContentView.findViewById(R.id.tv_releases_label).setOnClickListener(this);
+        mContentView.findViewById(R.id.tv_contributors_label).setOnClickListener(this::onOtherInfoLabelClick);
+        mContentView.findViewById(R.id.tv_releases_label).setOnClickListener(this::onOtherInfoLabelClick);
 
         Permissions permissions = mRepository.permissions();
         updateClickableLabel(R.id.tv_collaborators_label, permissions != null && permissions.push());
@@ -308,7 +307,7 @@ public class RepositoryFragment extends LoadingFragmentBase implements
     private void updateClickableLabel(int id, boolean enable) {
         View view = mContentView.findViewById(id);
         if (enable) {
-            view.setOnClickListener(this);
+            view.setOnClickListener(this::onOtherInfoLabelClick);
             view.setVisibility(View.VISIBLE);
         } else {
             view.setVisibility(View.GONE);
@@ -342,8 +341,7 @@ public class RepositoryFragment extends LoadingFragmentBase implements
         mWatcherRow.setToggleState(mIsWatching != null && mIsWatching);
     }
 
-    @Override
-    public void onClick(View view) {
+    private void onOtherInfoLabelClick(View view) {
         int id = view.getId();
 
         if (id == R.id.tv_discussions_label) {
@@ -363,8 +361,6 @@ public class RepositoryFragment extends LoadingFragmentBase implements
             intent = WikiListActivity.makeIntent(getActivity(), owner, name, null);
         } else if (id == R.id.tv_releases_label) {
             intent = ReleaseListActivity.makeIntent(getActivity(), owner, name);
-        } else if (view.getTag() instanceof Repository) {
-            intent = RepositoryActivity.makeIntent(getActivity(), (Repository) view.getTag());
         }
 
         if (intent != null) {

--- a/app/src/main/res/layout/repository.xml
+++ b/app/src/main/res/layout/repository.xml
@@ -208,6 +208,15 @@
                     android:text="@string/repo_collaborators" />
 
                 <TextView
+                    android:id="@+id/tv_discussions_label"
+                    style="@style/SelectableLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="@dimen/content_padding"
+                    android:paddingRight="@dimen/content_padding"
+                    android:text="@string/repo_discussions" />
+
+                <TextView
                     android:id="@+id/tv_wiki_label"
                     style="@style/SelectableLabel"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,7 @@
     <string name="repo_download_action">Download code as ZIP</string>
     <string name="repo_contributors">Contributors</string>
     <string name="repo_collaborators">Collaborators</string>
+    <string name="repo_discussions">Discussions</string>
     <string name="repo_files">Files</string>
     <string name="repo_short">Repos</string>
     <string name="repo_no_readme">No README file found</string>


### PR DESCRIPTION
This PR adds a "Discussions" shortcut to the "Other information" section for repositories that have discussions enabled, which opens the Discussions page in a custom tab or browser.

![other_info_discussions](https://github.com/user-attachments/assets/763de1e2-654b-4e90-9273-62a656c817e2)

I have decided not to put it near issues/pulls/forks etc. because it would have looked out of place, considering that there is no way to get the discussions count from the REST API.
While working on the code, I did some minor clean-ups to leverage lambdas/method references and removed some leftover dead code.

Open question: is _"Other information"_ still a good title for this section? Releases and discussions are not really "information", maybe just _"Other"_ would be a better fit?