### PR TITLE
Display more helpful error messages in snackbars

### DIFF
--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -109,7 +109,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
 
         return service.createCommitCommentReaction(mRepoOwner, mRepoName, comment.comment.id(), request)
                 .map(ApiHelpers::throwOnFailure)
-                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.add_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(this, R.string.add_reaction_error));
     }
 
     @Override
@@ -118,6 +118,6 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
         final ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deleteCommitCommentReaction(mRepoOwner, mRepoName, comment.comment.id(), reactionId)
                 .map(ApiHelpers::mapToTrueOnSuccess)
-                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.remove_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(this, R.string.remove_reaction_error));
     }
 }

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -125,7 +125,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
 
         return service.createPullRequestReviewCommentReaction(mRepoOwner, mRepoName, comment.comment.id(), request)
                 .map(ApiHelpers::throwOnFailure)
-                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.add_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(this, R.string.add_reaction_error));
     }
 
     @Override
@@ -134,6 +134,6 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deletePullRequestReviewCommentReaction(mRepoOwner, mRepoName, comment.comment.id(), reactionId)
                 .map(ApiHelpers::mapToTrueOnSuccess)
-                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.remove_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(this, R.string.remove_reaction_error));
     }
 }

--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -277,7 +277,7 @@ public class ReleaseInfoActivity extends BaseActivity implements
         ReactionRequest request = ReactionRequest.builder().content(content).build();
         return service.createReleaseReaction(mRepoOwner, mRepoName, mRelease.id(), request)
                 .map(ApiHelpers::throwOnFailure)
-                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.add_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(this, R.string.add_reaction_error));
     }
 
     @Override
@@ -285,7 +285,7 @@ public class ReleaseInfoActivity extends BaseActivity implements
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deleteReleaseReaction(mRepoOwner, mRepoName, mRelease.id(), reactionId)
                 .map(ApiHelpers::mapToTrueOnSuccess)
-                .compose(RxUtils.wrapWithRetrySnackbar(this, R.string.remove_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(this, R.string.remove_reaction_error));
     }
 
     private void onReactionsUpdated(ReactionBar.Item item, Reactions reactions) {

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -487,7 +487,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         ReactionRequest request = ReactionRequest.builder().content(content).build();
         return service.createIssueReaction(mRepoOwner, mRepoName, mIssue.number(), request)
                 .map(ApiHelpers::throwOnFailure)
-                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.add_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(getBaseActivity(), R.string.add_reaction_error));
     }
 
     @Override
@@ -495,7 +495,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deleteIssueReaction(mRepoOwner, mRepoName, mIssue.number(), reactionId)
                 .map(ApiHelpers::mapToTrueOnSuccess)
-                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.remove_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(getBaseActivity(), R.string.remove_reaction_error));
     }
 
     @Override
@@ -512,7 +512,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         ReactionRequest request = ReactionRequest.builder().content(content).build();
         return service.createIssueCommentReaction(mRepoOwner, mRepoName, comment.id(), request)
                 .map(ApiHelpers::throwOnFailure)
-                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.add_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(getBaseActivity(), R.string.add_reaction_error));
     }
 
     @Override
@@ -520,7 +520,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
         ReactionService service = ServiceFactory.get(ReactionService.class, false);
         return service.deleteIssueCommentReaction(mRepoOwner, mRepoName, comment.id(), reactionId)
                 .map(ApiHelpers::mapToTrueOnSuccess)
-                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.remove_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(getBaseActivity(), R.string.remove_reaction_error));
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
@@ -433,7 +433,7 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
                 ? service.createPullRequestReviewCommentReaction(mRepoOwner, mRepoName, comment.id(), request)
                 : service.createIssueCommentReaction(mRepoOwner, mRepoName, comment.id(), request);
         return responseSingle.map(ApiHelpers::throwOnFailure)
-                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.add_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(getBaseActivity(), R.string.add_reaction_error));
     }
 
     @Override
@@ -443,7 +443,7 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
                 ? service.deletePullRequestReviewCommentReaction(mRepoOwner, mRepoName, comment.id(), reactionId)
                 : service.deleteIssueCommentReaction(mRepoOwner, mRepoName, comment.id(), reactionId);
         return responseSingle.map(ApiHelpers::mapToTrueOnSuccess)
-                .compose(RxUtils.wrapWithRetrySnackbar(getBaseActivity(), R.string.remove_reaction_error));
+                .compose(RxUtils.wrapWithErrorSnackbar(getBaseActivity(), R.string.remove_reaction_error));
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,8 +54,8 @@
     <string name="add_comment">Add comment</string>
     <string name="add_reaction">Add reaction</string>
     <string name="remove_reaction">Remove reaction</string>
-    <string name="add_reaction_error">Adding reaction failed.</string>
-    <string name="remove_reaction_error">Removing reaction failed.</string>
+    <string name="add_reaction_error">Adding reaction failed</string>
+    <string name="remove_reaction_error">Removing reaction failed</string>
     <string name="edit">Edit</string>
     <string name="members">Members</string>
     <string name="open">Open</string>
@@ -68,6 +68,11 @@
     <string name="load_failure_explanation_dmca">This repository was taken down for legal reasons.\nPlease see %1$s for details.</string>
     <string name="load_failure_explanation_parsing">There was an error while parsing GitHub\'s response. You can use the button below to report this issue to the app developers.</string>
     <string name="load_failure_explanation_with_reason">Loading the data from GitHub failed. GitHub told us the following reason:\n%1$s</string>
+    <string name="snackbar_network_error">%1$s. Please check your internet connection.</string>
+    <string name="snackbar_application_error">%1$s. You can copy the error log to provide more details when reporting the issue to the app developers.</string>
+    <string name="snackbar_github_api_error">%1$s: %2$s</string>
+    <string name="snackbar_copy_error_msg_action">Copy error message</string>
+    <string name="snackbar_copy_error_log_action">Copy error log</string>
     <string name="issue_reported">The issue has been reported. Thank you!</string>
     <string name="find_next">Find next</string>
     <string name="find_previous">Find previous</string>
@@ -353,8 +358,8 @@
     <string name="commit_comment_hint">Comment on this commit</string>
     <string name="commit_details">Committed by [b]%1$s[/b] %2$s</string>
     <string name="commit_comment_dialog_title">Comment on line -%1$d +%2$d</string>
-    <string name="error_delete_commit_comment">Deletion of commit comment failed.</string>
-    <string name="error_delete_comment">Comment deletion failed.</string>
+    <string name="error_delete_commit_comment">Deletion of commit comment failed</string>
+    <string name="error_delete_comment">Comment deletion failed</string>
     <string name="commit_use_as_ref">Select as branch reference</string>
 
     <!-- Release -->
@@ -381,8 +386,8 @@
     <string name="issue_loading_template_hint">Loading issue body template\u2026</string>
     <string name="issue_error_title">Please enter a title</string>
     <string name="issue_edit_title">Edit Issue #%1$d</string>
-    <string name="issue_error_close">Closing issue #%1$d failed.</string>
-    <string name="issue_error_reopen">Reopening issue #%1$d failed.</string>
+    <string name="issue_error_close">Closing issue #%1$d failed</string>
+    <string name="issue_error_reopen">Reopening issue #%1$d failed</string>
     <string name="issue_sort_order">Sort order</string>
     <string name="issue_sort_created_asc">Oldest</string>
     <string name="issue_sort_created_desc">Newest</string>
@@ -396,15 +401,15 @@
     <string name="issue_labels">Labels</string>
     <string name="issue_milestones">Milestones</string>
     <string name="issue_dialog_delete_message">Do you really want to delete %1$s?</string>
-    <string name="issue_error_comment">Comment creation failed.</string>
-    <string name="issue_error_create">Issue creation failed.</string>
-    <string name="issue_error_edit">Editing issue #%1$d failed.</string>
+    <string name="issue_error_comment">Comment creation failed</string>
+    <string name="issue_error_create">Issue creation failed</string>
+    <string name="issue_error_edit">Editing issue #%1$d failed</string>
     <string name="issue_error_create_label">Creation of label \'%1$s\' failed</string>
     <string name="issue_error_edit_label">Editing label \'%1$s\' failed</string>
     <string name="issue_error_delete_label">Deletion of label \'%1$s\' failed</string>
-    <string name="issue_error_create_milestone">Creation of milestone \'%1$s\' failed.</string>
-    <string name="issue_error_edit_milestone">Editing milestone \'%1$s\' failed.</string>
-    <string name="issue_error_delete_milestone">Deletion of milestone failed.</string>
+    <string name="issue_error_create_milestone">Creation of milestone \'%1$s\' failed</string>
+    <string name="issue_error_edit_milestone">Editing milestone \'%1$s\' failed</string>
+    <string name="issue_error_delete_milestone">Deletion of milestone failed</string>
     <string name="issue_error_milestone_title">Please enter a title</string>
     <string name="issue_label_new">New Label</string>
     <string name="issue_milestone_new">New Milestone</string>
@@ -413,8 +418,8 @@
     <string name="issue_milestone_closed_issues">%d closed</string>
     <string name="issue_milestone_close_message">Do you really want to close this milestone?</string>
     <string name="issue_milestone_reopen_message">Do you really want to reopen this milestone?</string>
-    <string name="issue_milestone_close_error">Closing milestone failed.</string>
-    <string name="issue_milestone_reopen_error">Reopening milestone failed.</string>
+    <string name="issue_milestone_close_error">Closing milestone failed</string>
+    <string name="issue_milestone_reopen_error">Reopening milestone failed</string>
     <string name="issue_filter">Filter</string>
     <string name="issue_filter_by_label">Filter by label</string>
     <string name="issue_filter_by_milestone">Filter by milestone</string>
@@ -459,7 +464,7 @@
     <string name="pull_request_close">Close</string>
     <string name="pull_request_merge">Merge</string>
     <string name="pull_request_merged">Merged</string>
-    <string name="pull_error_merge">Merging pull request #%1$d failed.</string>
+    <string name="pull_error_merge">Merging pull request #%1$d failed</string>
     <string name="pull_message_dialog_title">Merge pull request #%1$d</string>
     <string name="pull_merge_title_description">Merge commit title</string>
     <string name="pull_merge_title_helper">Leave this empty to use the default title provided by GitHub.</string>
@@ -494,9 +499,9 @@
     <string name="pull_request_review_body">Review Summary</string>
     <string name="pull_request_review_description">Leave a comment about this review below.</string>
     <string name="pull_request_review_button_affirm">Comment</string>
-    <string name="pull_request_review_error">Adding review to pull request #%1$d failed.</string>
+    <string name="pull_request_review_error">Adding review to pull request #%1$d failed</string>
     <string name="pull_request_review_changes">Review</string>
-    <string name="review_create_error">Review creation failed.</string>
+    <string name="review_create_error">Review creation failed</string>
 
     <!-- Object -->
     <string name="object_view_file_at">View file @ %1$s</string>


### PR DESCRIPTION
This PR adds more information to error snackbars when the GitHub API returns an error upon performing an action, in order to help users understand the reason without digging into the logcat:

<img src="https://github.com/user-attachments/assets/3acf9c81-04a8-434b-9b2b-9851c3c23e52" width="420" />

In these cases, the "Retry" button - which is almost always useless for API errors - is replaced by "Copy error message", which should make it easy to get the full message when reporting an issue or when it's too long to fit in the snackbar, as it's the case with OAuth restriction errors:

<img src="https://github.com/user-attachments/assets/3bc213b4-d9b4-4918-ae33-713347d88b05" width="420" />

When an action fails due to a non-API error, the usual "Retry" button is displayed instead, but the message has been reworded to make it clear that it's most likely a connectivity issue (which should be the only other likely cause of errors, unless we have a bug in the code).

<img src="https://github.com/user-attachments/assets/54622b8d-35fe-411b-9096-eea737a06032" width="420" />

Let me know your thoughts!