### PR TITLE
Miscellaneous data loading optimizations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ android {
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'
 
-    def okHttpVersion = '3.14.9'
+    def okHttpVersion = '4.12.0'
     def retrofitVersion = '2.11.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.cardview:cardview:1.0.0'

--- a/app/src/main/java/com/gh4a/ServiceFactory.java
+++ b/app/src/main/java/com/gh4a/ServiceFactory.java
@@ -118,6 +118,10 @@ public class ServiceFactory {
         return get(serviceClass, bypassCache, null, null, null);
     }
 
+    public static <S> S get(Class<S> serviceClass, boolean bypassCache, Integer pageSize) {
+        return get(serviceClass, bypassCache, null, null, pageSize);
+    }
+
     public static <S> S get(Class<S> serviceClass, boolean bypassCache, String acceptHeader,
             String token, Integer pageSize) {
         String key = makeKey(serviceClass, bypassCache, acceptHeader, token, pageSize);

--- a/app/src/main/java/com/gh4a/ServiceFactory.java
+++ b/app/src/main/java/com/gh4a/ServiceFactory.java
@@ -3,6 +3,7 @@ package com.gh4a;
 import android.content.Context;
 import android.util.Log;
 
+import com.gh4a.utils.ApiHelpers;
 import com.meisolsson.githubsdk.core.ByteArrayResponseConverterFactory;
 import com.meisolsson.githubsdk.core.GitHubPaginationInterceptor;
 import com.meisolsson.githubsdk.core.ServiceGenerator;
@@ -120,6 +121,10 @@ public class ServiceFactory {
 
     public static <S> S get(Class<S> serviceClass, boolean bypassCache, Integer pageSize) {
         return get(serviceClass, bypassCache, null, null, pageSize);
+    }
+
+    public static <S> S getForFullPagedLists(Class<S> serviceClass, boolean bypassCache) {
+        return get(serviceClass, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
     }
 
     public static <S> S get(Class<S> serviceClass, boolean bypassCache, String acceptHeader,

--- a/app/src/main/java/com/gh4a/ServiceFactory.java
+++ b/app/src/main/java/com/gh4a/ServiceFactory.java
@@ -161,7 +161,7 @@ public class ServiceFactory {
                         requestBuilder.header("Authorization",
                                 Credentials.basic(BuildConfig.CLIENT_ID, BuildConfig.CLIENT_SECRET));
                     }
-                    if (pageSize != null) {
+                    if (pageSize != null && original.url().queryParameterNames().contains("page")) {
                         requestBuilder.url(original.url().newBuilder()
                                 .addQueryParameter("per_page", String.valueOf(pageSize))
                                 .build());

--- a/app/src/main/java/com/gh4a/activities/CommitActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitActivity.java
@@ -225,7 +225,7 @@ public class CommitActivity extends BaseFragmentPagerActivity implements
 
     private void loadComments(boolean force) {
         final RepositoryCommentService service =
-                ServiceFactory.get(RepositoryCommentService.class, force);
+                ServiceFactory.get(RepositoryCommentService.class, force, ApiHelpers.MAX_PAGE_SIZE);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mObjectSha, page))
                 .compose(makeLoaderSingle(ID_LOADER_COMMENTS, force))

--- a/app/src/main/java/com/gh4a/activities/CommitActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitActivity.java
@@ -224,8 +224,7 @@ public class CommitActivity extends BaseFragmentPagerActivity implements
     }
 
     private void loadComments(boolean force) {
-        final RepositoryCommentService service =
-                ServiceFactory.get(RepositoryCommentService.class, force, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(RepositoryCommentService.class, force);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mObjectSha, page))
                 .compose(makeLoaderSingle(ID_LOADER_COMMENTS, force))

--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -88,7 +88,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
     @Override
     protected Single<List<GitComment>> getCommentsSingle(boolean bypassCache) {
         final RepositoryCommentService service =
-                ServiceFactory.get(RepositoryCommentService.class, bypassCache);
+                ServiceFactory.get(RepositoryCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mSha, page))
                 .compose(RxUtils.filter(c -> c.position() != null));
@@ -97,7 +97,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
         final CommentWrapper comment = (CommentWrapper) item;
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
+        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitCommentReactions(mRepoOwner, mRepoName, comment.comment.id(), page));
     }

--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -87,8 +87,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
 
     @Override
     protected Single<List<GitComment>> getCommentsSingle(boolean bypassCache) {
-        final RepositoryCommentService service =
-                ServiceFactory.get(RepositoryCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(RepositoryCommentService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mSha, page))
                 .compose(RxUtils.filter(c -> c.position() != null));
@@ -97,7 +96,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
         final CommentWrapper comment = (CommentWrapper) item;
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitCommentReactions(mRepoOwner, mRepoName, comment.comment.id(), page));
     }

--- a/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
@@ -544,7 +544,7 @@ public class IssueEditActivity extends BasePagerActivity implements
     }
 
     private void loadLabels(OnLabelsLoaded callback) {
-        final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false);
+        final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false, ApiHelpers.MAX_PAGE_SIZE);
         if (mLabelSingle == null) {
             mLabelSingle = ApiHelpers.PageIterator
                     .toSingle(page -> service.getRepositoryLabels(mRepoOwner, mRepoName, page))
@@ -557,7 +557,7 @@ public class IssueEditActivity extends BasePagerActivity implements
     }
 
     private void loadMilestones(OnMilestonesLoaded callback) {
-        final IssueMilestoneService service = ServiceFactory.get(IssueMilestoneService.class, false);
+        final IssueMilestoneService service = ServiceFactory.get(IssueMilestoneService.class, false, ApiHelpers.MAX_PAGE_SIZE);
         if (mMilestoneSingle == null) {
             mMilestoneSingle = ApiHelpers.PageIterator
                     .toSingle(page -> service
@@ -572,7 +572,7 @@ public class IssueEditActivity extends BasePagerActivity implements
 
     private void loadPotentialAssignees(OnAssigneesLoaded callback) {
         final RepositoryCollaboratorService service =
-                ServiceFactory.get(RepositoryCollaboratorService.class, false);
+                ServiceFactory.get(RepositoryCollaboratorService.class, false, ApiHelpers.MAX_PAGE_SIZE);
 
         if (mAssigneeSingle == null) {
             mAssigneeSingle = ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
@@ -544,7 +544,7 @@ public class IssueEditActivity extends BasePagerActivity implements
     }
 
     private void loadLabels(OnLabelsLoaded callback) {
-        final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(IssueLabelService.class, false);
         if (mLabelSingle == null) {
             mLabelSingle = ApiHelpers.PageIterator
                     .toSingle(page -> service.getRepositoryLabels(mRepoOwner, mRepoName, page))
@@ -557,7 +557,7 @@ public class IssueEditActivity extends BasePagerActivity implements
     }
 
     private void loadMilestones(OnMilestonesLoaded callback) {
-        final IssueMilestoneService service = ServiceFactory.get(IssueMilestoneService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(IssueMilestoneService.class, false);
         if (mMilestoneSingle == null) {
             mMilestoneSingle = ApiHelpers.PageIterator
                     .toSingle(page -> service
@@ -571,8 +571,7 @@ public class IssueEditActivity extends BasePagerActivity implements
     }
 
     private void loadPotentialAssignees(OnAssigneesLoaded callback) {
-        final RepositoryCollaboratorService service =
-                ServiceFactory.get(RepositoryCollaboratorService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(RepositoryCollaboratorService.class, false);
 
         if (mAssigneeSingle == null) {
             mAssigneeSingle = ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/activities/IssueLabelListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueLabelListActivity.java
@@ -330,7 +330,7 @@ public class IssueLabelListActivity extends BaseActivity implements
     }
 
     private void loadLabels(boolean force) {
-        final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(IssueLabelService.class, false);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getRepositoryLabels(mRepoOwner, mRepoName, page))
                 .compose(RxUtils.mapList(IssueLabelAdapter.EditableLabel::new))

--- a/app/src/main/java/com/gh4a/activities/IssueLabelListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueLabelListActivity.java
@@ -330,7 +330,7 @@ public class IssueLabelListActivity extends BaseActivity implements
     }
 
     private void loadLabels(boolean force) {
-        final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false);
+        final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false, ApiHelpers.MAX_PAGE_SIZE);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getRepositoryLabels(mRepoOwner, mRepoName, page))
                 .compose(RxUtils.mapList(IssueLabelAdapter.EditableLabel::new))

--- a/app/src/main/java/com/gh4a/activities/IssueListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueListActivity.java
@@ -612,7 +612,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         if (mAssignees != null) {
             showAssigneesDialog();
         } else {
-            final IssueAssigneeService service = ServiceFactory.get(IssueAssigneeService.class, false);
+            final IssueAssigneeService service = ServiceFactory.get(IssueAssigneeService.class, false, ApiHelpers.MAX_PAGE_SIZE);
             registerTemporarySubscription(ApiHelpers.PageIterator
                     .toSingle(page -> service.getAssignees(mRepoOwner, mRepoName, page))
                     .compose(RxUtils::doInBackground)
@@ -628,7 +628,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         if (mMilestones != null) {
             showMilestonesDialog();
         } else {
-            final IssueMilestoneService service = ServiceFactory.get(IssueMilestoneService.class, false);
+            final IssueMilestoneService service = ServiceFactory.get(IssueMilestoneService.class, false, ApiHelpers.MAX_PAGE_SIZE);
             registerTemporarySubscription(ApiHelpers.PageIterator
                     .toSingle(page -> service.getRepositoryMilestones(mRepoOwner, mRepoName, "open", page))
                     .compose(RxUtils::doInBackground)
@@ -644,7 +644,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         if (mLabels != null) {
             showLabelsDialog();
         } else {
-            final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false);
+            final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false, ApiHelpers.MAX_PAGE_SIZE);
             registerTemporarySubscription(ApiHelpers.PageIterator
                     .toSingle(page -> service.getRepositoryLabels(mRepoOwner, mRepoName, page))
                     .compose(RxUtils::doInBackground)

--- a/app/src/main/java/com/gh4a/activities/IssueListActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueListActivity.java
@@ -612,7 +612,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         if (mAssignees != null) {
             showAssigneesDialog();
         } else {
-            final IssueAssigneeService service = ServiceFactory.get(IssueAssigneeService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+            var service = ServiceFactory.getForFullPagedLists(IssueAssigneeService.class, false);
             registerTemporarySubscription(ApiHelpers.PageIterator
                     .toSingle(page -> service.getAssignees(mRepoOwner, mRepoName, page))
                     .compose(RxUtils::doInBackground)
@@ -628,7 +628,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         if (mMilestones != null) {
             showMilestonesDialog();
         } else {
-            final IssueMilestoneService service = ServiceFactory.get(IssueMilestoneService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+            var service = ServiceFactory.getForFullPagedLists(IssueMilestoneService.class, false);
             registerTemporarySubscription(ApiHelpers.PageIterator
                     .toSingle(page -> service.getRepositoryMilestones(mRepoOwner, mRepoName, "open", page))
                     .compose(RxUtils::doInBackground)
@@ -644,7 +644,7 @@ public class IssueListActivity extends BaseFragmentPagerActivity implements
         if (mLabels != null) {
             showLabelsDialog();
         } else {
-            final IssueLabelService service = ServiceFactory.get(IssueLabelService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+            var service = ServiceFactory.getForFullPagedLists(IssueLabelService.class, false);
             registerTemporarySubscription(ApiHelpers.PageIterator
                     .toSingle(page -> service.getRepositoryLabels(mRepoOwner, mRepoName, page))
                     .compose(RxUtils::doInBackground)

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -541,7 +541,7 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
     private void loadPendingReview(boolean force) {
         String ownLogin = Gh4Application.get().getAuthLogin();
-        PullRequestReviewService service = ServiceFactory.get(PullRequestReviewService.class, force, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(PullRequestReviewService.class, force);
 
         ApiHelpers.PageIterator
                 .first(page -> service.getReviews(mRepoOwner, mRepoName, mPullRequestNumber, page),

--- a/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestActivity.java
@@ -541,7 +541,7 @@ public class PullRequestActivity extends BaseFragmentPagerActivity implements
 
     private void loadPendingReview(boolean force) {
         String ownLogin = Gh4Application.get().getAuthLogin();
-        PullRequestReviewService service = ServiceFactory.get(PullRequestReviewService.class, force);
+        PullRequestReviewService service = ServiceFactory.get(PullRequestReviewService.class, force, ApiHelpers.MAX_PAGE_SIZE);
 
         ApiHelpers.PageIterator
                 .first(page -> service.getReviews(mRepoOwner, mRepoName, mPullRequestNumber, page),

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -71,7 +71,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
     @Override
     protected Single<List<ReviewComment>> getCommentsSingle(boolean bypassCache) {
         final PullRequestReviewCommentService service =
-                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache);
+                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestComments(
                         mRepoOwner, mRepoName, mPullRequestNumber, page))
@@ -112,7 +112,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
         final CommentWrapper comment = (CommentWrapper) item;
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
+        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestReviewCommentReactions(
                         mRepoOwner, mRepoName, comment.comment.id(), page));

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -70,8 +70,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
 
     @Override
     protected Single<List<ReviewComment>> getCommentsSingle(boolean bypassCache) {
-        final PullRequestReviewCommentService service =
-                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(PullRequestReviewCommentService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestComments(
                         mRepoOwner, mRepoName, mPullRequestNumber, page))
@@ -112,7 +111,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
         final CommentWrapper comment = (CommentWrapper) item;
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestReviewCommentReactions(
                         mRepoOwner, mRepoName, comment.comment.id(), page));

--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -266,7 +266,7 @@ public class ReleaseInfoActivity extends BaseActivity implements
 
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
-        ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
+        ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getReleaseReactions(mRepoOwner, mRepoName, mRelease.id(), page));
     }

--- a/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
+++ b/app/src/main/java/com/gh4a/activities/ReleaseInfoActivity.java
@@ -266,7 +266,7 @@ public class ReleaseInfoActivity extends BaseActivity implements
 
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
-        ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getReleaseReactions(mRepoOwner, mRepoName, mRelease.id(), page));
     }

--- a/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
 
 public class RepositoryActivity extends BaseFragmentPagerActivity implements
         CommitListFragment.ContextSelectionCallback,
@@ -380,9 +381,11 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
             final RepositoryService repoService = ServiceFactory.get(RepositoryService.class, false);
 
             Single<List<Branch>> branchSingle = ApiHelpers.PageIterator
-                    .toSingle(page -> branchService.getBranches(mRepoOwner, mRepoName, page));
+                    .toSingle(page -> branchService.getBranches(mRepoOwner, mRepoName, page))
+                    .subscribeOn(Schedulers.io());
             Single<List<Branch>> tagSingle = ApiHelpers.PageIterator
-                    .toSingle(page -> repoService.getTags(mRepoOwner, mRepoName, page));
+                    .toSingle(page -> repoService.getTags(mRepoOwner, mRepoName, page))
+                    .subscribeOn(Schedulers.io());
 
             registerTemporarySubscription(Single.zip(branchSingle, tagSingle, Pair::create)
                     .compose(RxUtils::doInBackground)

--- a/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
@@ -376,10 +376,8 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
         if (mBranches != null) {
             showRefSelectionDialog();
         } else {
-            final RepositoryBranchService branchService =
-                    ServiceFactory.get(RepositoryBranchService.class, false, ApiHelpers.MAX_PAGE_SIZE);
-            final RepositoryService repoService =
-                    ServiceFactory.get(RepositoryService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+            var branchService = ServiceFactory.getForFullPagedLists(RepositoryBranchService.class, false);
+            var repoService = ServiceFactory.getForFullPagedLists(RepositoryService.class, false);
 
             Single<List<Branch>> branchSingle = ApiHelpers.PageIterator
                     .toSingle(page -> branchService.getBranches(mRepoOwner, mRepoName, page))

--- a/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
@@ -377,8 +377,9 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
             showRefSelectionDialog();
         } else {
             final RepositoryBranchService branchService =
-                    ServiceFactory.get(RepositoryBranchService.class, false);
-            final RepositoryService repoService = ServiceFactory.get(RepositoryService.class, false);
+                    ServiceFactory.get(RepositoryBranchService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+            final RepositoryService repoService =
+                    ServiceFactory.get(RepositoryService.class, false, ApiHelpers.MAX_PAGE_SIZE);
 
             Single<List<Branch>> branchSingle = ApiHelpers.PageIterator
                     .toSingle(page -> branchService.getBranches(mRepoOwner, mRepoName, page))

--- a/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
+++ b/app/src/main/java/com/gh4a/activities/home/HomeActivity.java
@@ -571,8 +571,7 @@ public class HomeActivity extends BaseFragmentPagerActivity implements
     }
 
     private void loadNotificationIndicator(boolean force) {
-        NotificationService service = ServiceFactory.get(
-                NotificationService.class, force, null, null, 1);
+        NotificationService service = ServiceFactory.get(NotificationService.class, force, 1);
         HashMap<String, Object> options = new HashMap<>();
         options.put("all", false);
         options.put("participating", false);

--- a/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
@@ -204,7 +204,7 @@ public class CommitNoteAdapter extends RootAdapter<GitComment, CommitNoteAdapter
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
         final GitComment comment = ((ViewHolder) item).mBoundItem;
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
+        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitCommentReactions(mRepoOwner, mRepoName, comment.id(), page));
     }

--- a/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CommitNoteAdapter.java
@@ -204,7 +204,7 @@ public class CommitNoteAdapter extends RootAdapter<GitComment, CommitNoteAdapter
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
         final GitComment comment = ((ViewHolder) item).mBoundItem;
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitCommentReactions(mRepoOwner, mRepoName, comment.id(), page));
     }

--- a/app/src/main/java/com/gh4a/fragment/CommitNoteFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/CommitNoteFragment.java
@@ -233,7 +233,7 @@ public class CommitNoteFragment extends ListDataBaseFragment<GitComment> impleme
     @Override
     protected Single<List<GitComment>> onCreateDataSingle(boolean bypassCache) {
         final RepositoryCommentService service =
-                ServiceFactory.get(RepositoryCommentService.class, bypassCache);
+                ServiceFactory.get(RepositoryCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
 
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mObjectSha, page))

--- a/app/src/main/java/com/gh4a/fragment/CommitNoteFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/CommitNoteFragment.java
@@ -232,8 +232,7 @@ public class CommitNoteFragment extends ListDataBaseFragment<GitComment> impleme
 
     @Override
     protected Single<List<GitComment>> onCreateDataSingle(boolean bypassCache) {
-        final RepositoryCommentService service =
-                ServiceFactory.get(RepositoryCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(RepositoryCommentService.class, bypassCache);
 
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mObjectSha, page))

--- a/app/src/main/java/com/gh4a/fragment/IssueFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragment.java
@@ -19,8 +19,6 @@ import com.meisolsson.githubsdk.model.IssueState;
 import com.meisolsson.githubsdk.service.issues.IssueCommentService;
 import com.meisolsson.githubsdk.service.issues.IssueTimelineService;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import io.reactivex.Single;
@@ -74,8 +72,7 @@ public class IssueFragment extends IssueFragmentBase {
     @Override
     protected Single<List<TimelineItem>> onCreateDataSingle(boolean bypassCache) {
         final int issueNumber = mIssue.number();
-        final IssueTimelineService timelineService =
-                ServiceFactory.get(IssueTimelineService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var timelineService = ServiceFactory.getForFullPagedLists(IssueTimelineService.class, bypassCache);
 
         return ApiHelpers.PageIterator
                 .toSingle(page -> timelineService.getTimeline(mRepoOwner, mRepoName, issueNumber, page))

--- a/app/src/main/java/com/gh4a/fragment/IssueFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragment.java
@@ -74,7 +74,8 @@ public class IssueFragment extends IssueFragmentBase {
     @Override
     protected Single<List<TimelineItem>> onCreateDataSingle(boolean bypassCache) {
         final int issueNumber = mIssue.number();
-        final IssueTimelineService timelineService = ServiceFactory.get(IssueTimelineService.class, bypassCache);
+        final IssueTimelineService timelineService =
+                ServiceFactory.get(IssueTimelineService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
 
         return ApiHelpers.PageIterator
                 .toSingle(page -> timelineService.getTimeline(mRepoOwner, mRepoName, issueNumber, page))

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -471,7 +471,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
 
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getIssueReactions(mRepoOwner, mRepoName, mIssue.number(), page));
     }
@@ -501,7 +501,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
     @Override
     public Single<List<Reaction>> loadReactionDetails(final GitHubCommentBase comment,
             boolean bypassCache) {
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getIssueCommentReactions(mRepoOwner, mRepoName, comment.id(), page));
     }

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -471,7 +471,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
 
     @Override
     public Single<List<Reaction>> loadReactionDetails(ReactionBar.Item item, boolean bypassCache) {
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
+        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getIssueReactions(mRepoOwner, mRepoName, mIssue.number(), page));
     }
@@ -501,7 +501,7 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
     @Override
     public Single<List<Reaction>> loadReactionDetails(final GitHubCommentBase comment,
             boolean bypassCache) {
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
+        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getIssueCommentReactions(mRepoOwner, mRepoName, comment.id(), page));
     }

--- a/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueFragmentBase.java
@@ -87,7 +87,8 @@ public abstract class IssueFragmentBase extends ListDataBaseFragment<TimelineIte
             IssueEventType.HeadRefForcePushed, IssueEventType.CommentDeleted,
             IssueEventType.ReviewRequested, IssueEventType.ReviewRequestRemoved,
             IssueEventType.ConvertToDraft, IssueEventType.ReadyForReview,
-            IssueEventType.ReviewDismissed, IssueEventType.CrossReferenced
+            IssueEventType.ReviewDismissed, IssueEventType.CrossReferenced,
+            IssueEventType.Commented
     );
 
     protected View mListHeaderView;

--- a/app/src/main/java/com/gh4a/fragment/IssueMilestoneListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueMilestoneListFragment.java
@@ -100,7 +100,7 @@ public class IssueMilestoneListFragment extends ListDataBaseFragment<Milestone> 
     @Override
     protected Single<List<Milestone>> onCreateDataSingle(boolean bypassCache) {
         final IssueMilestoneService service =
-                ServiceFactory.get(IssueMilestoneService.class, bypassCache);
+                ServiceFactory.get(IssueMilestoneService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         String targetState = mShowClosed ? "closed" : "open";
 
         return ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/fragment/IssueMilestoneListFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/IssueMilestoneListFragment.java
@@ -99,8 +99,7 @@ public class IssueMilestoneListFragment extends ListDataBaseFragment<Milestone> 
 
     @Override
     protected Single<List<Milestone>> onCreateDataSingle(boolean bypassCache) {
-        final IssueMilestoneService service =
-                ServiceFactory.get(IssueMilestoneService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(IssueMilestoneService.class, bypassCache);
         String targetState = mShowClosed ? "closed" : "open";
 
         return ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
@@ -191,12 +191,9 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
     @Override
     protected Single<List<TimelineItem>> onCreateDataSingle(boolean bypassCache) {
         final int issueNumber = mIssue.number();
-        final IssueTimelineService timelineService =
-                ServiceFactory.get(IssueTimelineService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
-        final PullRequestReviewService reviewService =
-                ServiceFactory.get(PullRequestReviewService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
-        final PullRequestReviewCommentService prCommentService =
-                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var timelineService = ServiceFactory.getForFullPagedLists(IssueTimelineService.class, bypassCache);
+        var reviewService = ServiceFactory.getForFullPagedLists(PullRequestReviewService.class, bypassCache);
+        var prCommentService = ServiceFactory.getForFullPagedLists(PullRequestReviewCommentService.class, bypassCache);
 
         Single<List<TimelineItem>> timelineItemsSingle = ApiHelpers.PageIterator
                 .toSingle(page -> timelineService.getTimeline(mRepoOwner, mRepoName, issueNumber, page))
@@ -437,7 +434,7 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
         CommitStatusBox commitStatusBox = mListHeaderView.findViewById(R.id.commit_status_box);
         commitStatusBox.setVisibility(View.VISIBLE);
 
-        RepositoryStatusService repoService = ServiceFactory.get(RepositoryStatusService.class, force, ApiHelpers.MAX_PAGE_SIZE);
+        var repoService = ServiceFactory.getForFullPagedLists(RepositoryStatusService.class, force);
         String sha = mPullRequest.head().sha();
 
         Single<List<Status>> statusSingle = ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
@@ -192,11 +192,11 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
     protected Single<List<TimelineItem>> onCreateDataSingle(boolean bypassCache) {
         final int issueNumber = mIssue.number();
         final IssueTimelineService timelineService =
-                ServiceFactory.get(IssueTimelineService.class, bypassCache);
+                ServiceFactory.get(IssueTimelineService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         final PullRequestReviewService reviewService =
-                ServiceFactory.get(PullRequestReviewService.class, bypassCache);
+                ServiceFactory.get(PullRequestReviewService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         final PullRequestReviewCommentService prCommentService =
-                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache);
+                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
 
         Single<List<TimelineItem>> timelineItemsSingle = ApiHelpers.PageIterator
                 .toSingle(page -> timelineService.getTimeline(mRepoOwner, mRepoName, issueNumber, page))
@@ -437,7 +437,7 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
         CommitStatusBox commitStatusBox = mListHeaderView.findViewById(R.id.commit_status_box);
         commitStatusBox.setVisibility(View.VISIBLE);
 
-        RepositoryStatusService repoService = ServiceFactory.get(RepositoryStatusService.class, force);
+        RepositoryStatusService repoService = ServiceFactory.get(RepositoryStatusService.class, force, ApiHelpers.MAX_PAGE_SIZE);
         String sha = mPullRequest.head().sha();
 
         Single<List<Status>> statusSingle = ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/fragment/PullRequestFilesFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestFilesFragment.java
@@ -121,7 +121,7 @@ public class PullRequestFilesFragment extends CommitFragment {
     }
 
     private void loadFiles(boolean force) {
-        final PullRequestService service = ServiceFactory.get(PullRequestService.class, force, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(PullRequestService.class, force);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestFiles(
                         mRepoOwner, mRepoName, mPullRequestNumber, page))
@@ -133,8 +133,7 @@ public class PullRequestFilesFragment extends CommitFragment {
     }
 
     private void loadComments(boolean force) {
-        final PullRequestReviewCommentService service =
-                ServiceFactory.get(PullRequestReviewCommentService.class, force, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(PullRequestReviewCommentService.class, force);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestComments(
                         mRepoOwner, mRepoName, mPullRequestNumber, page))

--- a/app/src/main/java/com/gh4a/fragment/PullRequestFilesFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestFilesFragment.java
@@ -121,7 +121,7 @@ public class PullRequestFilesFragment extends CommitFragment {
     }
 
     private void loadFiles(boolean force) {
-        final PullRequestService service = ServiceFactory.get(PullRequestService.class, force);
+        final PullRequestService service = ServiceFactory.get(PullRequestService.class, force, ApiHelpers.MAX_PAGE_SIZE);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestFiles(
                         mRepoOwner, mRepoName, mPullRequestNumber, page))
@@ -134,7 +134,7 @@ public class PullRequestFilesFragment extends CommitFragment {
 
     private void loadComments(boolean force) {
         final PullRequestReviewCommentService service =
-                ServiceFactory.get(PullRequestReviewCommentService.class, force);
+                ServiceFactory.get(PullRequestReviewCommentService.class, force, ApiHelpers.MAX_PAGE_SIZE);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestComments(
                         mRepoOwner, mRepoName, mPullRequestNumber, page))

--- a/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/RepositoryFragment.java
@@ -439,7 +439,7 @@ public class RepositoryFragment extends LoadingFragmentBase implements
     }
 
     private void loadPullRequestCount(boolean force) {
-        SearchService service = ServiceFactory.get(SearchService.class, force, null, null, 1);
+        SearchService service = ServiceFactory.get(SearchService.class, force, 1);
         String query = String.format(Locale.US, "type:pr repo:%s/%s state:open",
                 mRepository.owner().login(), mRepository.name());
 

--- a/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
@@ -161,11 +161,12 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
 
     @Override
     protected Single<List<TimelineItem>> onCreateDataSingle(boolean bypassCache) {
-        final PullRequestService prService = ServiceFactory.get(PullRequestService.class, bypassCache);
+        final PullRequestService prService =
+                ServiceFactory.get(PullRequestService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         final PullRequestReviewService reviewService =
-                ServiceFactory.get(PullRequestReviewService.class, bypassCache);
+                ServiceFactory.get(PullRequestReviewService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         final PullRequestReviewCommentService commentService =
-                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache);
+                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
 
         // The Review object passed to this fragment may be incomplete, so we re-fetch it to make
         // sure it has all the needed fields
@@ -418,7 +419,7 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
     @Override
     public Single<List<Reaction>> loadReactionDetails(final GitHubCommentBase comment,
             boolean bypassCache) {
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache);
+        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> comment instanceof ReviewComment
                         ? service.getPullRequestReviewCommentReactions(

--- a/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/ReviewFragment.java
@@ -161,12 +161,9 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
 
     @Override
     protected Single<List<TimelineItem>> onCreateDataSingle(boolean bypassCache) {
-        final PullRequestService prService =
-                ServiceFactory.get(PullRequestService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
-        final PullRequestReviewService reviewService =
-                ServiceFactory.get(PullRequestReviewService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
-        final PullRequestReviewCommentService commentService =
-                ServiceFactory.get(PullRequestReviewCommentService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var prService = ServiceFactory.getForFullPagedLists(PullRequestService.class, bypassCache);
+        var reviewService = ServiceFactory.getForFullPagedLists(PullRequestReviewService.class, bypassCache);
+        var commentService = ServiceFactory.getForFullPagedLists(PullRequestReviewCommentService.class, bypassCache);
 
         // The Review object passed to this fragment may be incomplete, so we re-fetch it to make
         // sure it has all the needed fields
@@ -419,7 +416,7 @@ public class ReviewFragment extends ListDataBaseFragment<TimelineItem> implement
     @Override
     public Single<List<Reaction>> loadReactionDetails(final GitHubCommentBase comment,
             boolean bypassCache) {
-        final ReactionService service = ServiceFactory.get(ReactionService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(ReactionService.class, bypassCache);
         return ApiHelpers.PageIterator
                 .toSingle(page -> comment instanceof ReviewComment
                         ? service.getPullRequestReviewCommentReactions(

--- a/app/src/main/java/com/gh4a/fragment/UserFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/UserFragment.java
@@ -351,7 +351,7 @@ public class UserFragment extends LoadingFragmentBase implements
     }
 
     private void loadTopRepositories(boolean force) {
-        RepositoryService service = ServiceFactory.get(RepositoryService.class, force, null, null, 5);
+        RepositoryService service = ServiceFactory.get(RepositoryService.class, force, 5);
         final Single<Response<Page<Repository>>> observable;
 
         Map<String, String> filterData = new HashMap<>();

--- a/app/src/main/java/com/gh4a/fragment/UserFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/UserFragment.java
@@ -382,7 +382,7 @@ public class UserFragment extends LoadingFragmentBase implements
             return;
         }
 
-        final OrganizationService service = ServiceFactory.get(OrganizationService.class, force);
+        final OrganizationService service = ServiceFactory.get(OrganizationService.class, force, ApiHelpers.MAX_PAGE_SIZE);
         ApiHelpers.PageIterator
                 .toSingle(page -> mIsSelf
                         ? service.getMyOrganizations(page)
@@ -397,7 +397,7 @@ public class UserFragment extends LoadingFragmentBase implements
             return;
         }
         final OrganizationMemberService service =
-                ServiceFactory.get(OrganizationMemberService.class, force);
+                ServiceFactory.get(OrganizationMemberService.class, force, ApiHelpers.MAX_PAGE_SIZE);
         ApiHelpers.PageIterator
                 .toSingle(page -> service.getMembers(mUser.login(), page))
                 .map(memberList -> memberList.size())

--- a/app/src/main/java/com/gh4a/fragment/UserFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/UserFragment.java
@@ -382,7 +382,7 @@ public class UserFragment extends LoadingFragmentBase implements
             return;
         }
 
-        final OrganizationService service = ServiceFactory.get(OrganizationService.class, force, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(OrganizationService.class, force);
         ApiHelpers.PageIterator
                 .toSingle(page -> mIsSelf
                         ? service.getMyOrganizations(page)

--- a/app/src/main/java/com/gh4a/fragment/UserFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/UserFragment.java
@@ -396,11 +396,13 @@ public class UserFragment extends LoadingFragmentBase implements
         if (mUser.type() != UserType.Organization) {
             return;
         }
-        final OrganizationMemberService service =
-                ServiceFactory.get(OrganizationMemberService.class, force, ApiHelpers.MAX_PAGE_SIZE);
-        ApiHelpers.PageIterator
-                .toSingle(page -> service.getMembers(mUser.login(), page))
-                .map(memberList -> memberList.size())
+        final OrganizationMemberService service = ServiceFactory.get(OrganizationMemberService.class, force, 1);
+        service.getMembers(mUser.login(), 1)
+                .map(ApiHelpers::throwOnFailure)
+                .map(page -> {
+                    int pagesCount = ApiHelpers.getTotalPagesCount(page);
+                    return pagesCount == 1 ? page.items().size() : pagesCount;
+                })
                 .compose(makeLoaderSingle(ID_LOADER_ORG_MEMBER_COUNT, force))
                 .subscribe(count -> {
                     OverviewRow membersRow = mContentView.findViewById(R.id.members_row);

--- a/app/src/main/java/com/gh4a/model/TimelineItem.java
+++ b/app/src/main/java/com/gh4a/model/TimelineItem.java
@@ -5,10 +5,10 @@ import android.content.Intent;
 
 import com.gh4a.activities.PullRequestDiffViewerActivity;
 import com.gh4a.utils.IntentUtils;
-import com.meisolsson.githubsdk.model.GitHubComment;
 import com.meisolsson.githubsdk.model.GitHubCommentBase;
 import com.meisolsson.githubsdk.model.GitHubFile;
 import com.meisolsson.githubsdk.model.IssueEvent;
+import com.meisolsson.githubsdk.model.IssueEventType;
 import com.meisolsson.githubsdk.model.Reactions;
 import com.meisolsson.githubsdk.model.Review;
 import com.meisolsson.githubsdk.model.ReviewComment;
@@ -38,6 +38,13 @@ public abstract class TimelineItem {
         return lhs.getCreatedAt().compareTo(rhs.getCreatedAt());
     };
 
+    public static TimelineItem fromIssueEvent(IssueEvent event) {
+        if (event.event() == IssueEventType.Commented) {
+            return new TimelineComment(event.toComment());
+        } else {
+            return new TimelineEvent(event);
+        }
+    }
 
     public static class TimelineComment extends TimelineItem {
         private static final Pattern PULL_REQUEST_PATTERN =

--- a/app/src/main/java/com/gh4a/resolver/CommitCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitCommentLoadTask.java
@@ -53,8 +53,7 @@ public class CommitCommentLoadTask extends UrlLoadTask {
             String repoOwner, String repoName, String commitSha,
             IntentUtils.InitialCommentMarker marker) {
         RepositoryCommitService commitService = ServiceFactory.get(RepositoryCommitService.class, false);
-        RepositoryCommentService commentService =
-                ServiceFactory.get(RepositoryCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var commentService = ServiceFactory.getForFullPagedLists(RepositoryCommentService.class, false);
 
         Single<Commit> commitSingle = commitService.getCommit(repoOwner, repoName, commitSha)
                 .map(ApiHelpers::throwOnFailure);

--- a/app/src/main/java/com/gh4a/resolver/CommitCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitCommentLoadTask.java
@@ -54,7 +54,7 @@ public class CommitCommentLoadTask extends UrlLoadTask {
             IntentUtils.InitialCommentMarker marker) {
         RepositoryCommitService commitService = ServiceFactory.get(RepositoryCommitService.class, false);
         RepositoryCommentService commentService =
-                ServiceFactory.get(RepositoryCommentService.class, false);
+                ServiceFactory.get(RepositoryCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
 
         Single<Commit> commitSingle = commitService.getCommit(repoOwner, repoName, commitSha)
                 .map(ApiHelpers::throwOnFailure);

--- a/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
@@ -60,8 +60,7 @@ public class CommitDiffLoadTask extends DiffLoadTask<GitComment> {
 
     @Override
     protected Single<List<GitComment>> getComments() throws ApiRequestException {
-        final RepositoryCommentService service =
-                ServiceFactory.get(RepositoryCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(RepositoryCommentService.class, false);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mSha, page));
     }

--- a/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
@@ -61,7 +61,7 @@ public class CommitDiffLoadTask extends DiffLoadTask<GitComment> {
     @Override
     protected Single<List<GitComment>> getComments() throws ApiRequestException {
         final RepositoryCommentService service =
-                ServiceFactory.get(RepositoryCommentService.class, false);
+                ServiceFactory.get(RepositoryCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mSha, page));
     }

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffCommentLoadTask.java
@@ -50,12 +50,12 @@ public class PullRequestDiffCommentLoadTask extends UrlLoadTask {
 
     @Override
     protected Single<Optional<Intent>> getSingle() {
-        PullRequestService service = ServiceFactory.get(PullRequestService.class, false);
+        PullRequestService service = ServiceFactory.get(PullRequestService.class, false, ApiHelpers.MAX_PAGE_SIZE);
         Single<PullRequest> pullRequestSingle = service.getPullRequest(mRepoOwner, mRepoName, mPullRequestNumber)
                 .map(ApiHelpers::throwOnFailure);
 
         final PullRequestReviewCommentService commentService =
-                ServiceFactory.get(PullRequestReviewCommentService.class, false);
+                ServiceFactory.get(PullRequestReviewCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
 
         Single<List<ReviewComment>> commentsSingle = ApiHelpers.PageIterator
                 .toSingle(page -> commentService.getPullRequestComments(

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
@@ -56,7 +56,8 @@ public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
 
     @Override
     protected Single<List<GitHubFile>> getFiles() {
-        final PullRequestService service = ServiceFactory.get(PullRequestService.class, false);
+        final PullRequestService service =
+                ServiceFactory.get(PullRequestService.class, false, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestFiles(mRepoOwner, mRepoName, mPullRequestNumber, page));
     }
@@ -64,7 +65,7 @@ public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
     @Override
     protected Single<List<ReviewComment>> getComments() {
         final PullRequestReviewCommentService service =
-                ServiceFactory.get(PullRequestReviewCommentService.class, false);
+                ServiceFactory.get(PullRequestReviewCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestComments(
                         mRepoOwner, mRepoName, mPullRequestNumber, page))

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
@@ -56,16 +56,14 @@ public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
 
     @Override
     protected Single<List<GitHubFile>> getFiles() {
-        final PullRequestService service =
-                ServiceFactory.get(PullRequestService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(PullRequestService.class, false);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestFiles(mRepoOwner, mRepoName, mPullRequestNumber, page));
     }
 
     @Override
     protected Single<List<ReviewComment>> getComments() {
-        final PullRequestReviewCommentService service =
-                ServiceFactory.get(PullRequestReviewCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(PullRequestReviewCommentService.class, false);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestComments(
                         mRepoOwner, mRepoName, mPullRequestNumber, page))

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewCommentLoadTask.java
@@ -52,8 +52,7 @@ public class PullRequestReviewCommentLoadTask extends UrlLoadTask {
             int pullRequestNumber, IntentUtils.InitialCommentMarker marker) {
         final PullRequestReviewService reviewService =
                 ServiceFactory.get(PullRequestReviewService.class, false);
-        final PullRequestReviewCommentService commentService =
-                ServiceFactory.get(PullRequestReviewCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var commentService = ServiceFactory.getForFullPagedLists(PullRequestReviewCommentService.class, false);
 
         return ApiHelpers.PageIterator
                 .toSingle(page -> commentService.getPullRequestComments(

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewCommentLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewCommentLoadTask.java
@@ -53,7 +53,7 @@ public class PullRequestReviewCommentLoadTask extends UrlLoadTask {
         final PullRequestReviewService reviewService =
                 ServiceFactory.get(PullRequestReviewService.class, false);
         final PullRequestReviewCommentService commentService =
-                ServiceFactory.get(PullRequestReviewCommentService.class, false);
+                ServiceFactory.get(PullRequestReviewCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
 
         return ApiHelpers.PageIterator
                 .toSingle(page -> commentService.getPullRequestComments(

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewDiffLoadTask.java
@@ -37,8 +37,7 @@ public class PullRequestReviewDiffLoadTask extends UrlLoadTask {
 
     @Override
     protected Single<Optional<Intent>> getSingle() {
-        final PullRequestReviewCommentService service =
-                ServiceFactory.get(PullRequestReviewCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(PullRequestReviewCommentService.class, false);
         final PullRequestReviewService reviewService =
                 ServiceFactory.get(PullRequestReviewService.class, false);
         long diffCommentId = Long.parseLong(mDiffId.fileHash);

--- a/app/src/main/java/com/gh4a/resolver/PullRequestReviewDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestReviewDiffLoadTask.java
@@ -38,7 +38,7 @@ public class PullRequestReviewDiffLoadTask extends UrlLoadTask {
     @Override
     protected Single<Optional<Intent>> getSingle() {
         final PullRequestReviewCommentService service =
-                ServiceFactory.get(PullRequestReviewCommentService.class, false);
+                ServiceFactory.get(PullRequestReviewCommentService.class, false, ApiHelpers.MAX_PAGE_SIZE);
         final PullRequestReviewService reviewService =
                 ServiceFactory.get(PullRequestReviewService.class, false);
         long diffCommentId = Long.parseLong(mDiffId.fileHash);

--- a/app/src/main/java/com/gh4a/resolver/RefPathDisambiguationTask.java
+++ b/app/src/main/java/com/gh4a/resolver/RefPathDisambiguationTask.java
@@ -130,10 +130,8 @@ public class RefPathDisambiguationTask extends UrlLoadTask {
                     slashPos > 0 ? mRefAndPath.substring(slashPos + 1) : "")));
         }
 
-        final RepositoryBranchService branchService =
-                ServiceFactory.get(RepositoryBranchService.class, false, ApiHelpers.MAX_PAGE_SIZE);
-        final RepositoryService repoService =
-                ServiceFactory.get(RepositoryService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        var branchService = ServiceFactory.getForFullPagedLists(RepositoryBranchService.class, false);
+        var repoService = ServiceFactory.getForFullPagedLists(RepositoryService.class, false);
 
         // then look for matching branches
         return ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/resolver/RefPathDisambiguationTask.java
+++ b/app/src/main/java/com/gh4a/resolver/RefPathDisambiguationTask.java
@@ -131,8 +131,9 @@ public class RefPathDisambiguationTask extends UrlLoadTask {
         }
 
         final RepositoryBranchService branchService =
-                ServiceFactory.get(RepositoryBranchService.class, false);
-        final RepositoryService repoService = ServiceFactory.get(RepositoryService.class, false);
+                ServiceFactory.get(RepositoryBranchService.class, false, ApiHelpers.MAX_PAGE_SIZE);
+        final RepositoryService repoService =
+                ServiceFactory.get(RepositoryService.class, false, ApiHelpers.MAX_PAGE_SIZE);
 
         // then look for matching branches
         return ApiHelpers.PageIterator

--- a/app/src/main/java/com/gh4a/utils/ApiHelpers.java
+++ b/app/src/main/java/com/gh4a/utils/ApiHelpers.java
@@ -233,6 +233,12 @@ public class ApiHelpers {
         return "";
     }
 
+    public static int getTotalPagesCount(Page<?> page) {
+        // When all items of a paginated list fit in a single page,
+        // GitHub API responses do not include pagination details
+        return page.last() != null ? page.last() : 1;
+    }
+
     public static <T> T throwOnFailure(Response<T> response) throws ApiRequestException {
         if (response.code() == HttpURLConnection.HTTP_UNAUTHORIZED) {
             Gh4Application.get().logout();

--- a/app/src/main/java/com/gh4a/utils/ApiHelpers.java
+++ b/app/src/main/java/com/gh4a/utils/ApiHelpers.java
@@ -40,6 +40,8 @@ import io.reactivex.subjects.BehaviorSubject;
 import retrofit2.Response;
 
 public class ApiHelpers {
+    public static final int MAX_PAGE_SIZE = 100;
+
     public interface IssueState {
         String OPEN = "open";
         String CLOSED = "closed";

--- a/app/src/main/java/com/gh4a/utils/SingleFactory.java
+++ b/app/src/main/java/com/gh4a/utils/SingleFactory.java
@@ -57,8 +57,7 @@ public class SingleFactory {
 
     public static Single<NotificationListLoadResult> getNotifications(boolean all,
             boolean participating, boolean bypassCache) {
-        final NotificationService service =
-                ServiceFactory.get(NotificationService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
+        var service = ServiceFactory.getForFullPagedLists(NotificationService.class, bypassCache);
         final Map<String, Object> options = new HashMap<>();
         options.put("all", all);
         options.put("participating", participating);

--- a/app/src/main/java/com/gh4a/utils/SingleFactory.java
+++ b/app/src/main/java/com/gh4a/utils/SingleFactory.java
@@ -58,7 +58,7 @@ public class SingleFactory {
     public static Single<NotificationListLoadResult> getNotifications(boolean all,
             boolean participating, boolean bypassCache) {
         final NotificationService service =
-                ServiceFactory.get(NotificationService.class, bypassCache);
+                ServiceFactory.get(NotificationService.class, bypassCache, ApiHelpers.MAX_PAGE_SIZE);
         final Map<String, Object> options = new HashMap<>();
         options.put("all", all);
         options.put("participating", participating);


### PR DESCRIPTION
This PR implements several optimizations with the goal of reducing loading times (especially in worst-case scenarios) and reduce data usage when possible:
- for issues and PRs, extract comments from timeline API responses instead of making extra calls to the issue comments API. This change alone does not improve loading times, but reduces the amount of fetched data.
- load branches and tags in parallel when opening the branch selection dialog, instead of sequentially fetching branches first and then tags
- employ a smarter mechanism for finding the number of organization members: instead of fetching the full paginated list of members (which can take a long time for orgs with hundreds of public members), we now only fetch the first page by requesting a single item per page, and then look at the number of total pages in the `Link` header.
Since we requested the API to return 1 member per page, the number of pages will be equal to the number of members (except when there are 0 or 1 members in an org, but I made sure to handle that case as well).
- for paginated lists that are fetched entirely by requesting all pages (I looked for usages of `ApiHelpers.PageIterator`), set the number of results per page to 100 instead of using the default (which is 30).
This gives a fairly big performance improvement when paginated lists have several hundreds of items. Below are some examples of such worst-case scenarios:

|  | master | This PR |
|--------|--------|--------|
| branches/tags loading (`torvalds/linux` repo) | 7 secs | 2,5 secs |
| PR conversation loading | 14 secs | 6,5 secs |
| PR files loading (~2000 items) | 22 secs | 8 secs |
| issue conversation loading | 16,5 secs | 8 secs |
| PR review loading | 22,5 secs | 17 secs | 

It's important to note that performance gains are much less prominent for paginated lists that have less items in total (<100). For example, a PR conversation that previously took 6,5 secs to load now takes ~5 secs in my testing.

One last thing worth mentioning: updating OkHttp to version 4 was required to make AS network inspector work properly, since it doesn't support OkHttp 3.x anymore. [Breaking changes in 4.x](https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4) do not affect us and the bindings were updated to support OkHttp 4 [quite some time ago](https://github.com/maniac103/GitHubSdk/pull/7) :slightly_smiling_face: 