### PR TITLE
Minor miscellaneous UI fixes

### DIFF
--- a/app/src/main/assets/markdown-light.css
+++ b/app/src/main/assets/markdown-light.css
@@ -194,8 +194,12 @@ table tr td :last-child,table tr th :last-child {
     margin-bottom: 0;
 }
 
-img {
+img, video {
     height: auto;
+    max-width: 100%;
+}
+
+.wp-video {  /* Prevents videos from overflowing in GitHub blog articles */
     max-width: 100%;
 }
 

--- a/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueEditActivity.java
@@ -75,6 +75,7 @@ import com.meisolsson.githubsdk.service.issues.IssueMilestoneService;
 import com.meisolsson.githubsdk.service.issues.IssueService;
 import com.meisolsson.githubsdk.service.repositories.RepositoryCollaboratorService;
 import com.meisolsson.githubsdk.service.repositories.RepositoryContentService;
+import com.vdurmont.emoji.EmojiParser;
 
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
@@ -991,7 +992,7 @@ public class IssueEditActivity extends BasePagerActivity implements
                 viewColor.setBackgroundColor(ApiHelpers.colorForLabel(label));
 
                 final TextView tvLabel = rowView.findViewById(R.id.tv_title);
-                tvLabel.setText(label.name());
+                tvLabel.setText(EmojiParser.parseToUnicode(label.name()));
                 tvLabel.setOnClickListener(clickListener);
                 tvLabel.setTag(label);
 

--- a/app/src/main/java/com/gh4a/adapter/IssueLabelAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/IssueLabelAdapter.java
@@ -18,6 +18,7 @@ import com.gh4a.ColorPickerDialog;
 import com.gh4a.R;
 import com.gh4a.utils.UiUtils;
 import com.meisolsson.githubsdk.model.Label;
+import com.vdurmont.emoji.EmojiParser;
 
 public class IssueLabelAdapter extends
         RootAdapter<IssueLabelAdapter.EditableLabel, IssueLabelAdapter.ViewHolder> {
@@ -148,7 +149,7 @@ public class IssueLabelAdapter extends
         }
 
         assignColor(holder, label.editedColor != null ? label.editedColor : label.color());
-        holder.label.setText(label.name());
+        holder.label.setText(EmojiParser.parseToUnicode(label.name()));
         holder.editor.setText(label.editedName != null ? label.editedName : label.name());
     }
 

--- a/app/src/main/java/com/gh4a/adapter/RepositoryAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/RepositoryAdapter.java
@@ -51,8 +51,7 @@ public class RepositoryAdapter extends RootAdapter<Repository, RepositoryAdapter
 
         if (!StringUtils.isBlank(repository.description())) {
             holder.tvDesc.setVisibility(View.VISIBLE);
-            holder.tvDesc.setText(
-                    EmojiParser.parseToUnicode(StringUtils.doTeaser(repository.description())));
+            holder.tvDesc.setText(EmojiParser.parseToUnicode(repository.description()));
         } else {
             holder.tvDesc.setVisibility(View.GONE);
         }

--- a/app/src/main/java/com/gh4a/adapter/timeline/DiffViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/DiffViewHolder.java
@@ -94,7 +94,20 @@ class DiffViewHolder extends TimelineItemAdapter.TimelineItemViewHolder<Timeline
         mFileTextView.setClickable(isClickable);
         mFileTextView.setTextColor(isClickable ? mAccentColor : mSecondaryTextColor);
 
-        String[] lines = comment.diffChunk().split("\n");
+        String diffHunk = comment.diffChunk();
+        if (diffHunk.isEmpty()) {
+            mDiffHunkTextView.setVisibility(View.GONE);
+        } else {
+            mDiffHunkTextView.setVisibility(View.VISIBLE);
+            mDiffHunkTextView.setTypeface(Typeface.MONOSPACE);
+            mDiffHunkTextView.setText(buildFormattedDiffText(item, diffHunk));
+            mDiffHunkTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX,
+                    mInitialDiffTextSize * getDiffSizeMultiplier());
+        }
+    }
+
+    private SpannableStringBuilder buildFormattedDiffText(TimelineItem.Diff item, String diffHunk) {
+        String[] lines = diffHunk.split("\n");
 
         int leftLine = 0;
         int rightLine = 0;
@@ -164,10 +177,7 @@ class DiffViewHolder extends TimelineItemAdapter.TimelineItemViewHolder<Timeline
             builder.setSpan(new TypefaceSpan("normal"),
                     spanStart + lineNumberLength, builder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
-        mDiffHunkTextView.setTypeface(Typeface.MONOSPACE);
-        mDiffHunkTextView.setText(builder);
-        mDiffHunkTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX,
-                mInitialDiffTextSize * getDiffSizeMultiplier());
+        return builder;
     }
 
     private float getDiffSizeMultiplier() {

--- a/app/src/main/java/com/gh4a/adapter/timeline/EventViewHolder.java
+++ b/app/src/main/java/com/gh4a/adapter/timeline/EventViewHolder.java
@@ -30,6 +30,7 @@ import com.meisolsson.githubsdk.model.IssueStateReason;
 import com.meisolsson.githubsdk.model.Label;
 import com.meisolsson.githubsdk.model.Rename;
 import com.meisolsson.githubsdk.model.User;
+import com.vdurmont.emoji.EmojiParser;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -335,8 +336,9 @@ class EventViewHolder
     private void replaceLabelPlaceholder(SpannableStringBuilder text, Label label) {
         int pos = text.toString().indexOf("[label]");
         if (label != null && pos >= 0) {
-            int length = label.name().length();
-            text.replace(pos, pos + 7, label.name());
+            String labelName = EmojiParser.parseToUnicode(label.name());
+            int length = labelName.length();
+            text.replace(pos, pos + 7, labelName);
             text.setSpan(new IssueLabelSpan(mContext, label, false), pos, pos + length, 0);
         }
     }

--- a/app/src/main/java/com/gh4a/fragment/UserFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/UserFragment.java
@@ -50,6 +50,7 @@ import com.meisolsson.githubsdk.service.organizations.OrganizationMemberService;
 import com.meisolsson.githubsdk.service.organizations.OrganizationService;
 import com.meisolsson.githubsdk.service.repositories.RepositoryService;
 import com.meisolsson.githubsdk.service.users.UserFollowerService;
+import com.vdurmont.emoji.EmojiParser;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -205,7 +206,7 @@ public class UserFragment extends LoadingFragmentBase implements
         fillTextView(R.id.tv_website, mUser.blog());
         fillTextView(R.id.tv_company, mUser.company());
         fillTextView(R.id.tv_location, mUser.location());
-        fillTextView(R.id.tv_bio, mUser.bio());
+        fillTextView(R.id.tv_bio, mUser.bio() != null ? EmojiParser.parseToUnicode(mUser.bio()) : null);
     }
 
     private static int orZero(Integer count) {
@@ -274,7 +275,7 @@ public class UserFragment extends LoadingFragmentBase implements
                 TextView tvDesc = rowView.findViewById(R.id.tv_desc);
                 if (!StringUtils.isBlank(repo.description())) {
                     tvDesc.setVisibility(View.VISIBLE);
-                    tvDesc.setText(repo.description());
+                    tvDesc.setText(EmojiParser.parseToUnicode(repo.description()));
                 } else {
                     tvDesc.setVisibility(View.GONE);
                 }

--- a/app/src/main/java/com/gh4a/utils/StringUtils.java
+++ b/app/src/main/java/com/gh4a/utils/StringUtils.java
@@ -54,35 +54,6 @@ public class StringUtils {
         return val == null || val.trim().isEmpty();
     }
 
-    /**
-     * Do teaser.
-     *
-     * @param text the text
-     * @return the string
-     */
-    public static String doTeaser(String text) {
-        if (isBlank(text)) {
-            return "";
-        }
-
-        int indexNewLine = text.indexOf("\n");
-        int indexDot = text.indexOf(". ");
-
-        if (indexDot != -1 && indexNewLine != -1) {
-            if (indexDot > indexNewLine) {
-                text = text.substring(0, indexNewLine);
-            } else {
-                text = text.substring(0, indexDot + 1);
-            }
-        } else if (indexDot != -1) {
-            text = text.substring(0, indexDot + 1);
-        } else if (indexNewLine != -1) {
-            text = text.substring(0, indexNewLine);
-        }
-
-        return text;
-    }
-
     public static String getFirstLine(String input) {
         if (input == null) {
             return null;

--- a/app/src/main/java/com/gh4a/utils/StringUtils.java
+++ b/app/src/main/java/com/gh4a/utils/StringUtils.java
@@ -187,7 +187,11 @@ public class StringUtils {
         return sourceText.replace("&lt;", "<")
                 .replace("&gt;", ">")
                 .replace("&amp;", "&")
-                .replace("&#8217;", "’")
-                .replace("&#8211;", "–");
+                .replaceAll("&(lsquo|#8216);", "‘")
+                .replaceAll("&(rsquo|#8217);", "’")
+                .replaceAll("&(ldquo|#8220);", "“")
+                .replaceAll("&(rdquo|#8221);", "”")
+                .replaceAll("&(ndash|#8211);", "–")
+                .replaceAll("&(mdash|#8212);", "—");
     }
 }

--- a/app/src/main/java/com/gh4a/utils/UiUtils.java
+++ b/app/src/main/java/com/gh4a/utils/UiUtils.java
@@ -25,6 +25,7 @@ import android.widget.TextView;
 import com.gh4a.R;
 import com.gh4a.widget.IssueLabelSpan;
 import com.meisolsson.githubsdk.model.Label;
+import com.vdurmont.emoji.EmojiParser;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -320,8 +321,9 @@ public class UiUtils {
         for (Label label : labels) {
             int pos = builder.length();
             IssueLabelSpan span = new IssueLabelSpan(context, label, true);
-            builder.append(label.name());
-            builder.setSpan(span, pos, pos + label.name().length(), 0);
+            String labelName = EmojiParser.parseToUnicode(label.name());
+            builder.append(labelName);
+            builder.setSpan(span, pos, pos + labelName.length(), 0);
         }
         return builder;
     }


### PR DESCRIPTION
This PR fixes a few minor UI issues I've spotted throughout the app:

- there were some places where the app didn't parse emoji aliases in text (like `:smile:` or `:+1:`): user bios, label names and repository descriptions in the user/organization screen.
The only place which still lacks emoji parsing is the "Filter by label" selection screen. I've tried to implement it there too, but it broke filtering for labels with emojis because GH search filters expect the "raw" label name (with unparsed aliases). Since fixing this scenario would have required a lot more work, I've left it as is for now.
Also, while fixing repo descriptions in the user screen, I've noticed that in other repository lists there was some logic to display only the first sentence or line of the repo description. In the end, I've decided to get rid of it to make the behavior more predictable and consistent throughout the app.
- embedded videos in GitHub blog posts were overflowing due to some weird inline CSS styles in the article content. I've added a couple of rules to our Markdown stylesheets to override them.
- the diff holder used in the PR review screen had no logic for handling [comments on files](https://github.blog/changelog/2023-04-11-commenting-on-files-in-a-pull-request-is-now-generally-available/) (which have no diff attached to them), and displayed an empty space in place of the diff for those comments:

| Before | After |
|--------|--------|
| ![Screenshot_20250201-192034_OctoDroid](https://github.com/user-attachments/assets/6d0ca2d5-ec93-4b2e-bd8a-91b10a46c85a) | ![Screenshot_20250201-192126_OctoDroid_Debug](https://github.com/user-attachments/assets/be38ff22-9255-45c4-aa1b-105f71fe31df) | 

~~Lastly, while working on the diff holder, I've decided to give another try at making the code use the monospace font without wasting too much screen width (I tried to do that [some time ago](https://github.com/slapperwan/gh4a/pull/1144) but wasn't satisfied with the result). I think I have now reached a good compromise, thanks to the use of the `textScaleX` attribute that makes the text a bit more narrow:~~

| Before | After |
|--------|--------|
| ![Screenshot_20250201-191801_OctoDroid](https://github.com/user-attachments/assets/66364eed-a20f-44ae-bde6-cae3edabe753) | ![Screenshot_20250201-191730_OctoDroid_Debug](https://github.com/user-attachments/assets/44cc241a-028f-44cd-ab56-3df7c64576c8) | 


