### PR TITLE
Add ability to open repository in new window and fix behavior on Android 12L+

### DIFF
--- a/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
+++ b/app/src/main/java/com/gh4a/activities/RepositoryActivity.java
@@ -289,6 +289,11 @@ public class RepositoryActivity extends BaseFragmentPagerActivity implements
     }
 
     @Override
+    public boolean displayDetachAction() {
+        return true;
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         Uri url = IntentUtils.createBaseUriForRepo(mRepoOwner, mRepoName).build();
         switch (item.getItemId()) {

--- a/app/src/main/java/com/gh4a/utils/IntentUtils.java
+++ b/app/src/main/java/com/gh4a/utils/IntentUtils.java
@@ -227,9 +227,6 @@ public class IntentUtils {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
         intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            intent.addFlags(Intent.FLAG_ACTIVITY_LAUNCH_ADJACENT);
-        }
         intent.putExtra(EXTRA_NEW_TASK, true);
         context.startActivity(intent);
     }


### PR DESCRIPTION
I have added the "Open in new window" menu item to the repository activity too, since I've found myself trying to compare two folders of different repositories but the app wasn't making it very easy :slightly_smiling_face:. I've also looked in the original PR (#784) to see if there was a reason for not adding this feature to the repository screen, but couldn't find one.

While testing this change on the emulator, I've noticed that "Open in window" was always splitting the screen and opening the activity in the bottom half, instead of just launching it as it does on my Android 10 device. It turns out that the behavior of `FLAG_ACTIVITY_LAUNCH_ADJACENT` [was changed since Android 12L](https://developer.android.com/develop/ui/views/layout/support-multi-window-mode#launch_adjacent):
>Android 12L (API level 32) and higher have extended the flag's definition to enable apps running full screen to activate split-screen mode and then launch activities in the adjacent window.

Since this is not the intended behavior for our scenario, I've removed the flag altogether so that the behavior is consistent between Android versions. The launch adjacent flag was originally added so that _"when the app is in split-screen then the detached task will appear in the second split"_ but apparently this became the default behavior at some point, because on Android 10 it occurs even without the flag :man_shrugging: 