### PR TITLE
Fix crash on PRs made by deleted users and add icon for discussion notifications

### DIFF
--- a/app/src/main/java/com/gh4a/adapter/NotificationAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/NotificationAdapter.java
@@ -30,6 +30,7 @@ public class NotificationAdapter extends
     public static final String SUBJECT_PULL_REQUEST = "PullRequest";
     public static final String SUBJECT_COMMIT = "Commit";
     public static final String SUBJECT_RELEASE = "Release";
+    public static final String SUBJECT_DISCUSSION = "Discussion";
 
     public interface OnNotificationActionCallback {
         void markAsRead(NotificationHolder notificationHolder);
@@ -174,17 +175,14 @@ public class NotificationAdapter extends
     }
 
     private int getIconResId(String subjectType) {
-        if (SUBJECT_ISSUE.equals(subjectType)) {
-            return R.drawable.issue;
-        } else if (SUBJECT_PULL_REQUEST.equals(subjectType)) {
-            return R.drawable.pull_request;
-        } else if (SUBJECT_COMMIT.equals(subjectType)) {
-            return R.drawable.commit;
-        } else if (SUBJECT_RELEASE.equals(subjectType)) {
-            return R.drawable.release;
-        } else {
-            return 0;
-        }
+        return switch (subjectType) {
+            case SUBJECT_ISSUE -> R.drawable.issue;
+            case SUBJECT_PULL_REQUEST -> R.drawable.pull_request;
+            case SUBJECT_COMMIT -> R.drawable.commit;
+            case SUBJECT_RELEASE -> R.drawable.release;
+            case SUBJECT_DISCUSSION -> R.drawable.discussion;
+            default -> 0;
+        };
     }
 
     public static class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener,

--- a/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/PullRequestConversationFragment.java
@@ -516,13 +516,13 @@ public class PullRequestConversationFragment extends IssueFragmentBase {
 
         PullRequestMarker head = mPullRequest.head();
         Repository repo = head.repo();
-        Single<Optional<GitReference>> refSingle = repo == null
-                ? Single.just(Optional.empty())
-                : service.getGitReference(repo.owner().login(), repo.name(), head.ref())
+        Single<Optional<GitReference>> refSingle = repo != null && repo.owner() != null
+                ? service.getGitReference(repo.owner().login(), repo.name(), head.ref())
                         .map(ApiHelpers::throwOnFailure)
                         .map(Optional::of)
-                        .compose(RxUtils.mapFailureToValue(HttpURLConnection.HTTP_NOT_FOUND, Optional.<GitReference>empty()))
-                        .compose(makeLoaderSingle(ID_LOADER_HEAD_REF, force));
+                        .compose(RxUtils.mapFailureToValue(HttpURLConnection.HTTP_NOT_FOUND, Optional.<GitReference> empty()))
+                        .compose(makeLoaderSingle(ID_LOADER_HEAD_REF, force))
+                : Single.just(Optional.empty());
 
         refSingle.subscribe(refOpt -> {
             mHeadReference = refOpt.orElse(null);

--- a/app/src/main/java/com/gh4a/worker/NotificationsWorker.java
+++ b/app/src/main/java/com/gh4a/worker/NotificationsWorker.java
@@ -375,19 +375,16 @@ public class NotificationsWorker extends Worker {
         nm.notify(0, builder.build());
     }
 
-    private String determineNotificationTypeLabel(NotificationThread n) {
+    private String determineNotificationTypeLabel(NotificationThread notification) {
         final Resources res = getApplicationContext().getResources();
-        switch (n.subject().type()) {
-            case NotificationAdapter.SUBJECT_COMMIT:
-                return res.getString(R.string.notification_subject_commit);
-            case NotificationAdapter.SUBJECT_ISSUE:
-                return res.getString(R.string.notification_subject_issue);
-            case NotificationAdapter.SUBJECT_PULL_REQUEST:
-                return res.getString(R.string.notification_subject_pr);
-            case NotificationAdapter.SUBJECT_RELEASE:
-                return res.getString(R.string.notification_subject_release);
-        }
-        return n.subject().type();
+        return switch (notification.subject().type()) {
+            case NotificationAdapter.SUBJECT_COMMIT -> res.getString(R.string.notification_subject_commit);
+            case NotificationAdapter.SUBJECT_ISSUE -> res.getString(R.string.notification_subject_issue);
+            case NotificationAdapter.SUBJECT_PULL_REQUEST -> res.getString(R.string.notification_subject_pr);
+            case NotificationAdapter.SUBJECT_RELEASE -> res.getString(R.string.notification_subject_release);
+            case NotificationAdapter.SUBJECT_DISCUSSION -> res.getString(R.string.notification_subject_discussion);
+            default -> notification.subject().type();
+        };
     }
 
     private NotificationCompat.Builder makeBaseBuilder() {

--- a/app/src/main/res/drawable-night/discussion.xml
+++ b/app/src/main/res/drawable-night/discussion.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M15,4v7L5.17,11L4,12.17L4,4h11m1,-2L3,2c-0.55,0 -1,0.45 -1,1v14l4,-4h10c0.55,0 1,-0.45 1,-1L17,3c0,-0.55 -0.45,-1 -1,-1zM21,6h-2v9L6,15v2c0,0.55 0.45,1 1,1h11l4,4L22,7c0,-0.55 -0.45,-1 -1,-1z"
+      android:fillColor="#ccffffff"/>
+</vector>

--- a/app/src/main/res/drawable/discussion.xml
+++ b/app/src/main/res/drawable/discussion.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M15,4v7L5.17,11L4,12.17L4,4h11m1,-2L3,2c-0.55,0 -1,0.45 -1,1v14l4,-4h10c0.55,0 1,-0.45 1,-1L17,3c0,-0.55 -0.45,-1 -1,-1zM21,6h-2v9L6,15v2c0,0.55 0.45,1 1,1h11l4,4L22,7c0,-0.55 -0.45,-1 -1,-1z"
+      android:fillColor="#99343434"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -610,6 +610,7 @@
     <string name="notification_subject_issue">Issue</string>
     <string name="notification_subject_pr">PR</string>
     <string name="notification_subject_release">Release</string>
+    <string name="notification_subject_discussion">Discussion</string>
     <string name="notification_interval">Sync interval</string>
     <string name="detach">Open in new window</string>
 


### PR DESCRIPTION
This PR includes a couple of small changes that IMO would be worthwhile to include before the next release:
- fix a crash that occurs on PRs made by deleted users due to the `head` repository object having a `null` owner. There are several closed PRs in [azahar-emu/azahar](https://github.com/azahar-emu/azahar) repo which trigger this crash in the current version of the app.
- add an icon for discussion notifications in the notifications list (previously the app didn't show any icon for those). I've chosen to use the Material ["forum" outline icon](https://fonts.google.com/icons?selected=Material+Icons+Outlined:forum:&icon.set=Material+Icons&icon.size=24&icon.color=%231f1f1f) which is the one that most resembles [the icon used by GitHub](https://primer.style/octicons/icon/comment-discussion-16/).
<img src="https://github.com/user-attachments/assets/fa514237-998e-4c7f-9754-9e2db5bbed25" width=415 />