### PR TITLE
Fix crash on commits with many comments and refactor compression in bundle

### DIFF
--- a/app/src/main/java/com/gh4a/activities/CommitActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitActivity.java
@@ -30,7 +30,7 @@ import com.gh4a.BaseFragmentPagerActivity;
 import com.gh4a.R;
 import com.gh4a.ServiceFactory;
 import com.gh4a.fragment.CommitFragment;
-import com.gh4a.fragment.CommitNoteFragment;
+import com.gh4a.fragment.CommitCommentsFragment;
 import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.IntentUtils;
 import com.gh4a.widget.BottomSheetCompatibleScrollingViewBehavior;
@@ -42,7 +42,7 @@ import com.meisolsson.githubsdk.service.repositories.RepositoryCommitService;
 import java.util.List;
 
 public class CommitActivity extends BaseFragmentPagerActivity implements
-        CommitFragment.CommentUpdateListener, CommitNoteFragment.CommentUpdateListener {
+        CommitFragment.CommentUpdateListener, CommitCommentsFragment.CommentUpdateListener {
     public static Intent makeIntent(Context context, String repoOwner, String repoName, String sha) {
         return makeIntent(context, repoOwner, repoName, -1, sha, null);
     }
@@ -138,7 +138,7 @@ public class CommitActivity extends BaseFragmentPagerActivity implements
     @Override
     protected Fragment makeFragment(int position) {
         if (position == 1) {
-            Fragment f = CommitNoteFragment.newInstance(mRepoOwner, mRepoName, mObjectSha,
+            Fragment f = CommitCommentsFragment.newInstance(mRepoOwner, mRepoName, mObjectSha,
                     mCommit, mComments, mInitialComment);
             mInitialComment = null;
             return f;

--- a/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/DiffViewerActivity.java
@@ -74,7 +74,7 @@ public abstract class DiffViewerActivity<C extends PositionalCommentBase> extend
             // When there are lots of comments containing a huge amount of text, the extras bundle may
             // become too large, causing a TransactionTooLargeException when launching the activity.
             // In order to avoid this problem, we store the data in compressed form
-            IntentUtils.putCompressedArrayListExtra(intent, "comments", new ArrayList<>(comments), 500_000);
+            IntentUtils.putCompressedExtra(intent, "comments", comments);
         }
         return intent;
     }
@@ -227,7 +227,7 @@ public abstract class DiffViewerActivity<C extends PositionalCommentBase> extend
     @Override
     protected boolean canSwipeToRefresh() {
         // no need for pull-to-refresh if everything was passed in the intent extras
-        return !IntentUtils.hasCompressedExtra(getIntent(), "comments");
+        return !getIntent().hasExtra("comments");
     }
 
     @Override
@@ -481,7 +481,7 @@ public abstract class DiffViewerActivity<C extends PositionalCommentBase> extend
 
     private void refresh() {
         // Make sure we load the comments from remote, as we now know they've changed
-        IntentUtils.removeCompressedExtra(getIntent(), "comments");
+        getIntent().removeExtra("comments");
 
         // Make sure our callers are aware of the change
         setResult(RESULT_OK);
@@ -513,7 +513,7 @@ public abstract class DiffViewerActivity<C extends PositionalCommentBase> extend
 
     private void loadComments(boolean useIntentExtraIfPresent, boolean force) {
         List<C> intentComments = useIntentExtraIfPresent
-                ? IntentUtils.getCompressedArrayListExtra(getIntent(), "comments") : null;
+                ? IntentUtils.getCompressedExtra(getIntent(), "comments") : null;
         Single<List<C>> commentsSingle = intentComments != null
                 ? Single.just(intentComments)
                 : getCommentsSingle(force).compose(makeLoaderSingle(ID_LOADER_COMMENTS, force));

--- a/app/src/main/java/com/gh4a/activities/WikiActivity.java
+++ b/app/src/main/java/com/gh4a/activities/WikiActivity.java
@@ -30,7 +30,7 @@ public class WikiActivity extends WebViewerActivity {
                 .putExtra("owner", repoOwner)
                 .putExtra("repo", repoName);
         // Avoid TransactionTooLargeExceptions on activity launch when page content is too big
-        IntentUtils.putCompressedParcelableExtra(intent, "page_feed", feed, 800_000);
+        IntentUtils.putCompressedExtra(intent, "page_feed", feed);
         return intent;
     }
 
@@ -62,7 +62,7 @@ public class WikiActivity extends WebViewerActivity {
         super.onInitExtras(extras);
         mUserLogin = extras.getString("owner");
         mRepoName = extras.getString("repo");
-        mWikiPageFeed = IntentUtils.readCompressedParcelableFromBundle(extras, "page_feed");
+        mWikiPageFeed = IntentUtils.readCompressedValueFromBundle(extras, "page_feed");
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/adapter/CommitCommentAdapter.java
+++ b/app/src/main/java/com/gh4a/adapter/CommitCommentAdapter.java
@@ -53,11 +53,11 @@ import java.util.Set;
 
 import io.reactivex.Single;
 
-public class CommitNoteAdapter extends RootAdapter<GitComment, CommitNoteAdapter.ViewHolder>
+public class CommitCommentAdapter extends RootAdapter<GitComment, CommitCommentAdapter.ViewHolder>
         implements ReactionBar.Callback, ReactionBar.ReactionDetailsCache.Listener {
-    public interface OnCommentAction<T> {
-        void editComment(T comment);
-        void deleteComment(T comment);
+    public interface OnCommentAction {
+        void editComment(GitComment comment);
+        void deleteComment(GitComment comment);
         void quoteText(CharSequence text);
         void addText(CharSequence text);
     }
@@ -96,7 +96,7 @@ public class CommitNoteAdapter extends RootAdapter<GitComment, CommitNoteAdapter
         }
     };
 
-    public CommitNoteAdapter(Context context, String repoOwner, String repoName,
+    public CommitCommentAdapter(Context context, String repoOwner, String repoName,
             OnCommentAction actionCallback) {
         super(context);
         mImageGetter = new HttpImageGetter(context);

--- a/app/src/main/java/com/gh4a/fragment/CommitCommentsFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/CommitCommentsFragment.java
@@ -18,7 +18,7 @@ import com.gh4a.Gh4Application;
 import com.gh4a.R;
 import com.gh4a.ServiceFactory;
 import com.gh4a.activities.EditCommitCommentActivity;
-import com.gh4a.adapter.CommitNoteAdapter;
+import com.gh4a.adapter.CommitCommentAdapter;
 import com.gh4a.adapter.RootAdapter;
 import com.gh4a.utils.ActivityResultHelpers;
 import com.gh4a.utils.ApiHelpers;
@@ -39,13 +39,13 @@ import io.reactivex.Single;
 
 import static java.util.stream.Collectors.toCollection;
 
-public class CommitNoteFragment extends ListDataBaseFragment<GitComment> implements
-        CommitNoteAdapter.OnCommentAction<GitComment>, ConfirmationDialogFragment.Callback,
+public class CommitCommentsFragment extends ListDataBaseFragment<GitComment> implements
+        CommitCommentAdapter.OnCommentAction, ConfirmationDialogFragment.Callback,
         EditorBottomSheet.Callback, EditorBottomSheet.Listener {
 
-    public static CommitNoteFragment newInstance(String repoOwner, String repoName, String commitSha, Commit commit,
+    public static CommitCommentsFragment newInstance(String repoOwner, String repoName, String commitSha, Commit commit,
             List<GitComment> allComments, IntentUtils.InitialCommentMarker initialComment) {
-        CommitNoteFragment f = new CommitNoteFragment();
+        CommitCommentsFragment f = new CommitCommentsFragment();
 
         ArrayList<GitComment> nonPositionalComments = allComments.stream()
                 .filter(comment -> comment.position() == null)
@@ -77,7 +77,7 @@ public class CommitNoteFragment extends ListDataBaseFragment<GitComment> impleme
     private User mCommitter;
     private IntentUtils.InitialCommentMarker mInitialComment;
 
-    private CommitNoteAdapter mAdapter;
+    private CommitCommentAdapter mAdapter;
     private EditorBottomSheet mBottomSheet;
 
     private final ActivityResultLauncher<Intent> mEditLauncher = registerForActivityResult(
@@ -197,7 +197,7 @@ public class CommitNoteFragment extends ListDataBaseFragment<GitComment> impleme
 
     @Override
     protected RootAdapter<GitComment, ? extends RecyclerView.ViewHolder> onCreateAdapter() {
-        mAdapter = new CommitNoteAdapter(getActivity(), mRepoOwner, mRepoName, this);
+        mAdapter = new CommitCommentAdapter(getActivity(), mRepoOwner, mRepoName, this);
         return mAdapter;
     }
 

--- a/app/src/main/java/com/gh4a/fragment/CommitFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/CommitFragment.java
@@ -55,8 +55,8 @@ public class CommitFragment extends LoadingFragmentBase implements OnClickListen
         // and can potentially have a very high number of comments.
         // In order to avoid TransactionTooLargeExceptions being thrown when the activity we're
         // attached to is stopped, store the data in compressed form.
-        IntentUtils.putParcelableToBundleCompressed(args, "commit", commit, 100_000);
-        IntentUtils.putArrayListToBundleCompressed(args, "comments", new ArrayList<>(comments), 100_000);
+        IntentUtils.putCompressedValueToBundle(args, "commit", commit);
+        IntentUtils.putCompressedValueToBundle(args, "comments", comments);
         f.setArguments(args);
         return f;
     }
@@ -88,8 +88,8 @@ public class CommitFragment extends LoadingFragmentBase implements OnClickListen
         mRepoOwner = args.getString("owner");
         mRepoName = args.getString("repo");
         mObjectSha = args.getString("sha");
-        mCommit = IntentUtils.readCompressedParcelableFromBundle(args, "commit");
-        mComments = IntentUtils.readCompressedArrayListFromBundle(args, "comments");
+        mCommit = IntentUtils.readCompressedValueFromBundle(args, "commit");
+        mComments = IntentUtils.readCompressedValueFromBundle(args, "comments");
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/CommitFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/CommitFragment.java
@@ -51,11 +51,12 @@ public class CommitFragment extends LoadingFragmentBase implements OnClickListen
         args.putString("owner", repoOwner);
         args.putString("repo", repoName);
         args.putString("sha", commitSha);
-        // Commit objects can be huge, depending on the number of patches attached to it.
+        // Commits can be huge, depending on the number of patches attached to it,
+        // and can potentially have a very high number of comments.
         // In order to avoid TransactionTooLargeExceptions being thrown when the activity we're
-        // attached to is recreated, store the data in compressed form
-        IntentUtils.putParcelableToBundleCompressed(args, "commit", commit, 100000);
-        args.putParcelableArrayList("comments", new ArrayList<>(comments));
+        // attached to is stopped, store the data in compressed form.
+        IntentUtils.putParcelableToBundleCompressed(args, "commit", commit, 100_000);
+        IntentUtils.putArrayListToBundleCompressed(args, "comments", new ArrayList<>(comments), 100_000);
         f.setArguments(args);
         return f;
     }
@@ -88,7 +89,7 @@ public class CommitFragment extends LoadingFragmentBase implements OnClickListen
         mRepoName = args.getString("repo");
         mObjectSha = args.getString("sha");
         mCommit = IntentUtils.readCompressedParcelableFromBundle(args, "commit");
-        mComments = args.getParcelableArrayList("comments");
+        mComments = IntentUtils.readCompressedArrayListFromBundle(args, "comments");
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/fragment/CommitNoteFragment.java
+++ b/app/src/main/java/com/gh4a/fragment/CommitNoteFragment.java
@@ -61,7 +61,7 @@ public class CommitNoteFragment extends ListDataBaseFragment<GitComment> impleme
         // Commits can potentially have a very high number of comments.
         // In order to avoid TransactionTooLargeExceptions being thrown when the activity we're
         // attached to is stopped, store them in compressed form.
-        IntentUtils.putArrayListToBundleCompressed(args, "comments", nonPositionalComments, 100_000);
+        IntentUtils.putCompressedValueToBundle(args, "comments", nonPositionalComments);
         f.setArguments(args);
         return f;
     }
@@ -240,7 +240,7 @@ public class CommitNoteFragment extends ListDataBaseFragment<GitComment> impleme
 
     @Override
     protected List<GitComment> onGetInitialData() {
-        List<GitComment> comments = IntentUtils.readCompressedArrayListFromBundle(getArguments(), "comments");
+        List<GitComment> comments = IntentUtils.readCompressedValueFromBundle(getArguments(), "comments");
         return comments != null && !comments.isEmpty() ? comments : null;
     }
 


### PR DESCRIPTION
The main goal of this PR is to fix a crash that occurs when switching away from the commit activity when the commit has many comments (such as https://github.com/git/git/commit/e83c5163316f89bfbde7d9ab23ca2e25604af290 with almost 300 comments), caused by a `TransactionTooLargeException` due to the comments being saved in the fragment args `Bundle` (and then stored in the saved instance state by Android) without compression.
However, I've ended up heavily refactoring the code for compressing args in `Bundle`s/`Intent` extras because otherwise I would have introduced more duplication. In summary:
- I've made the compression/decompression functions able to work with any kind of object supported by `Parcel`s, so that we don't need to have a different function for each type of object we want to compress 
- I've removed the compression threshold: objects are now always stored in compressed form when using `IntentUtils.putCompressed*` functions. We were previously setting thresholds to 100/500/800KB assuming that the OS would tolerate serialized payloads up to 1MB, however when debugging I've seen `TransactionTooLargeException` being thrown even for smaller sizes (around 600KB). Indeed, [the docs say](https://developer.android.com/reference/android/os/TransactionTooLargeException.html) (emphasis mine):
> The Binder transaction buffer has a limited fixed size, currently 1MB, which is shared by all transactions in progress for the process. Consequently this exception can be thrown when there are many transactions in progress **even when most of the individual transactions are of moderate size**.

[And also](https://developer.android.com/guide/components/activities/parcelables-and-bundles#sdbp):

> For the specific case of savedInstanceState, the amount of data should be kept small [...]. We recommend that you keep saved state **to less than 50k of data**.

So, in the end, I think it's better to play it safer and don't let callers worry about those details. This change also helped a lot in making the code easier to follow and more generic.

Furthermore, I've noticed that for compression we could just use a [`DeflaterOutputStream`](https://developer.android.com/reference/java/util/zip/DeflaterOutputStream), a superclass of the `GZipOutputStream` which also lets us tweak the compression level to our needs.
I've experimented a bit with the levels and found out that `3` (default is `6` on a 1-9 range) looks like the sweet spot for speed (around 2x faster than `4` and 2,5-3x faster than `6`) without losing much on compressed size (a few tens of KBs at worst for payloads close to 1MB).
It might look like a superfluous optimization - and for most scenarios it likely is - but on my Galaxy A3 2017 I've measured the compression of a long wiki article taking 77ms (still acceptable but not quite fast), which was reduced to 29ms simply by tweaking the compression level.

Lastly, while I was at it I've renamed the `CommitNoteFragment` and related adapter to `CommitCommentsFragment` (the "notes" part didn't look very obvious to me, maybe a remnant of the past?).