### PR TITLE
Fix handling of diff and commit comment URLs

### DIFF
--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -60,7 +60,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
         if (replyId > 0L) {
             builder.fragment("commitcomment-" + replyId);
         } else {
-            builder.fragment("diff-" + ApiHelpers.md5(mPath) + lineId);
+            builder.fragment("diff-" + ApiHelpers.sha256Of(mPath) + lineId);
         }
         return builder.build();
     }

--- a/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java
@@ -58,7 +58,7 @@ public class CommitDiffViewerActivity extends DiffViewerActivity<GitComment> {
                 .appendPath("commit")
                 .appendPath(mSha);
         if (replyId > 0L) {
-            builder.fragment("commitcomment-" + replyId);
+            builder.fragment("r" + replyId);
         } else {
             builder.fragment("diff-" + ApiHelpers.sha256Of(mPath) + lineId);
         }

--- a/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
+++ b/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java
@@ -86,7 +86,7 @@ public class PullRequestDiffViewerActivity extends DiffViewerActivity<ReviewComm
         if (replyId > 0L) {
             builder.fragment("r" + replyId);
         } else {
-            builder.fragment("diff-" + ApiHelpers.md5(mPath) + lineId);
+            builder.fragment("diff-" + ApiHelpers.sha256Of(mPath) + lineId);
         }
         return builder.build();
     }

--- a/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/CommitDiffLoadTask.java
@@ -14,15 +14,13 @@ import com.gh4a.activities.CommitDiffViewerActivity;
 import com.gh4a.utils.ApiHelpers;
 import com.meisolsson.githubsdk.model.Commit;
 import com.meisolsson.githubsdk.model.GitHubFile;
-import com.meisolsson.githubsdk.model.git.GitComment;
-import com.meisolsson.githubsdk.service.repositories.RepositoryCommentService;
 import com.meisolsson.githubsdk.service.repositories.RepositoryCommitService;
 
 import java.util.List;
 
 import io.reactivex.Single;
 
-public class CommitDiffLoadTask extends DiffLoadTask<GitComment> {
+public class CommitDiffLoadTask extends DiffLoadTask {
     @VisibleForTesting
     protected final String mSha;
 
@@ -33,10 +31,9 @@ public class CommitDiffLoadTask extends DiffLoadTask<GitComment> {
     }
 
     @Override
-    protected @NonNull Intent getLaunchIntent(String sha, @NonNull GitHubFile file,
-            List<GitComment> comments, DiffHighlightId diffId) {
+    protected @NonNull Intent getLaunchIntent(String sha, @NonNull GitHubFile file, DiffHighlightId diffId) {
         return CommitDiffViewerActivity.makeIntent(mActivity, mRepoOwner, mRepoName,
-                sha, file.filename(), file.patch(), comments, diffId.startLine,
+                sha, file.filename(), file.patch(), null, diffId.startLine,
                 diffId.endLine, diffId.right, null);
     }
 
@@ -56,12 +53,5 @@ public class CommitDiffLoadTask extends DiffLoadTask<GitComment> {
         return service.getCommit(mRepoOwner, mRepoName, mSha)
                 .map(ApiHelpers::throwOnFailure)
                 .map(Commit::files);
-    }
-
-    @Override
-    protected Single<List<GitComment>> getComments() throws ApiRequestException {
-        var service = ServiceFactory.getForFullPagedLists(RepositoryCommentService.class, false);
-        return ApiHelpers.PageIterator
-                .toSingle(page -> service.getCommitComments(mRepoOwner, mRepoName, mSha, page));
     }
 }

--- a/app/src/main/java/com/gh4a/resolver/DiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/DiffLoadTask.java
@@ -11,14 +11,13 @@ import com.gh4a.utils.ApiHelpers;
 import com.gh4a.utils.FileUtils;
 import com.gh4a.utils.RxUtils;
 import com.meisolsson.githubsdk.model.GitHubFile;
-import com.meisolsson.githubsdk.model.PositionalCommentBase;
 
 import java.util.List;
 import java.util.Optional;
 
 import io.reactivex.Single;
 
-public abstract class DiffLoadTask<C extends PositionalCommentBase> extends UrlLoadTask {
+public abstract class DiffLoadTask extends UrlLoadTask {
     protected final String mRepoOwner;
     protected final String mRepoName;
     protected final DiffHighlightId mDiffId;
@@ -43,7 +42,7 @@ public abstract class DiffLoadTask<C extends PositionalCommentBase> extends UrlL
                 intent = FileViewerActivity.makeIntent(mActivity, mRepoOwner, mRepoName,
                         sha, file.filename());
             } else if (file != null) {
-                intent = getLaunchIntent(sha, file, getComments().blockingGet(), mDiffId);
+                intent = getLaunchIntent(sha, file, mDiffId);
             } else {
                 intent = getFallbackIntent(sha);
             }
@@ -53,8 +52,6 @@ public abstract class DiffLoadTask<C extends PositionalCommentBase> extends UrlL
 
     protected abstract Single<List<GitHubFile>> getFiles();
     protected abstract Single<String> getSha();
-    protected abstract Single<List<C>> getComments();
-    protected abstract @NonNull Intent getLaunchIntent(String sha, @NonNull GitHubFile file,
-            List<C> comments, DiffHighlightId diffId);
+    protected abstract @NonNull Intent getLaunchIntent(String sha, @NonNull GitHubFile file, DiffHighlightId diffId);
     protected abstract @NonNull Intent getFallbackIntent(String sha);
 }

--- a/app/src/main/java/com/gh4a/resolver/DiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/DiffLoadTask.java
@@ -35,7 +35,7 @@ public abstract class DiffLoadTask<C extends PositionalCommentBase> extends UrlL
     protected Single<Optional<Intent>> getSingle() {
         Single<Optional<GitHubFile>> fileSingle = getFiles()
                 .compose(RxUtils.filterAndMapToFirst(
-                        f -> ApiHelpers.md5(f.filename()).equalsIgnoreCase(mDiffId.fileHash)));
+                        f -> ApiHelpers.sha256Of(f.filename()).equalsIgnoreCase(mDiffId.fileHash)));
         return Single.zip(getSha(), fileSingle, (sha, fileOpt) -> {
             final Intent intent;
             GitHubFile file = fileOpt.orElse(null);

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -317,9 +317,7 @@ public class LinkParser {
             return null;
         }
 
-        DiffHighlightId diffId =
-                extractDiffId(uri.getFragment(), "diff-", true);
-
+        DiffHighlightId diffId = extractDiffId(uri.getFragment(), "diff-");
         if (diffId != null) {
             return new ParseResult(new PullRequestDiffLoadTask(activity, uri, user, repo, diffId,
                     pullRequestNumber));
@@ -336,23 +334,20 @@ public class LinkParser {
         }
 
         IntentUtils.InitialCommentMarker reviewMarker =
-                generateInitialCommentMarkerWithoutFallback(uri.getFragment(),
-                        "pullrequestreview-");
+                generateInitialCommentMarkerWithoutFallback(uri.getFragment(), "pullrequestreview-");
         if (reviewMarker != null) {
             return new ParseResult(new PullRequestReviewLoadTask(activity, uri, user, repo,
                     pullRequestNumber, reviewMarker));
         }
 
         IntentUtils.InitialCommentMarker reviewCommentMarker =
-                generateInitialCommentMarkerWithoutFallback(uri.getFragment(),
-                        "discussion_r");
+                generateInitialCommentMarkerWithoutFallback(uri.getFragment(), "discussion_r");
         if (reviewCommentMarker != null) {
             return new ParseResult(new PullRequestReviewCommentLoadTask(activity, uri, user, repo,
                     pullRequestNumber, reviewCommentMarker));
         }
 
-        DiffHighlightId reviewDiffHunkId =
-                extractDiffId(uri.getFragment(), "discussion-diff-", false);
+        DiffHighlightId reviewDiffHunkId = extractDiffId(uri.getFragment(), "discussion-diff-");
         if (reviewDiffHunkId != null) {
             return new ParseResult(new PullRequestReviewDiffLoadTask(activity, uri, user, repo,
                     reviewDiffHunkId, pullRequestNumber));
@@ -384,8 +379,7 @@ public class LinkParser {
         if (StringUtils.isBlank(id)) {
             return null;
         }
-        DiffHighlightId diffId =
-                extractDiffId(uri.getFragment(), "diff-", true);
+        DiffHighlightId diffId = extractDiffId(uri.getFragment(), "diff-");
         if (diffId != null) {
             return new ParseResult(new CommitDiffLoadTask(activity, uri, user, repo, diffId, id));
         }
@@ -445,8 +439,7 @@ public class LinkParser {
         return initialCommentMarker != null ? initialCommentMarker : fallback;
     }
 
-    private static DiffHighlightId extractDiffId(String fragment, String prefix,
-            boolean isMd5Hash) {
+    private static DiffHighlightId extractDiffId(String fragment, String prefix) {
         if (fragment == null || !fragment.startsWith(prefix)) {
             return null;
         }
@@ -461,9 +454,6 @@ public class LinkParser {
         String fileHash = typePos > 0
                 ? fragment.substring(prefix.length(), typePos)
                 : fragment.substring(prefix.length());
-        if (isMd5Hash && fileHash.length() != 32) { // MD5 hash length
-            return null;
-        }
         if (typePos < 0) {
             return new DiffHighlightId(fileHash, -1, -1, false);
         }
@@ -473,10 +463,10 @@ public class LinkParser {
             String linePart = fragment.substring(typePos + 1);
             int startLine, endLine, dashPos = linePart.indexOf("-" + type);
             if (dashPos > 0) {
-                startLine = Integer.valueOf(linePart.substring(0, dashPos));
-                endLine = Integer.valueOf(linePart.substring(dashPos + 2));
+                startLine = Integer.parseInt(linePart.substring(0, dashPos));
+                endLine = Integer.parseInt(linePart.substring(dashPos + 2));
             } else {
-                startLine = Integer.valueOf(linePart);
+                startLine = Integer.parseInt(linePart);
                 endLine = startLine;
             }
             return new DiffHighlightId(fileHash, startLine, endLine, right);

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -384,10 +384,16 @@ public class LinkParser {
             return new ParseResult(new CommitDiffLoadTask(activity, uri, user, repo, diffId, id));
         }
 
-        IntentUtils.InitialCommentMarker initialComment = generateInitialCommentMarker(
-                uri.getFragment(), "commitcomment-", initialCommentFallback);
+        IntentUtils.InitialCommentMarker initialComment =
+                generateInitialCommentMarker(uri.getFragment(), "commitcomment-", initialCommentFallback);
         if (initialComment != null) {
-            return new ParseResult(new CommitCommentLoadTask(activity, uri, user, repo, id, initialComment));
+            return new ParseResult(CommitActivity.makeIntent(activity, user, repo, id, initialComment));
+        }
+
+        IntentUtils.InitialCommentMarker initialDiffComment =
+                generateInitialCommentMarker(uri.getFragment(), "r", initialCommentFallback);
+        if (initialDiffComment != null) {
+            return new ParseResult(new CommitCommentLoadTask(activity, uri, user, repo, id, initialDiffComment));
         }
         return new ParseResult(CommitActivity.makeIntent(activity, user, repo, id, null));
     }

--- a/app/src/main/java/com/gh4a/resolver/LinkParser.java
+++ b/app/src/main/java/com/gh4a/resolver/LinkParser.java
@@ -317,14 +317,14 @@ public class LinkParser {
             return null;
         }
 
+        String target = parts.size() >= 5 ? parts.get(4) : null;
+        int page = parsePullRequestPage(target);
+
         DiffHighlightId diffId = extractDiffId(uri.getFragment(), "diff-");
         if (diffId != null) {
             return new ParseResult(new PullRequestDiffLoadTask(activity, uri, user, repo, diffId,
-                    pullRequestNumber));
+                    pullRequestNumber, page));
         }
-
-        String target = parts.size() >= 5 ? parts.get(4) : null;
-        int page = parsePullRequestPage(target);
 
         IntentUtils.InitialCommentMarker initialDiffComment =
                 generateInitialCommentMarkerWithoutFallback(uri.getFragment(), "r");

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
@@ -22,13 +22,14 @@ import java.util.List;
 import io.reactivex.Single;
 
 public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
-    @VisibleForTesting
-    protected final int mPullRequestNumber;
+    private final int mPullRequestNumber;
+    private final int mPage;
 
     public PullRequestDiffLoadTask(FragmentActivity activity, Uri urlToResolve,
-            String repoOwner, String repoName, DiffHighlightId diffId, int pullRequestNumber) {
+            String repoOwner, String repoName, DiffHighlightId diffId, int pullRequestNumber, int page) {
         super(activity, urlToResolve, repoOwner, repoName, diffId);
         mPullRequestNumber = pullRequestNumber;
+        mPage = page;
     }
 
     @Override
@@ -43,7 +44,7 @@ public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
     @Override
     protected Intent getFallbackIntent(String sha) {
         return PullRequestActivity.makeIntent(mActivity, mRepoOwner, mRepoName,
-                mPullRequestNumber);
+                mPullRequestNumber, mPage, null);
     }
 
     @Override

--- a/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
+++ b/app/src/main/java/com/gh4a/resolver/PullRequestDiffLoadTask.java
@@ -4,24 +4,20 @@ import android.content.Intent;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
 import com.gh4a.ServiceFactory;
 import com.gh4a.activities.PullRequestActivity;
 import com.gh4a.activities.PullRequestDiffViewerActivity;
 import com.gh4a.utils.ApiHelpers;
-import com.gh4a.utils.RxUtils;
 import com.meisolsson.githubsdk.model.GitHubFile;
-import com.meisolsson.githubsdk.model.ReviewComment;
-import com.meisolsson.githubsdk.service.pull_request.PullRequestReviewCommentService;
 import com.meisolsson.githubsdk.service.pull_request.PullRequestService;
 
 import java.util.List;
 
 import io.reactivex.Single;
 
-public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
+public class PullRequestDiffLoadTask extends DiffLoadTask {
     private final int mPullRequestNumber;
     private final int mPage;
 
@@ -33,11 +29,10 @@ public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
     }
 
     @Override
-    protected @NonNull Intent getLaunchIntent(String sha, @NonNull GitHubFile file,
-                           List<ReviewComment> comments, DiffHighlightId diffId) {
+    protected @NonNull Intent getLaunchIntent(String sha, @NonNull GitHubFile file, DiffHighlightId diffId) {
         return PullRequestDiffViewerActivity.makeIntent(mActivity, mRepoOwner,
                 mRepoName, mPullRequestNumber, sha, file.filename(), file.patch(),
-                comments, -1, diffId.startLine, diffId.endLine, diffId.right, null);
+                null, -1, diffId.startLine, diffId.endLine, diffId.right, null);
     }
 
     @NonNull
@@ -60,14 +55,5 @@ public class PullRequestDiffLoadTask extends DiffLoadTask<ReviewComment> {
         var service = ServiceFactory.getForFullPagedLists(PullRequestService.class, false);
         return ApiHelpers.PageIterator
                 .toSingle(page -> service.getPullRequestFiles(mRepoOwner, mRepoName, mPullRequestNumber, page));
-    }
-
-    @Override
-    protected Single<List<ReviewComment>> getComments() {
-        var service = ServiceFactory.getForFullPagedLists(PullRequestReviewCommentService.class, false);
-        return ApiHelpers.PageIterator
-                .toSingle(page -> service.getPullRequestComments(
-                        mRepoOwner, mRepoName, mPullRequestNumber, page))
-                .compose(RxUtils.filter(c -> c.position() != null));
     }
 }

--- a/app/src/main/java/com/gh4a/utils/ApiHelpers.java
+++ b/app/src/main/java/com/gh4a/utils/ApiHelpers.java
@@ -215,13 +215,12 @@ public class ApiHelpers {
         return Pair.create(urlParts[4], urlParts[5]);
     }
 
-    private final static char[] HEX_CHARS = "0123456789ABCDEF".toCharArray();
+    private final static char[] HEX_CHARS = "0123456789abcdef".toCharArray();
 
-    public static String md5(String input) {
+    public static String sha256Of(String input) {
         try {
-            MessageDigest digest = MessageDigest.getInstance("MD5");
-            digest.update(input.getBytes());
-            byte[] messageDigest = digest.digest();
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] messageDigest = digest.digest(input.getBytes());
             char[] hexChars = new char[messageDigest.length * 2];
             for ( int i = 0; i < messageDigest.length; i++ ) {
                 int b = messageDigest[i] & 0xFF;

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -484,7 +484,7 @@ public class LinkParserTest {
     public void pullRequestLink_withDiffMarker__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
-                        "#diff-38f43208e0c158ca7b78e175b8846bc6");
+                        "#diff-67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0");
         PullRequestDiffLoadTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, PullRequestDiffLoadTask.class);
         assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
@@ -492,7 +492,7 @@ public class LinkParserTest {
         DiffHighlightId diffId = loadTask.mDiffId;
         assertThat("Diff id is missing", diffId, is(notNullValue()));
         assertThat("File hash is incorrect", diffId.fileHash,
-                is("38f43208e0c158ca7b78e175b8846bc6"));
+                is("67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0"));
         assertThat("Start line is set", diffId.startLine, is(-1));
         assertThat("End line is set", diffId.endLine, is(-1));
         assertThat("Is right line", diffId.right, is(false));
@@ -502,7 +502,7 @@ public class LinkParserTest {
     public void pullRequestLink_withDiffMarker_andLeftNumber__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
-                        "#diff-38f43208e0c158ca7b78e175b8846bc6L24");
+                        "#diff-67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0L24");
         PullRequestDiffLoadTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, PullRequestDiffLoadTask.class);
         assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
@@ -510,7 +510,7 @@ public class LinkParserTest {
         DiffHighlightId diffId = loadTask.mDiffId;
         assertThat("Diff id is missing", diffId, is(notNullValue()));
         assertThat("File hash is incorrect", diffId.fileHash,
-                is("38f43208e0c158ca7b78e175b8846bc6"));
+                is("67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0"));
         assertThat("Start line is incorrect", diffId.startLine, is(24));
         assertThat("End line is incorrect", diffId.endLine, is(24));
         assertThat("Is right line", diffId.right, is(false));
@@ -520,7 +520,7 @@ public class LinkParserTest {
     public void pullRequestLink_withDiffMarker_andLineRange__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
-                        "#diff-38f43208e0c158ca7b78e175b8846bc6L24-L26");
+                        "#diff-67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0L24-L26");
         PullRequestDiffLoadTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, PullRequestDiffLoadTask.class);
         assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
@@ -528,7 +528,7 @@ public class LinkParserTest {
         DiffHighlightId diffId = loadTask.mDiffId;
         assertThat("Diff id is missing", diffId, is(notNullValue()));
         assertThat("File hash is incorrect", diffId.fileHash,
-                is("38f43208e0c158ca7b78e175b8846bc6"));
+                is("67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0"));
         assertThat("Start line is incorrect", diffId.startLine, is(24));
         assertThat("End line is incorrect", diffId.endLine, is(26));
         assertThat("Is right line", diffId.right, is(false));
@@ -538,7 +538,7 @@ public class LinkParserTest {
     public void pullRequestLink_withDiffMarker_andInvalidNumber__opensPullRequest() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
-                        "#diff-38f43208e0c158ca7b78e175b8846bc6LA3");
+                        "#diff-67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0LA3");
         assertRedirectsTo(result, PullRequestActivity.class);
         Bundle extras = result.intent.getExtras();
         assertThat("Extras are missing", extras, is(notNullValue()));
@@ -555,7 +555,7 @@ public class LinkParserTest {
     public void pullRequestLink_withDiffMarker_andRightNumber__loadsDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
-                        "#diff-38f43208e0c158ca7b78e175b8846bc6R24");
+                        "#diff-67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0R24");
         PullRequestDiffLoadTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, PullRequestDiffLoadTask.class);
         assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
@@ -563,27 +563,10 @@ public class LinkParserTest {
         DiffHighlightId diffId = loadTask.mDiffId;
         assertThat("Diff id is missing", diffId, is(notNullValue()));
         assertThat("File hash is incorrect", diffId.fileHash,
-                is("38f43208e0c158ca7b78e175b8846bc6"));
+                is("67060ff8c94bbee9421c7bcbed9c9ac8f69d93c26ffc59b26f15fb31982023a0"));
         assertThat("Start line is incorrect", diffId.startLine, is(24));
         assertThat("End line is incorrect", diffId.endLine, is(24));
         assertThat("Is not right line", diffId.right, is(true));
-    }
-
-    @Test
-    public void pullRequestLink_withDiffMarker_andIncorrectHash__loadsDiff() {
-        LinkParser.ParseResult result =
-                parseLink("https://github.com/slapperwan/gh4a/pull/665/files" +
-                        "#diff-38f43208e0c158ca7b78e1");
-        assertRedirectsTo(result, PullRequestActivity.class);
-        Bundle extras = result.intent.getExtras();
-        assertThat("Extras are missing", extras, is(notNullValue()));
-        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
-        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
-        assertThat("Pull request number is incorrect", extras.getInt("number"), is(665));
-        assertThat("Initial page is incorrect", extras.getInt("initial_page"),
-                is(PullRequestActivity.PAGE_FILES));
-        assertThat("Comment marker is set", extras.getParcelable("initial_comment"),
-                is(nullValue()));
     }
 
     @Test

--- a/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
+++ b/app/src/test/java/com/gh4a/resolver/LinkParserTest.java
@@ -646,6 +646,21 @@ public class LinkParserTest {
     }
 
     @Test
+    public void commitLink_withCommentMarker__opensCommitActivity() {
+        LinkParser.ParseResult result =
+                parseLink("https://github.com/slapperwan/gh4a/commit/commitSha#commitcomment-155241730");
+        assertRedirectsTo(result, CommitActivity.class);
+        Bundle extras = result.intent.getExtras();
+        assertThat("Extras are missing", extras, is(notNullValue()));
+        assertThat("User name is incorrect", extras.getString("owner"), is("slapperwan"));
+        assertThat("Repo name is incorrect", extras.getString("repo"), is("gh4a"));
+        assertThat("Commit sha is incorrect", extras.getString("sha"), is("commitSha"));
+        IntentUtils.InitialCommentMarker commentMarker = extras.getParcelable("initial_comment");
+        assertThat("Comment marker is missing", commentMarker, is(notNullValue()));
+        assertThat("Comment id is incorrect", commentMarker.commentId, is(155241730L));
+    }
+
+    @Test
     public void commitLink_withDiffMarker__loadsCommitDiff() {
         LinkParser.ParseResult result =
                 parseLink("https://github.com/slapperwan/gh4a/commit/" +
@@ -667,9 +682,9 @@ public class LinkParserTest {
     }
 
     @Test
-    public void commitLink_withCommentMarker__opensCommitActivity() {
+    public void commitLink_withDiffCommentMarker__loadsCommitDiff() {
         LinkParser.ParseResult result =
-                parseLink("https://github.com/slapperwan/gh4a/commit/commitSha#commitcomment-12");
+                parseLink("https://github.com/slapperwan/gh4a/commit/commitSha#r24675412");
         CommitCommentLoadTask loadTask =
                 assertThatLoadTaskIs(result.loadTask, CommitCommentLoadTask.class);
         assertThat("User name is incorrect", loadTask.mRepoOwner, is("slapperwan"));
@@ -677,7 +692,7 @@ public class LinkParserTest {
         assertThat("Commit sha is incorrect", loadTask.mCommitSha, is("commitSha"));
         IntentUtils.InitialCommentMarker commentMarker = loadTask.mMarker;
         assertThat("Comment marker is missing", commentMarker, is(notNullValue()));
-        assertThat("Comment id is incorrect", commentMarker.commentId, is(12L));
+        assertThat("Comment id is incorrect", commentMarker.commentId, is(24675412L));
     }
 
     @Test


### PR DESCRIPTION
While working on #1458, I noticed that the app handled diff URLs on PRs/commits and commit comment URLs incorrectly:
- URLs to diff lines in commits and PRs (those ending in `#diff-<hash>`) were being parsed as if the hash were the MD5 sum of the path, but the hash has been changed to be a SHA256 for a while now (at least since 2021 according to [some comments on StackOverflow](https://stackoverflow.com/questions/43996083/extraction-of-diff-hash-from-github-commit-url/69177495#69177495)) - fixed in d943b931
- the app incorrectly treated URLs ending in `#commitcomment-<id>` as URLs to comments _on the commit_ **or** to comments _on the commit diff_, but they can only be the former (fixed in 2300ddad84). The latter URLs always end in `#r<id>` instead (I suppose that GH changed them at some point to make them consistent with PR diff comment URLs).

In between those fixes I've made a few tweaks/optimizations:
- 823bd7f2: small change to preserve the same fallback behavior that was present before d943b931 when the diff hash in the URL is incorrect
- fd75edaa: I've removed the logic for fetching diff comments in `DiffLoadTask`s, which was duplicated with the one already present in `DiffViewerActivity`-s ([here](https://github.com/slapperwan/gh4a/blob/c00c5f3b4cdb505cf1313eebc5a0d6623e87fe88/app/src/main/java/com/gh4a/activities/CommitDiffViewerActivity.java#L89) and [here](https://github.com/slapperwan/gh4a/blob/c00c5f3b4cdb505cf1313eebc5a0d6623e87fe88/app/src/main/java/com/gh4a/activities/PullRequestDiffViewerActivity.java#L72)) that is triggered when comments are not passed in the Intent extras
- a3378d17: small optimization to parallelize API calls and avoid a duplicate request when handling a commit diff comment URL

I recommend reviewing this commit by commit.