### PR TITLE
Add support for "duplicate" issue close reason

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,8 +52,8 @@ android {
 
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
     namespace 'com.gh4a'
     buildFeatures {

--- a/app/src/main/java/com/gh4a/activities/IssueActivity.java
+++ b/app/src/main/java/com/gh4a/activities/IssueActivity.java
@@ -65,7 +65,7 @@ import com.meisolsson.githubsdk.model.IssueStateReason;
 import com.meisolsson.githubsdk.model.request.issue.IssueRequest;
 import com.meisolsson.githubsdk.service.issues.IssueService;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public class IssueActivity extends BaseActivity implements
@@ -433,22 +433,26 @@ public class IssueActivity extends BaseActivity implements
         @NonNull
         @Override
         public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-            var reasonItems = new ArrayList<ItemsWithDescriptionAdapter.Item>();
-            reasonItems.add(new ItemsWithDescriptionAdapter.Item(
+            var choiceItems = List.of(
+                    new ItemsWithDescriptionAdapter.Item(
                             getString(R.string.issue_reason_completed),
-                            getString(R.string.issue_reason_completed_description)));
-            reasonItems.add(new ItemsWithDescriptionAdapter.Item(
+                            getString(R.string.issue_reason_completed_description)),
+                    new ItemsWithDescriptionAdapter.Item(
                             getString(R.string.issue_reason_not_planned),
-                            getString(R.string.issue_reason_not_planned_description)));
+                            getString(R.string.issue_reason_not_planned_description)),
+                    new ItemsWithDescriptionAdapter.Item(
+                            getString(R.string.issue_reason_duplicate),
+                            getString(R.string.issue_reason_duplicate_description))
+            );
+            var reasonForItems = List.of(IssueStateReason.Completed, IssueStateReason.NotPlanned, IssueStateReason.Duplicate);
 
             IssueActivity activity = (IssueActivity) requireActivity();
             return new AlertDialog.Builder(activity)
                     .setTitle(R.string.close_issue_dialog_title)
                     .setAdapter(
-                        new ItemsWithDescriptionAdapter(activity, reasonItems),
+                        new ItemsWithDescriptionAdapter(activity, choiceItems),
                         (dialog, itemIndex) -> {
-                            var closeReason = itemIndex == 0 ? IssueStateReason.Completed : IssueStateReason.NotPlanned;
-                            activity.closeIssue(closeReason);
+                            activity.closeIssue(reasonForItems.get(itemIndex));
                         }
                     )
                     .setNegativeButton(R.string.cancel, null)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -459,7 +459,9 @@
     <string name="reopen_issue_confirm">Do you really want to reopen this issue?</string>
     <string name="close_issue_dialog_title">Close issue as\u2026</string>
     <string name="issue_reason_not_planned">Not planned</string>
-    <string name="issue_reason_not_planned_description">Won\'t fix, duplicate, stale</string>
+    <string name="issue_reason_not_planned_description">Won\'t fix, can\'t reproduce, stale</string>
+    <string name="issue_reason_duplicate">Duplicate</string>
+    <string name="issue_reason_duplicate_description">Duplicate of another issue</string>
     <string name="issue_reason_completed">Completed</string>
     <string name="issue_reason_completed_description">Done, closed, fixed, resolved</string>
     <string name="close_issue">Close issue</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,6 +307,8 @@
     <string name="issue_event_closed_completed_with_commit">[b]%1$s[/b] closed this issue as completed in [commit] [time]</string>
     <string name="issue_event_closed_not_planned">[b]%1$s[/b] closed this issue as not planned [time]</string>
     <string name="issue_event_closed_not_planned_with_commit">[b]%1$s[/b] closed this issue as not planned in [commit] [time]</string>
+    <string name="issue_event_closed_duplicate">[b]%1$s[/b] closed this issue as duplicate [time]</string>
+    <string name="issue_event_closed_duplicate_with_commit">[b]%1$s[/b] closed this issue as duplicate in [commit] [time]</string>
     <string name="issue_event_reopened">[b]%1$s[/b] reopened this issue [time]</string>
     <string name="issue_event_referenced">[b]%1$s[/b] referenced this issue [time]</string>
     <string name="issue_event_referenced_with_commit">[b]%1$s[/b] referenced this issue in commit [commit] [time]</string>


### PR DESCRIPTION
This PR adds the ability to close an issue as "duplicate" and also to see when an issue has been closed as a duplicate (previously the app showed those events as "closed as completed").

<img width="479" height="358" alt="duplicate_close_reason" src="https://github.com/user-attachments/assets/d9fe88ba-eef1-428f-a220-505b9276c6b2" />

Unfortunately, the GitHub REST API does not support retrieving or specifying the original issue when closing an issue as duplicate, so the app will always show "closed as duplicate" instead of "closed as a duplicate of X".
<img width="521" height="112" alt="closed_as_duplicate_event" src="https://github.com/user-attachments/assets/b40c6ecb-ecd8-4ba7-9b6e-b694e671453e" />

I've bumped the Java language version to 21 to allow using `case null` switch branches (because issues closed as completed sometimes have their `state_reason` set to null).

Partially addresses #1462 (marking as duplicate is a different feature)